### PR TITLE
Switch default asset to ETH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# BTC Game — Final (Telegram WebApp + Bot)
+# ETH Game — Final (Telegram WebApp + Bot)
 
-- Реальная цена BTC (Binance WS)
+- Реальная цена ETH (Binance WS)
 - Раунды: 60c, окно ставок 10c, пауза 10c
 - Комиссия 10% только с проигравших
 - Регистрация через бота → сразу $10 000
@@ -12,7 +12,7 @@
 Web Service (server):
 - Root Directory: server
 - Start: node server.js
-- Env: DATABASE_URL, BINANCE_WS, BOTS_ENABLED (optional bot settings in .env)
+- Env: DATABASE_URL, ASSET, BINANCE_WS, BOTS_ENABLED (optional bot settings in .env)
 
 Background Worker/Web Service (bot):
 - Root Directory: bot

--- a/bot/bot.js
+++ b/bot/bot.js
@@ -211,7 +211,7 @@ async function checkAndGrantChannelBonus(ctx) {
 
 function mainMenu(urlWithUid) {
   return Markup.keyboard([
-    [Markup.button.webApp('Открыть BTC Game', urlWithUid)],
+    [Markup.button.webApp('Открыть ETH Game', urlWithUid)],
     [{ text: 'Рефералы' }, { text: 'Проверить' }],
   ]).resize();
 }

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Real Price BTC Game</title>
+<title>Real Price ETH Game</title>
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 <style>
   :root{

--- a/server/server.js
+++ b/server/server.js
@@ -57,9 +57,10 @@ app.use(express.json());
 app.use(express.static('public'));
 
 const PORT = process.env.PORT || 8080;
+const ASSET = process.env.ASSET || 'ETH';
 const BINANCE_WS =
   process.env.BINANCE_WS ||
-  'wss://stream.binance.com:9443/ws/btcusdt@miniTicker';
+  'wss://stream.binance.com:9443/ws/ethusdt@miniTicker';
 
 const BOT_TOKEN = process.env.BOT_TOKEN; // нужен для createInvoiceLink
 const MIN_BET = 50; // ✅ минимальная ставка ($)
@@ -844,6 +845,7 @@ app.get('/api/round', async (req, res) => {
     bankBuy: state.bankBuy, bankSell: state.bankSell,
     betsBuy: state.betsBuy, betsSell: state.betsSell,
     lastSettlement: state.lastSettlement,
+    asset: ASSET,
     user
   });
 });


### PR DESCRIPTION
## Summary
- default Binance stream updated to ETH/USDT and expose asset via /api/round
- rename web app and bot menu to ETH Game
- document new ASSET environment variable in README

## Testing
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68acef12be948328868663c2294f7441