### PR TITLE
Fix duplicate Stars invoice endpoint and ignore node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+**/node_modules/

--- a/server/server.js
+++ b/server/server.js
@@ -475,38 +475,6 @@ app.get('/api/leaderboard', async (req, res) => {
   }
 });
 
-// Создание инвойса Stars
-app.post('/api/stars/create', async (req, res) => {
-  try {
-    const { uid, pack } = req.body || {};
-    const p = STARS_PACKS[pack];
-    if (!uid || !p) return res.json({ ok:false, error:'BAD_REQUEST' });
-
-    const payload = `${uid}:pack_${pack}`; // вернётся в successful_payment
-
-    // createInvoiceLink (валюта XTR, без provider_token)
-    const r = await fetch(`https://api.telegram.org/bot${BOT_TOKEN}/createInvoiceLink`, {
-      method: 'POST',
-      headers: { 'Content-Type':'application/json' },
-      body: JSON.stringify({
-        title:       `${pack}⭐`,
-        description: `Пакет на ${pack} звёзд`,
-        payload,
-        provider_token: '',
-        currency: 'XTR',
-        prices: [{ label: `${pack}⭐`, amount: p.millis }], // 1⭐ = 1000 millis
-      })
-    }).then(r=>r.json());
-
-    if (!r.ok) return res.json({ ok:false, error:'TG_API', details:r });
-
-    res.json({ ok:true, link: r.result });
-  } catch (e) {
-    console.error('stars/create', e);
-    res.json({ ok:false, error:'SERVER' });
-  }
-});
-
 /* ========= Проверка бонусов (подписка + ежедневка) ========= */
 // Вызывается фронтом из шита «Пополнение» — без редиректа в бота
 app.post('/api/bonus/check', async (req, res) => {


### PR DESCRIPTION
## Summary
- remove redundant /api/stars/create handler referencing undefined millis
- add .gitignore to exclude node_modules

## Testing
- `node --check server/server.js`
- `node --check bot/bot.js`


------
https://chatgpt.com/codex/tasks/task_e_68a859178fc083289419adab2ba3b06b