### PR TITLE
feat: add admin notification broadcast

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -99,6 +99,13 @@ const pool = new pg.Pool({
   ssl: { rejectUnauthorized: false },
 });
 
+export async function listTelegramIds() {
+  const { rows } = await pool.query(
+    'SELECT DISTINCT telegram_id FROM users WHERE telegram_id IS NOT NULL'
+  );
+  return rows.map((r) => Number(r.telegram_id));
+}
+
 /* ========= DB bootstrap / миграции ========= */
 await pool.query(`
   CREATE TABLE IF NOT EXISTS users(


### PR DESCRIPTION
## Summary
- add admin-only /notification command with preview and confirmation
- broadcast prepared messages to all bot users with progress, anti-flood and retry
- expose listTelegramIds helper for querying user IDs

## Testing
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`
- `node --check bot/bot.js`
- `node --check server/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68ad9907aabc8328bb2cab08111b3f4a