### PR TITLE
Add invites stat and win celebration

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -222,6 +222,11 @@
     50%  { color:#9be7a1; text-shadow: 0 0 6px rgba(155,231,161,.6); }
     100% { color:#fff; text-shadow: 0 0 0 rgba(255,255,255,0); }
   }
+
+  #fwCanvas{
+    position:fixed; inset:0; z-index:9999; pointer-events:none; display:none;
+    backdrop-filter:brightness(0.9);
+  }
 </style>
 </head>
 <body>
@@ -286,6 +291,8 @@
   <div class="head">Топ победителей за час</div>
   <div class="lb" id="lb"></div>
 </div>
+
+<canvas id="fwCanvas"></canvas>
 
 <!-- Backdrop -->
 <div class="sheet-backdrop" id="sheetBg"></div>
@@ -359,6 +366,7 @@
   <p>Побед: <span id="statsWins">0</span></p>
   <p>Поражений: <span id="statsLosses">0</span></p>
   <p>Онлайн: <span id="statsOnline">0</span></p>
+  <p>Приглашений: <span id="statsInv">0</span></p>
   <div id="statsList"></div>
   <div class="btnrow">
     <button class="btnsm cancel" data-close>Закрыть</button>
@@ -702,7 +710,7 @@ function bindOnce(){
   topupBtn.onclick = ()=> openSheet(sheetTopup);
   insBtn.onclick   = ()=>{ insCountEl.textContent = 'Доступно: ' + INS_COUNT; openSheet(sheetIns); };
   starsBtn.onclick = ()=> openSheet(sheetStars);
-  statsBtn.onclick = ()=>{ loadStats(); openSheet(sheetStats); };
+  statsBtn.onclick = ()=>{ loadMyStats(); openSheet(sheetStats); };
   claimBtn.onclick = async ()=>{
     openSheet(sheetClaim);
     claimVopEl.textContent = '… VOP';
@@ -888,14 +896,17 @@ async function leaderboard(){
     </div>
   `).join('') || '<div class="rank"><div class="left"><div class="badge">—</div><div class="name">ещё пусто</div></div><div class="val">$0</div></div>';
 }
-async function loadStats(){
-  const r = await api('/api/stats').catch(()=>({ok:false}));
+async function loadMyStats(){
+  const r = await fetch(`/api/my/stats?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
   if (!r.ok) return;
-  document.getElementById('statsWins').textContent = Number(r.wins||0);
-  document.getElementById('statsLosses').textContent = Number(r.losses||0);
-  document.getElementById('statsOnline').textContent = Number(r.online_count||0);
+  const s = r.stats;
+  document.getElementById('statsWins').textContent = s.wins;
+  document.getElementById('statsLosses').textContent = s.losses;
+  document.getElementById('statsOnline').textContent = s.online;
+  document.getElementById('statsInv').textContent = s.invites;
   const listEl = document.getElementById('statsList');
-  listEl.innerHTML = (r.list||[]).map(item=>`<div>${item}</div>`).join('');
+  listEl.innerHTML = (s.recent||[]).map(it=>`<div>${it.delta}</div>`).join('');
+  window.__lastWinRoundFromServer = s.last_win_round;
 }
 
 async function adPoll(){
@@ -908,6 +919,18 @@ async function adPoll(){
     nextPrice: Number(st.next_price || 0)
   };
   renderAdLine();
+}
+
+let lastCelebratedRound = Number(localStorage.getItem('lastCelebratedRound')||0);
+async function maybeCelebrateWin(){
+  const r = await fetch(`/api/my/stats?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
+  if (!r.ok) return;
+  const round = Number(r.stats.last_win_round||0);
+  if (round > 0 && round !== lastCelebratedRound){
+    lastCelebratedRound = round;
+    localStorage.setItem('lastCelebratedRound', String(round));
+    FW.start(2000);
+  }
 }
 
 // polling
@@ -1053,6 +1076,79 @@ bindOnce();
 if (!IS_VIEWER) await auth();
 poll();
 setInterval(poll, 1000);
+setInterval(maybeCelebrateWin, 3000);
+})();
+
+// ===== Fireworks (без библиотек)
+const FW = (() => {
+  const cnv = document.getElementById('fwCanvas');
+  const ctx = cnv.getContext('2d');
+  let W=0,H=0, rafId=null, t0=0, duration=1800;
+  const sparks = [];
+
+  function onResize(){ W = cnv.width = innerWidth * devicePixelRatio; H = cnv.height = innerHeight * devicePixelRatio; }
+  addEventListener('resize', onResize); onResize();
+
+  function burst(x,y,count=60){
+    for(let i=0;i<count;i++){
+      const a = Math.random()*Math.PI*2;
+      const v = (0.8+Math.random()*1.2) * (H/900);
+      sparks.push({
+        x, y,
+        vx: Math.cos(a)*v,
+        vy: Math.sin(a)*v,
+        life: 600 + Math.random()*600,
+        age: 0,
+        size: 2 + Math.random()*2,
+        hue: (Math.random()*60)+10
+      });
+    }
+  }
+
+  function step(ts){
+    const dt = ts - t0; t0 = ts;
+    ctx.clearRect(0,0,W,H);
+    // гравитация + рендер
+    for (let i=sparks.length-1;i>=0;i--){
+      const p = sparks[i];
+      p.age += dt;
+      p.vy += 0.0008 * dt * (H/900);
+      p.x += p.vx*dt/16;
+      p.y += p.vy*dt/16;
+      const alpha = Math.max(0,1 - p.age/p.life);
+      if (alpha<=0){ sparks.splice(i,1); continue; }
+      ctx.globalAlpha = alpha;
+      ctx.fillStyle = `hsl(${p.hue},100%,60%)`;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, p.size, 0, Math.PI*2);
+      ctx.fill();
+    }
+    if (performance.now() - __fwStartTime < duration || sparks.length>0){
+      rafId = requestAnimationFrame(step);
+    } else {
+      cnv.style.display='none';
+      cancelAnimationFrame(rafId);
+    }
+  }
+
+  let __fwStartTime = 0;
+  function start(ms=1800){
+    duration = ms;
+    cnv.style.display='block';
+    __fwStartTime = performance.now();
+    t0 = performance.now();
+    // 3 салюта из разных точек
+    const pr = devicePixelRatio;
+    burst(0.25*W, 0.55*H, 70);
+    burst(0.75*W, 0.60*H, 70);
+    burst(0.50*W, 0.40*H, 90);
+    cancelAnimationFrame(rafId);
+    rafId = requestAnimationFrame(step);
+    // лёгкая вибрация
+    if (navigator.vibrate) navigator.vibrate([40, 60, 40, 100]);
+  }
+
+  return { start };
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- track user activity with new `last_seen` column and update on auth
- provide `/api/my/stats` endpoint returning wins, losses, invites, and last win round
- show invite count on stats sheet and celebrate wins with fireworks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node --check server.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa187a7b0c832898f0934961f88136