### PR TITLE
Add shop sheet with tabbed sections

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -166,9 +166,15 @@
   .msg .text{font-size:14px;line-height:1.3}
 
 
-  @keyframes ringPulse{0%{transform:scale(1);}50%{transform:scale(1.02);}100%{transform:scale(1);}}
-  .timer.pulse{animation:ringPulse 0.5s ease;}
-</style>
+    @keyframes ringPulse{0%{transform:scale(1);}50%{transform:scale(1.02);}100%{transform:scale(1);}}
+    .timer.pulse{animation:ringPulse 0.5s ease;}
+    /* Shop sheet tabs */
+    .tabs{display:flex;gap:8px;margin:6px 0 10px}
+    .tab-btn{flex:1;background:#121212;border:1px solid var(--border);border-radius:10px;padding:8px 10px;font-size:13px;color:#fff;cursor:pointer}
+    .tab-btn.active{outline:2px solid var(--ring)}
+    .tab-pane{display:none}
+    .tab-pane.show{display:block}
+  </style>
 </head>
 <body>
 <div class="wrap">
@@ -217,6 +223,7 @@
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
     <button class="chipbtn" id="rulesBtn">Правила</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
+    <button class="chipbtn" id="shopBtn">Магазин</button>
     <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
   <div class="lb-head">Топ за 24 часа</div>
@@ -293,11 +300,40 @@
 </div>
 
 <!-- SHEET: история чата -->
-<div class="sheet" id="sheetChatFeed">
-  <h3>история чата</h3>
-  <div id="chatFeed" class="feed"></div>
-  <div class="btnrow"><button class="btnsm cancel" data-close>Закрыть</button></div>
-</div>
+  <div class="sheet" id="sheetChatFeed">
+    <h3>история чата</h3>
+    <div id="chatFeed" class="feed"></div>
+    <div class="btnrow"><button class="btnsm cancel" data-close>Закрыть</button></div>
+  </div>
+
+  <!-- SHEET: Магазин -->
+  <div class="sheet" id="sheetShop">
+    <h3>Магазин</h3>
+
+    <div class="tabs" id="shopTabs">
+      <button class="tab-btn active" data-tab="boosts">Бусты</button>
+      <button class="tab-btn" data-tab="cosm">Косметика</button>
+      <button class="tab-btn" data-tab="events">События</button>
+      <button class="tab-btn" data-tab="clans">Кланы</button>
+    </div>
+
+    <div class="tab-pane show" id="tab-boosts">
+      <p>Скоро: x2 XP на 30/60 мин, комбо-бусты, сезонные задания.</p>
+    </div>
+    <div class="tab-pane" id="tab-cosm">
+      <p>Скоро: рамки профиля, цвет ника, салюты побед.</p>
+    </div>
+    <div class="tab-pane" id="tab-events">
+      <p>Скоро: мини-турниры, джекпоты недели, марафоны.</p>
+    </div>
+    <div class="tab-pane" id="tab-clans">
+      <p>Скоро: кланы, клановые бусты и рейтинги.</p>
+    </div>
+
+    <div class="btnrow">
+      <button class="btnsm cancel" data-close>Закрыть</button>
+    </div>
+  </div>
 
 <script>
 const BOT_USERNAME = 'realpricebtc_bot';
@@ -338,6 +374,7 @@ const chatFeedBtn = document.getElementById('chatFeedBtn');
 const rulesBtn = document.getElementById('rulesBtn');
 const starsBtn = document.getElementById('starsBtn');
 const claimBtn = document.getElementById('claimBtn');
+const shopBtn = document.getElementById('shopBtn');
 
 const sheetBg = document.getElementById('sheetBg');
 const sheetRules = document.getElementById('sheetRules');
@@ -346,6 +383,8 @@ const sheetStars = document.getElementById('sheetStars');
 const sheetAd = document.getElementById('sheetAd');
 const sheetClaim = document.getElementById('sheetClaim');
 const sheetChatFeed = document.getElementById('sheetChatFeed');
+const sheetShop = document.getElementById('sheetShop');
+const shopTabs = document.getElementById('shopTabs');
 
 const openChannel = document.getElementById('openChannel');
 const checkBonus = document.getElementById('checkBonus');
@@ -487,6 +526,7 @@ topupBtn.onclick = ()=> openSheet(sheetTopup);
 chatFeedBtn.onclick = async ()=>{ await loadChatHistory(); openSheet(sheetChatFeed); };
 rulesBtn.onclick = ()=> openSheet(sheetRules);
 starsBtn.onclick = ()=> openSheet(sheetStars);
+shopBtn.onclick = ()=> openSheet(sheetShop);
 claimBtn.onclick = async ()=>{ openSheet(sheetClaim); claimVopEl.textContent='… VOP'; await fetchClaimInfo(); };
 adWriteBtn.onclick = ()=>{ adInput.value=''; adCount.textContent='0/50'; adSend.disabled=true; openSheet(sheetAd); };
 
@@ -504,6 +544,14 @@ adSend.onclick = async ()=>{
   if(r.ok){ closeAllSheets(); pollAd(); loadProfile(); }
   else if(r.error==='INSUFFICIENT'){ alert('Недостаточно средств'); }
 };
+shopTabs.addEventListener('click', (e)=>{
+  const b = e.target.closest('.tab-btn'); if(!b) return;
+  shopTabs.querySelectorAll('.tab-btn').forEach(x=>x.classList.remove('active'));
+  b.classList.add('active');
+  const tab = b.dataset.tab;
+  sheetShop.querySelectorAll('.tab-pane').forEach(p=>p.classList.remove('show'));
+  sheetShop.querySelector(`#tab-${tab}`)?.classList.add('show');
+});
 
 async function loadLb24(){
   const r = await fetch('/api/arena/leaderboard?window=24h').then(r=>r.json()).catch(()=>null);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -303,7 +303,13 @@
   .result-win{ color:#20d28a; }
   .result-lose{ color:#ff6b6b; }
 
-  .ring-flash{ filter: drop-shadow(0 0 16px currentColor) brightness(1.25); }
+.ring-flash{ filter: drop-shadow(0 0 16px currentColor) brightness(1.25); }
+/* Shop sheet tabs */
+.tabs{display:flex;gap:8px;margin:6px 0 10px}
+.tab-btn{flex:1;background:#121212;border:1px solid var(--border);border-radius:10px;padding:8px 10px;font-size:13px;color:#fff;cursor:pointer}
+.tab-btn.active{outline:2px solid var(--ring)}
+.tab-pane{display:none}
+.tab-pane.show{display:block}
 </style>
 </head>
 <body>
@@ -380,6 +386,7 @@
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
     <button class="chipbtn" id="arenaBtn">Арена</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
+    <button class="chipbtn" id="shopBtn">Магазин</button>
     <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
   <div id="viewerHint" style="display:none;text-align:center;color:var(--muted);font-size:13px;margin:6px 0 10px;">Зайдите через Telegram WebApp, чтобы играть.</div>
@@ -498,11 +505,40 @@
 </div>
 
 <!-- SHEET: history of paid chat -->
-<div class="sheet" id="sheetChatFeed">
-  <h3>история чата</h3>
-  <div id="chatFeed" class="feed"></div>
-  <div class="btnrow"><button class="btnsm cancel" data-close>Закрыть</button></div>
-</div>
+  <div class="sheet" id="sheetChatFeed">
+    <h3>история чата</h3>
+    <div id="chatFeed" class="feed"></div>
+    <div class="btnrow"><button class="btnsm cancel" data-close>Закрыть</button></div>
+  </div>
+
+  <!-- SHEET: Магазин -->
+  <div class="sheet" id="sheetShop">
+    <h3>Магазин</h3>
+
+    <div class="tabs" id="shopTabs">
+      <button class="tab-btn active" data-tab="boosts">Бусты</button>
+      <button class="tab-btn" data-tab="cosm">Косметика</button>
+      <button class="tab-btn" data-tab="events">События</button>
+      <button class="tab-btn" data-tab="clans">Кланы</button>
+    </div>
+
+    <div class="tab-pane show" id="tab-boosts">
+      <p>Скоро: x2 XP на 30/60 мин, комбо-бусты, сезонные задания.</p>
+    </div>
+    <div class="tab-pane" id="tab-cosm">
+      <p>Скоро: рамки профиля, цвет ника, салюты побед.</p>
+    </div>
+    <div class="tab-pane" id="tab-events">
+      <p>Скоро: мини-турниры, джекпоты недели, марафоны.</p>
+    </div>
+    <div class="tab-pane" id="tab-clans">
+      <p>Скоро: кланы, клановые бусты и рейтинги.</p>
+    </div>
+
+    <div class="btnrow">
+      <button class="btnsm cancel" data-close>Закрыть</button>
+    </div>
+  </div>
 
 <script>
 const BOT_USERNAME = 'realpricebtc_bot';
@@ -630,6 +666,7 @@ const chatFeedBtn = document.getElementById('chatFeedBtn');
 const arenaBtn = document.getElementById('arenaBtn');
 const cfgBtn  = document.getElementById('cfgBtn');
 const claimBtn   = document.getElementById('claimBtn');
+const shopBtn = document.getElementById('shopBtn');
 
 // sheets
 const sheetBg     = document.getElementById('sheetBg');
@@ -641,6 +678,8 @@ const sheetStats  = document.getElementById('sheetStats');
 const sheetAd     = document.getElementById('sheetAd');
 const sheetClaim  = document.getElementById('sheetClaim');
 const sheetChatFeed = document.getElementById('sheetChatFeed');
+const sheetShop  = document.getElementById('sheetShop');
+const shopTabs   = document.getElementById('shopTabs');
 const chatFeed      = document.getElementById('chatFeed');
 const claimVopEl  = document.getElementById('claimVop');
 const claimDo     = document.getElementById('claimDo');
@@ -899,13 +938,22 @@ function bindOnce(){
     claimDo.disabled = true;
     await fetchClaimInfo();
   };
-  chatFeedBtn.onclick = async ()=>{
-    await loadChatFeed();
-    openSheet(sheetChatFeed);
-  };
-  arenaBtn.onclick = ()=>{
-    location.href = `/arena.html?uid=${encodeURIComponent(uid)}`;
-  };
+    chatFeedBtn.onclick = async ()=>{
+      await loadChatFeed();
+      openSheet(sheetChatFeed);
+    };
+    shopBtn.onclick = ()=> openSheet(sheetShop);
+    shopTabs.addEventListener('click', (e)=>{
+      const b = e.target.closest('.tab-btn'); if(!b) return;
+      shopTabs.querySelectorAll('.tab-btn').forEach(x=>x.classList.remove('active'));
+      b.classList.add('active');
+      const tab = b.dataset.tab;
+      sheetShop.querySelectorAll('.tab-pane').forEach(p=>p.classList.remove('show'));
+      sheetShop.querySelector(`#tab-${tab}`)?.classList.add('show');
+    });
+    arenaBtn.onclick = ()=>{
+      location.href = `/arena.html?uid=${encodeURIComponent(uid)}`;
+    };
   chipsBox.addEventListener('click', e=>{
     const b = e.target.closest('.chipopt'); if (!b) return;
     document.querySelectorAll('#chips .chipopt').forEach(x=>x.classList.remove('active'));


### PR DESCRIPTION
## Summary
- add shared Shop sheet with tabbed sections for boosts, cosmetics, events, and clans
- wire up new Shop button and tab switching on main and arena pages

## Testing
- `node xp.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68ae2e307b8c83288d69d537bfae7ea5