### PR TITLE
Implement XP and level tracking system

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -656,10 +656,10 @@ function fmt(n){ return '$'+Number(n||0).toLocaleString(); }
 function renderProfile(p){
   if (!p) return;
   document.getElementById('lvl').textContent = p.level;
-  const prog = Math.max(0, Math.min(1, p.progress || (p.xp / p.next_xp)));
+  const prog = Math.max(0, Math.min(1, (p.level_progress || 0) / (p.level_threshold || 1)));
   document.getElementById('xpFill').style.width = (prog*100).toFixed(1)+'%';
-  document.getElementById('xpText').textContent = `${Number(p.xp).toLocaleString()} / ${Number(p.next_xp).toLocaleString()} XP`;
-  document.getElementById('nextReward').textContent = '+ ' + fmt(p.next_reward || 0);
+  document.getElementById('xpText').textContent = `${Number(p.level_progress || 0).toLocaleString()} / ${Number(p.level_threshold || 0).toLocaleString()} XP`;
+  document.getElementById('nextReward').textContent = '';
 }
 function phaseText(p){
   if (p==='betting') return 'Ставки открыты';
@@ -879,7 +879,7 @@ async function auth(){
     if (typeof r.user.ref_count === 'number') {
       claimBtn.style.display = r.user.ref_count >= 30 ? 'inline-block' : 'none';
     }
-    renderProfile(r.profile);
+    renderProfile(r.user);
   }
 }
 async function refreshBalance(){
@@ -894,6 +894,7 @@ async function refreshBalance(){
     if (typeof r.user.ref_count === 'number') {
       claimBtn.style.display = r.user.ref_count >= 30 ? 'inline-block' : 'none';
     }
+    renderProfile(r.user);
   }
 }
 
@@ -966,7 +967,7 @@ async function maybeCelebrateWin(){
 async function poll(){
   const r = await fetch(`/api/round?initData=${encodeURIComponent(initData)}`).then(r=>r.json()).catch(()=>null);
   if (!r) return;
-  renderProfile(r.profile);
+  renderProfile(r.user);
 
   if (r.price){
     priceEl.textContent = fmt(r.price);

--- a/xp.mjs
+++ b/xp.mjs
@@ -1,85 +1,64 @@
-export function xpNeededFor(level) {
-  return Math.round(5000 * Math.pow(1.40, level - 1));
-}
+export const XP = {
+  BET: 50,
+  WIN_PER_DOLLAR: 1,
+  CHAT: 300,
+  STARS: 1000,
+  INSURANCE: 1000,
+};
 
-export function levelUpReward(level) {
-  const mul = 1 + Math.min(0.3, 0.1 * (level - 1));
-  return Math.round(10000 * mul);
-}
+export const LEVEL = {
+  BASE: 5000,
+  GROWTH: 1.25,
+};
 
-export function isHappyHour(now = new Date()) {
-  if (process.env.XP_HAPPY_HOUR_ENABLED !== '1') return false;
-  const [from, to] = (process.env.XP_HAPPY_HOUR || '').split('-');
-  if (!from || !to) return false;
-  const pad = (n) => String(n).padStart(2, '0');
-  const hhmm = (h) => `${pad(h.getUTCHours())}:${pad(h.getUTCMinutes())}`;
-  const cur = hhmm(now);
-  return cur >= from && cur < to;
-}
-
-export function streakMultiplier(s = 0) {
-  if (s >= 15) return 1.5;
-  if (s >= 12) return 1.4;
-  if (s >= 8) return 1.3;
-  if (s >= 5) return 1.2;
-  if (s >= 3) return 1.1;
-  return 1;
-}
-
-export function xpMultiplierFor(user = {}, source, now = new Date()) {
-  let m = 1;
-  if (source === 'WIN') {
-    m *= streakMultiplier(user.streak_wins || 0);
+export function calcLevelFromXp(totalXp) {
+  let lvl = 1;
+  let need = LEVEL.BASE;
+  let remaining = Number(totalXp) || 0;
+  while (remaining >= need) {
+    remaining -= need;
+    lvl += 1;
+    need = Math.floor(need * LEVEL.GROWTH);
   }
-  if (isHappyHour(now)) m *= 2;
-  return m;
+  return lvl;
 }
 
-export async function grantXP(pool, userId, xp, source, meta = {}) {
-  if (xp <= 0) return;
-
-  const userRow = await pool.query(
-    'SELECT xp, level, next_xp, streak_wins FROM users WHERE id=$1',
-    [userId]
-  );
-  if (!userRow.rowCount) return;
-  const user = userRow.rows[0];
-  const mult = xpMultiplierFor(user, source, new Date());
-  const finalXp = Math.floor(xp * mult);
-
-  await pool.query(
-    'INSERT INTO xp_events(user_id, source, amount, meta) VALUES($1,$2,$3,$4)',
-    [userId, source, finalXp, { ...meta, multiplier: mult }]
-  );
-
-  await pool.query('BEGIN');
-  const r = await pool.query(
-    'SELECT xp, level, next_xp FROM users WHERE id=$1 FOR UPDATE',
-    [userId]
-  );
-  if (!r.rowCount) {
-    await pool.query('ROLLBACK');
-    return;
+export function levelThreshold(level) {
+  let need = LEVEL.BASE;
+  for (let i = 1; i < level; i++) {
+    need = Math.floor(need * LEVEL.GROWTH);
   }
+  return need;
+}
 
-  let { xp: cur, level, next_xp } = r.rows[0];
-  cur += finalXp;
-
-  const rewards = [];
-  while (cur >= next_xp) {
-    cur -= next_xp;
-    level += 1;
-    const rew = levelUpReward(level);
-    rewards.push(rew);
-    await pool.query('UPDATE users SET balance=balance+$1 WHERE id=$2', [rew, userId]);
-    next_xp = xpNeededFor(level);
+export function xpSpentBeforeLevel(level) {
+  let spent = 0;
+  let need = LEVEL.BASE;
+  for (let i = 1; i < level; i++) {
+    spent += need;
+    need = Math.floor(need * LEVEL.GROWTH);
   }
+  return spent;
+}
 
-  await pool.query(
-    'UPDATE users SET xp=$1, level=$2, next_xp=$3 WHERE id=$4',
-    [cur, level, next_xp, userId]
-  );
-  await pool.query('COMMIT');
-
-  return { level, xp: cur, next_xp, rewards };
+export async function grantXpOnce(pool, userId, source, sourceId, amount) {
+  if (!amount || amount <= 0) return;
+  try {
+    await pool.query(
+      `INSERT INTO xp_log(user_id, source, source_id, amount)
+       VALUES ($1,$2,$3,$4) ON CONFLICT DO NOTHING`,
+      [userId, source, sourceId || null, amount]
+    );
+    const r = await pool.query(
+      `UPDATE users SET xp = xp + $1 WHERE id=$2 RETURNING xp, level`,
+      [amount, userId]
+    );
+    const { xp, level } = r.rows[0];
+    const newLevel = calcLevelFromXp(xp);
+    if (newLevel !== level) {
+      await pool.query(`UPDATE users SET level=$1 WHERE id=$2`, [newLevel, userId]);
+    }
+  } catch (e) {
+    console.error('grantXpOnce', e);
+  }
 }


### PR DESCRIPTION
## Summary
- Add XP/level helpers and centralized `grantXpOnce` logic with `xp_log` storage
- Rework server and bot to award XP for bets, wins, chat, Stars and insurance purchases
- Expose level progress to client and update UI progress bar accordingly

## Testing
- `cd server && npm test` *(fails: Missing script "test")*
- `cd bot && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa2f7dae9c8328a343543b0e7bf5c4