### PR TITLE
Add XP and level system with profile UI

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -145,6 +145,15 @@
     to{ opacity:1; transform:translateY(0); }
   }
 
+  .card.profile{background:#0b0b0b;border:1px solid var(--border);border-radius:16px;padding:12px 14px;margin-top:10px}
+  .card.profile .row{display:flex;align-items:center}
+  .card.profile .between{justify-content:space-between}
+  .card.profile .title{font-weight:800}
+  .card.profile .badge{background:#121212;border:1px solid var(--border);border-radius:999px;padding:4px 10px;font-size:12px}
+  .xpbar{height:10px;background:#171717;border:1px solid #242424;border-radius:999px;overflow:hidden;margin:8px 0}
+  .xpbar .fill{height:100%;background:linear-gradient(90deg,#1fa36a,#45c987);width:0%;transition:width .35s ease}
+  .card.profile .muted{color:#b9b9b9;font-size:12px}
+
   /* ===== accessibility ===== */
   @media (prefers-reduced-motion: reduce) {
     .flash-win, .shake-outbid, .crown-bounce, .ad-shimmer::before {
@@ -284,6 +293,17 @@
       <div class="ad-price" id="adPrice">Цена: $100</div>
       <button class="chipbtn ad-write" id="adWrite">✍️ Написать</button>
     </div>
+  </div>
+
+  <div class="card profile" id="profileCard">
+    <div class="row between">
+      <div class="title">Уровень <span id="lvl">1</span></div>
+      <div class="badge" id="nextReward">+ $10 000</div>
+    </div>
+    <div class="xpbar">
+      <div class="fill" id="xpFill" style="width:0%"></div>
+    </div>
+    <div class="muted" id="xpText">0 / 5 000 XP</div>
   </div>
 
   <div class="history" id="hist"></div>
@@ -633,6 +653,14 @@ function floatAmount(parent, text, plus /*true for +, false for -*/) {
 
 // helpers
 function fmt(n){ return '$'+Number(n||0).toLocaleString(); }
+function renderProfile(p){
+  if (!p) return;
+  document.getElementById('lvl').textContent = p.level;
+  const prog = Math.max(0, Math.min(1, p.progress || (p.xp / p.next_xp)));
+  document.getElementById('xpFill').style.width = (prog*100).toFixed(1)+'%';
+  document.getElementById('xpText').textContent = `${Number(p.xp).toLocaleString()} / ${Number(p.next_xp).toLocaleString()} XP`;
+  document.getElementById('nextReward').textContent = '+ ' + fmt(p.next_reward || 0);
+}
 function phaseText(p){
   if (p==='betting') return 'Ставки открыты';
   if (p==='locked')  return 'Ставки закрыты';
@@ -851,6 +879,7 @@ async function auth(){
     if (typeof r.user.ref_count === 'number') {
       claimBtn.style.display = r.user.ref_count >= 30 ? 'inline-block' : 'none';
     }
+    renderProfile(r.profile);
   }
 }
 async function refreshBalance(){
@@ -937,6 +966,7 @@ async function maybeCelebrateWin(){
 async function poll(){
   const r = await fetch(`/api/round?initData=${encodeURIComponent(initData)}`).then(r=>r.json()).catch(()=>null);
   if (!r) return;
+  renderProfile(r.profile);
 
   if (r.price){
     priceEl.textContent = fmt(r.price);

--- a/xp.mjs
+++ b/xp.mjs
@@ -1,0 +1,85 @@
+export function xpNeededFor(level) {
+  return Math.round(5000 * Math.pow(1.40, level - 1));
+}
+
+export function levelUpReward(level) {
+  const mul = 1 + Math.min(0.3, 0.1 * (level - 1));
+  return Math.round(10000 * mul);
+}
+
+export function isHappyHour(now = new Date()) {
+  if (process.env.XP_HAPPY_HOUR_ENABLED !== '1') return false;
+  const [from, to] = (process.env.XP_HAPPY_HOUR || '').split('-');
+  if (!from || !to) return false;
+  const pad = (n) => String(n).padStart(2, '0');
+  const hhmm = (h) => `${pad(h.getUTCHours())}:${pad(h.getUTCMinutes())}`;
+  const cur = hhmm(now);
+  return cur >= from && cur < to;
+}
+
+export function streakMultiplier(s = 0) {
+  if (s >= 15) return 1.5;
+  if (s >= 12) return 1.4;
+  if (s >= 8) return 1.3;
+  if (s >= 5) return 1.2;
+  if (s >= 3) return 1.1;
+  return 1;
+}
+
+export function xpMultiplierFor(user = {}, source, now = new Date()) {
+  let m = 1;
+  if (source === 'WIN') {
+    m *= streakMultiplier(user.streak_wins || 0);
+  }
+  if (isHappyHour(now)) m *= 2;
+  return m;
+}
+
+export async function grantXP(pool, userId, xp, source, meta = {}) {
+  if (xp <= 0) return;
+
+  const userRow = await pool.query(
+    'SELECT xp, level, next_xp, streak_wins FROM users WHERE id=$1',
+    [userId]
+  );
+  if (!userRow.rowCount) return;
+  const user = userRow.rows[0];
+  const mult = xpMultiplierFor(user, source, new Date());
+  const finalXp = Math.floor(xp * mult);
+
+  await pool.query(
+    'INSERT INTO xp_events(user_id, source, amount, meta) VALUES($1,$2,$3,$4)',
+    [userId, source, finalXp, { ...meta, multiplier: mult }]
+  );
+
+  await pool.query('BEGIN');
+  const r = await pool.query(
+    'SELECT xp, level, next_xp FROM users WHERE id=$1 FOR UPDATE',
+    [userId]
+  );
+  if (!r.rowCount) {
+    await pool.query('ROLLBACK');
+    return;
+  }
+
+  let { xp: cur, level, next_xp } = r.rows[0];
+  cur += finalXp;
+
+  const rewards = [];
+  while (cur >= next_xp) {
+    cur -= next_xp;
+    level += 1;
+    const rew = levelUpReward(level);
+    rewards.push(rew);
+    await pool.query('UPDATE users SET balance=balance+$1 WHERE id=$2', [rew, userId]);
+    next_xp = xpNeededFor(level);
+  }
+
+  await pool.query(
+    'UPDATE users SET xp=$1, level=$2, next_xp=$3 WHERE id=$4',
+    [cur, level, next_xp, userId]
+  );
+  await pool.query('COMMIT');
+
+  return { level, xp: cur, next_xp, rewards };
+}


### PR DESCRIPTION
## Summary
- add XP/level utilities and DB schema for tracking player progression
- award XP on bets, wins, chat messages, and purchases; expose profile info and XP leaderboard
- show profile card with XP progress in client

## Testing
- `npm test --prefix server` *(fails: Missing script)*
- `node --test` in `server`
- `npm test --prefix bot` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2afb8a548328a5d684d5bc45cdfe