### PR TITLE
Add arena navigation and API aliases

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -52,6 +52,15 @@ const statusEl = document.getElementById('status');
 const leaderEl = document.getElementById('leader');
 const btn = document.getElementById('bidBtn');
 const R = 45; const CIRC = 2 * Math.PI * R;
+const uid = new URLSearchParams(location.search).get('uid') || tg?.initDataUnsafe?.user?.id || '';
+
+async function auth(){
+  if(!uid) return;
+  await fetch('/api/auth', {
+    method:'POST', headers:{'Content-Type':'application/json'},
+    body: JSON.stringify({ uid })
+  }).catch(()=>({}));
+}
 
 function render(s){
   current = s;
@@ -68,7 +77,7 @@ function render(s){
 }
 
 async function load(){
-  const r = await fetch('/api/auction/state');
+  const r = await fetch('/api/arena/state');
   const d = await r.json();
   render(d);
 }
@@ -77,7 +86,7 @@ btn.addEventListener('click', async () => {
   if(btn.disabled) return;
   btn.disabled = true;
   try {
-    const r = await fetch('/api/auction/bid', {
+    const r = await fetch('/api/arena/bid', {
       method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ initData: tg?.initData || '' })
     });
@@ -97,7 +106,7 @@ setInterval(()=>{
   }
 },1000);
 
-load();
+auth().then(load);
 </script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -361,6 +361,7 @@
     <button class="chipbtn" id="insBtn">Страховка</button>
     <button class="chipbtn" id="statsBtn">Статистика</button>
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
+    <button class="chipbtn" id="arenaBtn">Арена</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
     <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
@@ -551,6 +552,7 @@ const starsBtn= document.getElementById('starsBtn');
 const insBtn  = document.getElementById('insBtn');
 const statsBtn= document.getElementById('statsBtn');
 const chatFeedBtn = document.getElementById('chatFeedBtn');
+const arenaBtn = document.getElementById('arenaBtn');
 const cfgBtn  = document.getElementById('cfgBtn');
 const claimBtn   = document.getElementById('claimBtn');
 
@@ -600,7 +602,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (IS_VIEWER) {
-  [buyBtn, sellBtn, cfgBtn, refBtn, topupBtn, insBtn, statsBtn, chatFeedBtn, starsBtn, claimBtn, adWriteBtn, buyStars, buyIns, adSend, checkBonus, claimDo].forEach(b => b && (b.disabled = true));
+  [buyBtn, sellBtn, cfgBtn, refBtn, topupBtn, insBtn, statsBtn, chatFeedBtn, arenaBtn, starsBtn, claimBtn, adWriteBtn, buyStars, buyIns, adSend, checkBonus, claimDo].forEach(b => b && (b.disabled = true));
   viewerBanner.style.display = 'block';
   viewerHint.style.display   = 'block';
   viewerOpen.onclick = (e)=>{ e.preventDefault(); const link = `https://t.me/${BOT_USERNAME}?startapp=go`; try{ if(window.Telegram?.WebApp?.openTelegramLink) Telegram.WebApp.openTelegramLink(link); else window.location.href = link; } catch{ window.location.href = link; } };
@@ -825,6 +827,9 @@ function bindOnce(){
   chatFeedBtn.onclick = async ()=>{
     await loadChatFeed();
     openSheet(sheetChatFeed);
+  };
+  arenaBtn.onclick = ()=>{
+    location.href = `/arena.html?uid=${encodeURIComponent(uid)}`;
   };
   chipsBox.addEventListener('click', e=>{
     const b = e.target.closest('.chipopt'); if (!b) return;

--- a/server/server.js
+++ b/server/server.js
@@ -1225,7 +1225,7 @@ app.get('/api/leaderboard/xp', async (req, res) => {
 });
 
 /* ========= Auction API ========= */
-app.get('/api/auction/state', (req, res) => {
+function arenaStateHandler(req, res) {
   const nextBid = auctionNextBid();
   const leader = auctionState.leader
     ? { name: auctionState.leader.username || '@' + auctionState.leader.tg_id, lastBid: auctionState.lastBid }
@@ -1245,9 +1245,9 @@ app.get('/api/auction/state', (req, res) => {
     roundLen: AUCTION_ROUND_LEN,
     pauseLen: AUCTION_PAUSE_LEN,
   });
-});
+}
 
-app.post('/api/auction/bid', requireTgAuth, async (req, res) => {
+async function arenaBidHandler(req, res) {
   while (auctionState.lock) await new Promise(r => setTimeout(r, 5));
   auctionState.lock = true;
   try {
@@ -1312,7 +1312,12 @@ app.post('/api/auction/bid', requireTgAuth, async (req, res) => {
   } finally {
     auctionState.lock = false;
   }
-});
+}
+
+app.get('/api/auction/state', arenaStateHandler);
+app.get('/api/arena/state', arenaStateHandler);
+app.post('/api/auction/bid', requireTgAuth, arenaBidHandler);
+app.post('/api/arena/bid', requireTgAuth, arenaBidHandler);
 
 
 /* ========= Проверка бонусов (подписка + ежедневка) ========= */


### PR DESCRIPTION
## Summary
- Add "Arena" entry to main menu and wire button navigation
- Initialize and authenticate arena page and switch to `/api/arena` endpoints
- Expose arena API aliases on server for state and bid operations

## Testing
- `node xp.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68acfefca168832897897231b8c4c663