### PR TITLE
Handle invalid hash in verifyInitData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ import express from 'express';
 import cors from 'cors';
 import { WebSocket } from 'ws';
 import pg from 'pg';
+export { verifyInitData } from './verifyInitData.js';
 
 const app = express();
 app.use(cors());

--- a/server/verifyInitData.js
+++ b/server/verifyInitData.js
@@ -1,0 +1,35 @@
+import crypto from 'crypto';
+
+export function verifyInitData(initData, botToken = process.env.BOT_TOKEN) {
+  try {
+    const params = new URLSearchParams(initData);
+    const hash = params.get('hash');
+    if (!hash || hash.length !== 64) {
+      return { ok: false, error: 'BAD_HASH' };
+    }
+    params.delete('hash');
+    const dataCheckString = [...params.entries()]
+      .sort()
+      .map(([k, v]) => `${k}=${v}`)
+      .join('\n');
+
+    const secretKey = crypto
+      .createHash('sha256')
+      .update(botToken || '')
+      .digest();
+    const computed = crypto
+      .createHmac('sha256', secretKey)
+      .update(dataCheckString)
+      .digest('hex');
+
+    const hashBuf = Buffer.from(hash, 'hex');
+    const computedBuf = Buffer.from(computed, 'hex');
+    if (hashBuf.length !== computedBuf.length) {
+      return { ok: false, error: 'BAD_HASH' };
+    }
+    const valid = crypto.timingSafeEqual(hashBuf, computedBuf);
+    return valid ? { ok: true, data: Object.fromEntries(params.entries()) } : { ok: false, error: 'BAD_HASH' };
+  } catch {
+    return { ok: false, error: 'BAD_HASH' };
+  }
+}

--- a/server/verifyInitData.test.js
+++ b/server/verifyInitData.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { verifyInitData } from './verifyInitData.js';
+
+test('rejects short hash', () => {
+  const res = verifyInitData('user=1&hash=1234', 'token');
+  assert.deepEqual(res, { ok: false, error: 'BAD_HASH' });
+});


### PR DESCRIPTION
## Summary
- Add `verifyInitData` helper that checks hash presence and length before using `timingSafeEqual`
- Re-export `verifyInitData` from server for external use
- Add unit test verifying short hashes are rejected

## Testing
- `node --test server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a88ffcd2888328b444bc3343e6d58a