### PR TITLE
Add farming feature for USD and VOP

### DIFF
--- a/server/public/farm-usd.html
+++ b/server/public/farm-usd.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Фарм $</title>
+<script src="https://telegram.org/js/telegram-web-app.js"></script>
+<style>
+  body{background:#000;color:#fff;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;margin:0;padding:16px;}
+  .tabs{display:flex;gap:10px;margin-bottom:12px}
+  .tabs button{flex:1;padding:10px;border:none;border-radius:8px;font-weight:700;cursor:pointer}
+  .tabs .active{background:#1fa36a;color:#000}
+  .card{background:#0b0b0b;border:1px solid #1e1e1e;border-radius:12px;padding:12px;margin:10px 0}
+  button{background:#1fa36a;border:none;border-radius:8px;padding:10px 16px;font-weight:700;cursor:pointer}
+  button[disabled]{opacity:.5;cursor:not-allowed}
+</style>
+</head>
+<body>
+<div class="tabs">
+  <button class="active">Фарм $</button>
+  <button id="toVop">Фарм VOP</button>
+</div>
+<div class="card" id="status">
+  <div>Доступно к получению: $<span id="claimable">0</span></div>
+  <button id="claim">CLAIM</button>
+  <div>Скорость: <span id="rate">0</span> $/ч</div>
+  <div>FP: <span id="fp">0</span></div>
+  <div>Лимит сегодня: <span id="claimedToday">0</span> / <span id="dailyCap">0</span></div>
+</div>
+<div class="card">
+  <h3>Апгрейды</h3>
+  <div id="upgrades"></div>
+</div>
+<div class="card">
+  <h3>История</h3>
+  <div id="history"></div>
+</div>
+<script>
+const params = new URLSearchParams(location.search);
+const uid = params.get('uid');
+document.getElementById('toVop').onclick = ()=>{ location.href = `/farm-vop.html?uid=${uid}`; };
+async function load(){
+  const r = await fetch(`/api/farm/usd/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
+  if(!r.ok){ document.getElementById('status').textContent='Ошибка'; return; }
+  document.getElementById('claimable').textContent = r.claimable;
+  document.getElementById('rate').textContent = r.ratePerHour;
+  document.getElementById('fp').textContent = r.fp;
+  document.getElementById('claimedToday').textContent = r.claimedToday;
+  document.getElementById('dailyCap').textContent = r.dailyCap;
+  document.getElementById('claim').disabled = !r.active || r.claimable<=0;
+  renderUpgrades(r.upgrades);
+  renderHistory(r.history);
+}
+async function claim(){
+  const r = await fetch('/api/farm/usd/claim',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({ok:false}));
+  if(r.ok){ Telegram?.WebApp?.HapticFeedback?.notificationOccurred('success'); load(); }
+}
+function renderUpgrades(list){
+  const box=document.getElementById('upgrades');
+  box.innerHTML = list.map(u=>`<div>${u.title} (+${u.fp} FP) - $${u.cost} <button data-id="${u.id}" ${!u.canBuy?'disabled':''}>Купить</button></div>`).join('');
+  box.querySelectorAll('button').forEach(b=>b.onclick=async()=>{
+    const id=b.dataset.id;
+    const resp=await fetch('/api/farm/usd/upgrade',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid,upgradeId:id})}).then(r=>r.json()).catch(()=>({ok:false}));
+    if(resp.ok){ Telegram?.WebApp?.HapticFeedback?.impactOccurred('light'); load(); }
+  });
+}
+function renderHistory(items){
+  const h=document.getElementById('history');
+  h.innerHTML = items.map(it=>`<div>${it.type}: ${it.amount}</div>`).join('');
+}
+document.getElementById('claim').onclick=claim;
+load();
+</script>
+</body>
+</html>

--- a/server/public/farm-vop.html
+++ b/server/public/farm-vop.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Фарм VOP</title>
+<script src="https://telegram.org/js/telegram-web-app.js"></script>
+<style>
+  body{background:#000;color:#fff;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;margin:0;padding:16px;}
+  .tabs{display:flex;gap:10px;margin-bottom:12px}
+  .tabs button{flex:1;padding:10px;border:none;border-radius:8px;font-weight:700;cursor:pointer}
+  .tabs .active{background:#1fa36a;color:#000}
+  .card{background:#0b0b0b;border:1px solid #1e1e1e;border-radius:12px;padding:12px;margin:10px 0}
+  button{background:#1fa36a;border:none;border-radius:8px;padding:10px 16px;font-weight:700;cursor:pointer}
+  button[disabled]{opacity:.5;cursor:not-allowed}
+</style>
+</head>
+<body>
+<div class="tabs">
+  <button id="toUsd">Фарм $</button>
+  <button class="active">Фарм VOP</button>
+</div>
+<div class="card" id="status"></div>
+<div class="card" id="vopInfo" style="display:none">
+  <div>Доступно к получению: <span id="claimable">0</span> VOP</div>
+  <button id="claim">CLAIM</button>
+  <div>Скорость: <span id="rate">0</span> VOP/ч</div>
+  <div>FP: <span id="fp">0</span></div>
+  <div>Лимит сегодня: <span id="claimedToday">0</span> / <span id="dailyCap">0</span></div>
+  <div>Баланс: <span id="balance">0</span> VOP</div>
+</div>
+<div class="card" id="upgCard" style="display:none">
+  <h3>Апгрейды</h3>
+  <div id="upgrades"></div>
+</div>
+<div class="card" id="histCard" style="display:none">
+  <h3>История</h3>
+  <div id="history"></div>
+</div>
+<script>
+const params = new URLSearchParams(location.search);
+const uid = params.get('uid');
+document.getElementById('toUsd').onclick = ()=>{ location.href = `/farm-usd.html?uid=${uid}`; };
+async function load(){
+  const r = await fetch(`/api/farm/vop/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
+  const statusEl = document.getElementById('status');
+  if(!r.ok){ statusEl.textContent='Ошибка'; return; }
+  if(r.locked){ statusEl.textContent = 'Откроется на 25 уровне'; return; }
+  statusEl.style.display='none';
+  document.getElementById('vopInfo').style.display='block';
+  document.getElementById('upgCard').style.display='block';
+  document.getElementById('histCard').style.display='block';
+  document.getElementById('claimable').textContent = r.claimable;
+  document.getElementById('rate').textContent = r.ratePerHour;
+  document.getElementById('fp').textContent = r.fp;
+  document.getElementById('claimedToday').textContent = r.claimedToday;
+  document.getElementById('dailyCap').textContent = r.dailyCap;
+  document.getElementById('balance').textContent = r.vopBalance;
+  document.getElementById('claim').disabled = r.claimable<=0;
+  renderUpgrades(r.upgrades);
+  renderHistory(r.history);
+}
+async function claim(){
+  const r = await fetch('/api/farm/vop/claim',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({ok:false}));
+  if(r.ok){ Telegram?.WebApp?.HapticFeedback?.notificationOccurred('success'); load(); }
+}
+function renderUpgrades(list){
+  const box=document.getElementById('upgrades');
+  box.innerHTML = list.map(u=>`<div>${u.title} (+${u.fp} FP) - $${u.cost} <button data-id="${u.id}" ${!u.canBuy?'disabled':''}>Купить</button></div>`).join('');
+  box.querySelectorAll('button').forEach(b=>b.onclick=async()=>{
+    const id=b.dataset.id;
+    const resp=await fetch('/api/farm/vop/upgrade',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid,upgradeId:id})}).then(r=>r.json()).catch(()=>({ok:false}));
+    if(resp.ok){ Telegram?.WebApp?.HapticFeedback?.impactOccurred('light'); load(); }
+  });
+}
+function renderHistory(items){
+  const h=document.getElementById('history');
+  h.innerHTML = items.map(it=>`<div>${it.type}: ${it.amount}</div>`).join('');
+}
+document.getElementById('claim').onclick=claim;
+load();
+</script>
+</body>
+</html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -385,7 +385,7 @@
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
     <button class="chipbtn" id="arenaBtn">Арена</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
-    <button class="chipbtn" id="shopBtn">Магазин</button>
+    <button class="chipbtn" id="shopBtn">Магазин<span id="farmPill" style="display:none;margin-left:4px;background:#1fa36a;color:#000;border-radius:999px;padding:0 6px;font-size:12px;font-weight:700"></span></button>
     <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
   <div id="viewerHint" style="display:none;text-align:center;color:var(--muted);font-size:13px;margin:6px 0 10px;">Зайдите через Telegram WebApp, чтобы играть.</div>
@@ -666,6 +666,7 @@ const arenaBtn = document.getElementById('arenaBtn');
 const cfgBtn  = document.getElementById('cfgBtn');
 const claimBtn   = document.getElementById('claimBtn');
 const shopBtn = document.getElementById('shopBtn');
+const farmPill = document.getElementById('farmPill');
 
 // sheets
 const sheetBg     = document.getElementById('sheetBg');
@@ -940,7 +941,7 @@ function bindOnce(){
       await loadChatFeed();
       openSheet(sheetChatFeed);
     };
-    shopBtn.onclick = ()=> openSheet(sheetShop);
+    shopBtn.onclick = ()=>{ location.href = `/farm-usd.html?uid=${encodeURIComponent(uid)}`; };
     shopTabs.addEventListener('click', (e)=>{
       const b = e.target.closest('.tab-btn'); if(!b) return;
       shopTabs.querySelectorAll('.tab-btn').forEach(x=>x.classList.remove('active'));
@@ -1102,6 +1103,16 @@ async function fetchClaimInfo(){
 
   // Кнопка по ТЗ остаётся серой/disabled (боевой клейм добавим потом)
   claimDo.disabled = true;
+}
+
+async function refreshFarmUsdPill(){
+  const r = await fetch(`/api/farm/usd/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
+  if (r.ok && Number(r.claimable)>0){
+    farmPill.textContent = '+ $' + Number(r.claimable);
+    farmPill.style.display='inline';
+  } else {
+    farmPill.style.display='none';
+  }
 }
 async function leaderboard(){
   const r = await fetch(`/api/leaderboard?initData=${encodeURIComponent(initData)}`).then(r=>r.json()).catch(()=>({ok:false}));
@@ -1321,6 +1332,7 @@ function escapeHtml(s){
 // init
 bindOnce();
 if (!IS_VIEWER) await auth();
+await refreshFarmUsdPill();
 poll();
 setInterval(poll, 1000);
 setInterval(maybeCelebrateWin, 3000);


### PR DESCRIPTION
## Summary
- add farming constants, migrations, helpers, and USD/VOP farming APIs
- add farm pages and indicator on main page

## Testing
- `node server/verifyInitData.test.js`
- `node xp.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68af4b8171688328bb56ef69b66bcce6