### PR TITLE
Tie shout price decay to rounds and show online count

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -348,6 +348,7 @@
   <h3>Статистика</h3>
   <p>Побед: <span id="statsWins">0</span></p>
   <p>Поражений: <span id="statsLosses">0</span></p>
+  <p>Онлайн: <span id="statsOnline">0</span></p>
   <div id="statsList"></div>
   <div class="btnrow">
     <button class="btnsm cancel" data-close>Закрыть</button>
@@ -702,6 +703,7 @@ async function loadStats(){
   if (!r.ok) return;
   document.getElementById('statsWins').textContent = Number(r.wins||0);
   document.getElementById('statsLosses').textContent = Number(r.losses||0);
+  document.getElementById('statsOnline').textContent = Number(r.online_count||0);
   const listEl = document.getElementById('statsList');
   listEl.innerHTML = (r.list||[]).map(item=>`<div>${item}</div>`).join('');
 }


### PR DESCRIPTION
## Summary
- Drop chat banner price by $100 at the start of each round with a floor of $100 and track last decay round.
- Track user activity to compute online players and expose `online_count` via the stats API.
- Display current online player count in the statistics panel.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8e6defa50832899b57fcfc0a75ffd