### PR TITLE
feat: add arena auction page and API

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Арена</title>
+<script src="https://telegram.org/js/telegram-web-app.js"></script>
+<style>
+  :root{ --bg:#000; --text:#fff; --muted:#b9b9b9; --green:#1fa36a; --ring:#ff8c00; --border:#1e1e1e; }
+  *{box-sizing:border-box}
+  html,body{height:100%;margin:0}
+  body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Arial}
+  .wrap{max-width:520px;margin:0 auto;padding:16px 14px 28px;text-align:center}
+  header{display:flex;align-items:center;gap:12px;margin-bottom:12px}
+  header a{color:var(--text);text-decoration:none;font-size:14px}
+  h1{flex:1;font-size:20px;margin:0;text-align:center}
+  .timer{position:relative;width:260px;height:260px;margin:0 auto}
+  .timer svg{width:100%;height:100%;display:block;transform:rotate(-90deg)}
+  .inring{position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px}
+  #bank{font-size:32px;font-weight:800}
+  #time{font-size:14px;color:var(--muted)}
+  #status{font-size:14px;color:var(--muted)}
+  #bidBtn{width:100%;margin-top:16px;background:var(--green);border:none;border-radius:16px;padding:14px 0;font-size:20px;font-weight:800;color:#fff;cursor:pointer}
+  #bidBtn[disabled]{opacity:.5;cursor:not-allowed}
+  #leader{margin-top:16px;font-size:14px;color:var(--text)}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header><a href="index.html">← Назад</a><h1>Арена</h1></header>
+  <div class="timer">
+    <svg viewBox="0 0 100 100">
+      <circle cx="50" cy="50" r="45" stroke="#333" stroke-width="8" fill="none"/>
+      <circle id="ring" cx="50" cy="50" r="45" stroke="var(--ring)" stroke-width="8" fill="none" stroke-linecap="round" stroke-dasharray="282.6" stroke-dashoffset="0"/>
+    </svg>
+    <div class="inring">
+      <div id="bank">$0</div>
+      <div id="time">00:00</div>
+      <div id="status">Ожидание</div>
+    </div>
+  </div>
+  <button id="bidBtn">Ставка</button>
+  <div id="leader"></div>
+</div>
+<script>
+const tg = window.Telegram?.WebApp; tg?.expand();
+let current = null;
+const ring = document.getElementById('ring');
+const bankEl = document.getElementById('bank');
+const timeEl = document.getElementById('time');
+const statusEl = document.getElementById('status');
+const leaderEl = document.getElementById('leader');
+const btn = document.getElementById('bidBtn');
+const R = 45; const CIRC = 2 * Math.PI * R;
+
+function render(s){
+  current = s;
+  bankEl.textContent = '$' + Number(s.bank).toLocaleString();
+  timeEl.textContent = '00:' + String(s.secsLeft).padStart(2,'0');
+  statusEl.textContent = s.phase === 'idle' ? 'Ожидание' : (s.phase==='running' ? 'Идёт аукцион' : 'Пауза');
+  btn.textContent = 'Ставка $' + s.nextBid;
+  btn.disabled = s.phase === 'pause';
+  if(s.leader){ leaderEl.textContent = `Лидер: ${s.leader.name} — $${s.leader.lastBid}`; }
+  else { leaderEl.textContent = ''; }
+  const pct = s.phase==='running' ? s.secsLeft / s.roundLen : (s.phase==='pause'? s.secsLeft/s.pauseLen:0);
+  ring.style.strokeDasharray = CIRC;
+  ring.style.strokeDashoffset = CIRC * (1 - pct);
+}
+
+async function load(){
+  const r = await fetch('/api/auction/state');
+  const d = await r.json();
+  render(d);
+}
+
+btn.addEventListener('click', async () => {
+  if(btn.disabled) return;
+  btn.disabled = true;
+  try {
+    const r = await fetch('/api/auction/bid', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({ initData: tg?.initData || '' })
+    });
+    const d = await r.json();
+    if(d.ok){ await load(); }
+    else if(d.error==='OUTBID'){ await load(); }
+    else if(d.error==='INSUFFICIENT_BALANCE'){ alert('Недостаточно средств'); }
+  } finally {
+    btn.disabled = false;
+  }
+});
+
+setInterval(()=>{
+  if(!current) return;
+  if((current.phase==='running' || current.phase==='pause') && current.secsLeft>0){
+    current.secsLeft--; render(current);
+  }
+},1000);
+
+load();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add environment constants and database tables for auction rounds and bids
- implement server-side penny auction state with endpoints to fetch state and place bids
- create simple `arena.html` UI to interact with auction

## Testing
- `node xp.test.mjs`
- `node --check server/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68acfb0a288083288d821ae8d959588b