### PR TITLE
feat: redesign farm pages with shared styles

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -1,0 +1,42 @@
+:root{
+  --bg:#000;
+  --card:#0b0b0b;
+  --text:#fff;
+  --muted:#b9b9b9;
+  --accent:#1fa36a;
+  --success:#1fa36a;
+  --warn:#ff8c00;
+  --danger:#c6423a;
+  --outline:#1e1e1e;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;color:var(--text);background:var(--bg);}
+body{padding:16px}
+.btn{display:inline-flex;justify-content:center;align-items:center;height:48px;padding:0 16px;border:none;border-radius:16px;font-weight:700;font-size:16px;cursor:pointer;transition:transform .1s}
+.btn:active{transform:scale(.98)}
+.btn-primary{background:var(--accent);color:#000}
+.btn-secondary{background:#333;color:var(--text)}
+.btn-ghost{background:transparent;color:var(--text);border:1px solid var(--outline)}
+.btn-success{background:var(--success);color:#000}
+.btn-danger{background:var(--danger);color:#fff}
+.btn[disabled]{opacity:.5;cursor:not-allowed}
+.card{background:var(--card);border:1px solid var(--outline);border-radius:16px;padding:16px;margin:16px 0;box-shadow:0 0 4px rgba(0,0,0,.2)}
+.progress{height:6px;background:var(--outline);border-radius:6px;overflow:hidden}
+.progress .bar{height:100%;background:var(--accent);border-radius:inherit}
+.progress.success .bar{background:var(--success)}
+.chip{display:inline-block;background:var(--outline);border-radius:999px;padding:6px 10px;font-size:12px}
+.grid-2{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px}
+.list.history{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
+.row{display:flex;gap:16px;align-items:center}
+.col{flex:1}
+.label{color:var(--muted);font-size:12px}
+.val{font-weight:700}
+.muted{color:var(--muted);font-size:12px}
+.banner{padding:12px;border-radius:12px;margin-top:12px}
+.banner.warn{background:#332;color:#ffb}
+.card-compact{padding:12px;margin:0}
+.upgrade .title{font-weight:700;margin-bottom:6px}
+.upgrade .row{justify-content:space-between}
+.price{font-weight:700}
+.list.history li{display:flex;justify-content:space-between}
+.safe-bottom{padding-bottom:calc(16px + env(safe-area-inset-bottom))}

--- a/server/public/farm-usd.html
+++ b/server/public/farm-usd.html
@@ -4,72 +4,49 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Фарм $</title>
+<link rel="stylesheet" href="css/styles.css" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
-<style>
-  body{background:#000;color:#fff;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;margin:0;padding:16px;}
-  .tabs{display:flex;gap:10px;margin-bottom:12px}
-  .tabs button{flex:1;padding:10px;border:none;border-radius:8px;font-weight:700;cursor:pointer}
-  .tabs .active{background:#1fa36a;color:#000}
-  .card{background:#0b0b0b;border:1px solid #1e1e1e;border-radius:12px;padding:12px;margin:10px 0}
-  button{background:#1fa36a;border:none;border-radius:8px;padding:10px 16px;font-weight:700;cursor:pointer}
-  button[disabled]{opacity:.5;cursor:not-allowed}
-</style>
 </head>
-<body>
-<div class="tabs">
-  <button class="active">Фарм $</button>
-  <button id="toVop">Фарм VOP</button>
+<body class="safe-bottom">
+<div class="tabs row">
+  <button class="btn btn-primary" disabled>Фарм $</button>
+  <button class="btn btn-ghost" id="toVop">Фарм VOP</button>
 </div>
-<div class="card" id="status">
-  <div>Доступно к получению: $<span id="claimable">0</span></div>
-  <button id="claim">CLAIM</button>
-  <div>Скорость: <span id="rate">0</span> $/ч</div>
-  <div>FP: <span id="fp">0</span></div>
-  <div>Лимит сегодня: <span id="claimedToday">0</span> / <span id="dailyCap">0</span></div>
-</div>
-<div class="card">
+<section class="card claim-card" id="usdContent">
+  <div class="claim-top row" style="justify-content:space-between;align-items:center">
+    <div class="claim-amount">Доступно к получению: <b id="claimAmountUsd">$0</b></div>
+    <button class="btn btn-success" id="btnClaimUsd">CLAIM</button>
+  </div>
+  <div class="metrics row">
+    <div class="col"><div class="label">Скорость</div><div class="val" id="rateUsd">0 $/ч</div></div>
+    <div class="col"><div class="label">FP</div><div class="val" id="fpUsd">0</div></div>
+  </div>
+  <div class="cap">
+    <div class="cap-row row" style="justify-content:space-between"><span>Лимит сегодня</span><span id="capTextUsd">$0 / $0</span></div>
+    <div class="progress"><div class="bar" id="capBarUsd" style="width:0%"></div></div>
+    <div class="muted">Оффлайн-лимит: до 12 ч</div>
+  </div>
+  <div class="banner warn" id="usdInactiveBanner" hidden>
+    Чтобы активировать фарм $, сделай ставку от $50 за 24 часа
+    <button class="btn btn-secondary" id="goPlay">Играть</button>
+  </div>
+</section>
+<section class="card upgrades-card">
   <h3>Апгрейды</h3>
-  <div id="upgrades"></div>
-</div>
-<div class="card">
+  <div class="grid-2" id="usdUpgrades"></div>
+</section>
+<section class="card history-card">
   <h3>История</h3>
-  <div id="history"></div>
-</div>
+  <ul id="usdHistory" class="list history"></ul>
+  <button class="btn btn-ghost" id="moreUsdHistory">Показать ещё</button>
+</section>
+<script src="js/farm.js"></script>
 <script>
-const params = new URLSearchParams(location.search);
-const uid = params.get('uid');
-document.getElementById('toVop').onclick = ()=>{ location.href = `/farm-vop.html?uid=${uid}`; };
-async function load(){
-  const r = await fetch(`/api/farm/usd/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
-  if(!r.ok){ document.getElementById('status').textContent='Ошибка'; return; }
-  document.getElementById('claimable').textContent = r.claimable;
-  document.getElementById('rate').textContent = r.ratePerHour;
-  document.getElementById('fp').textContent = r.fp;
-  document.getElementById('claimedToday').textContent = r.claimedToday;
-  document.getElementById('dailyCap').textContent = r.dailyCap;
-  document.getElementById('claim').disabled = !r.active || r.claimable<=0;
-  renderUpgrades(r.upgrades);
-  renderHistory(r.history);
-}
-async function claim(){
-  const r = await fetch('/api/farm/usd/claim',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({ok:false}));
-  if(r.ok){ Telegram?.WebApp?.HapticFeedback?.notificationOccurred('success'); load(); }
-}
-function renderUpgrades(list){
-  const box=document.getElementById('upgrades');
-  box.innerHTML = list.map(u=>`<div>${u.title} (+${u.fp} FP) - $${u.cost} <button data-id="${u.id}" ${!u.canBuy?'disabled':''}>Купить</button></div>`).join('');
-  box.querySelectorAll('button').forEach(b=>b.onclick=async()=>{
-    const id=b.dataset.id;
-    const resp=await fetch('/api/farm/usd/upgrade',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid,upgradeId:id})}).then(r=>r.json()).catch(()=>({ok:false}));
-    if(resp.ok){ Telegram?.WebApp?.HapticFeedback?.impactOccurred('light'); load(); }
-  });
-}
-function renderHistory(items){
-  const h=document.getElementById('history');
-  h.innerHTML = items.map(it=>`<div>${it.type}: ${it.amount}</div>`).join('');
-}
-document.getElementById('claim').onclick=claim;
-load();
+const params=new URLSearchParams(location.search);
+const uid=params.get('uid');
+document.getElementById('toVop').onclick=()=>{location.href=`/farm-vop.html?uid=${encodeURIComponent(uid)}`};
+document.getElementById('goPlay').onclick=()=>{location.href=`/index.html?uid=${encodeURIComponent(uid)}`};
+initFarm('usd');
 </script>
 </body>
 </html>

--- a/server/public/farm-vop.html
+++ b/server/public/farm-vop.html
@@ -4,81 +4,50 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Фарм VOP</title>
+<link rel="stylesheet" href="css/styles.css" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
-<style>
-  body{background:#000;color:#fff;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;margin:0;padding:16px;}
-  .tabs{display:flex;gap:10px;margin-bottom:12px}
-  .tabs button{flex:1;padding:10px;border:none;border-radius:8px;font-weight:700;cursor:pointer}
-  .tabs .active{background:#1fa36a;color:#000}
-  .card{background:#0b0b0b;border:1px solid #1e1e1e;border-radius:12px;padding:12px;margin:10px 0}
-  button{background:#1fa36a;border:none;border-radius:8px;padding:10px 16px;font-weight:700;cursor:pointer}
-  button[disabled]{opacity:.5;cursor:not-allowed}
-</style>
 </head>
-<body>
-<div class="tabs">
-  <button id="toUsd">Фарм $</button>
-  <button class="active">Фарм VOP</button>
+<body class="safe-bottom">
+<div class="tabs row">
+  <button class="btn btn-ghost" id="toUsd">Фарм $</button>
+  <button class="btn btn-primary" disabled>Фарм VOP</button>
 </div>
-<div class="card" id="status"></div>
-<div class="card" id="vopInfo" style="display:none">
-  <div>Доступно к получению: <span id="claimable">0</span> VOP</div>
-  <button id="claim">CLAIM</button>
-  <div>Скорость: <span id="rate">0</span> VOP/ч</div>
-  <div>FP: <span id="fp">0</span></div>
-  <div>Лимит сегодня: <span id="claimedToday">0</span> / <span id="dailyCap">0</span></div>
-  <div>Баланс: <span id="balance">0</span> VOP</div>
-</div>
-<div class="card" id="upgCard" style="display:none">
+<section class="card lock-card" id="vopLocked" hidden>
+  <h3>Фарм VOP недоступен</h3>
+  <p>Откроется на 25 уровне.</p>
+  <button class="btn btn-secondary" id="goPlayFromVop">Играть</button>
+</section>
+<section class="card claim-card" id="vopContent" hidden>
+  <div class="claim-top row" style="justify-content:space-between;align-items:center">
+    <div class="claim-amount">Доступно к получению: <b id="claimAmountVop">0 💎</b></div>
+    <button class="btn btn-success" id="btnClaimVop">CLAIM</button>
+  </div>
+  <div class="metrics row">
+    <div class="col"><div class="label">Скорость</div><div class="val" id="rateVop">0 VOP/ч</div></div>
+    <div class="col"><div class="label">FP</div><div class="val" id="fpVop">0</div></div>
+  </div>
+  <div class="cap">
+    <div class="cap-row row" style="justify-content:space-between"><span>Лимит сегодня</span><span id="capTextVop">0 / 0</span></div>
+    <div class="progress success"><div class="bar" id="capBarVop" style="width:0%"></div></div>
+    <div class="muted">Оффлайн-лимит: до 12 ч</div>
+  </div>
+</section>
+<section class="card upgrades-card" id="vopUpgCard" hidden>
   <h3>Апгрейды</h3>
-  <div id="upgrades"></div>
-</div>
-<div class="card" id="histCard" style="display:none">
+  <div class="grid-2" id="vopUpgrades"></div>
+</section>
+<section class="card history-card" id="vopHistCard" hidden>
   <h3>История</h3>
-  <div id="history"></div>
-</div>
+  <ul id="vopHistory" class="list history"></ul>
+  <button class="btn btn-ghost" id="moreVopHistory">Показать ещё</button>
+</section>
+<script src="js/farm.js"></script>
 <script>
-const params = new URLSearchParams(location.search);
-const uid = params.get('uid');
-document.getElementById('toUsd').onclick = ()=>{ location.href = `/farm-usd.html?uid=${uid}`; };
-async function load(){
-  const r = await fetch(`/api/farm/vop/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
-  const statusEl = document.getElementById('status');
-  if(!r.ok){ statusEl.textContent='Ошибка'; return; }
-  if(r.locked){ statusEl.textContent = 'Откроется на 25 уровне'; return; }
-  statusEl.style.display='none';
-  document.getElementById('vopInfo').style.display='block';
-  document.getElementById('upgCard').style.display='block';
-  document.getElementById('histCard').style.display='block';
-  document.getElementById('claimable').textContent = r.claimable;
-  document.getElementById('rate').textContent = r.ratePerHour;
-  document.getElementById('fp').textContent = r.fp;
-  document.getElementById('claimedToday').textContent = r.claimedToday;
-  document.getElementById('dailyCap').textContent = r.dailyCap;
-  document.getElementById('balance').textContent = r.vopBalance;
-  document.getElementById('claim').disabled = r.claimable<=0;
-  renderUpgrades(r.upgrades);
-  renderHistory(r.history);
-}
-async function claim(){
-  const r = await fetch('/api/farm/vop/claim',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({ok:false}));
-  if(r.ok){ Telegram?.WebApp?.HapticFeedback?.notificationOccurred('success'); load(); }
-}
-function renderUpgrades(list){
-  const box=document.getElementById('upgrades');
-  box.innerHTML = list.map(u=>`<div>${u.title} (+${u.fp} FP) - $${u.cost} <button data-id="${u.id}" ${!u.canBuy?'disabled':''}>Купить</button></div>`).join('');
-  box.querySelectorAll('button').forEach(b=>b.onclick=async()=>{
-    const id=b.dataset.id;
-    const resp=await fetch('/api/farm/vop/upgrade',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid,upgradeId:id})}).then(r=>r.json()).catch(()=>({ok:false}));
-    if(resp.ok){ Telegram?.WebApp?.HapticFeedback?.impactOccurred('light'); load(); }
-  });
-}
-function renderHistory(items){
-  const h=document.getElementById('history');
-  h.innerHTML = items.map(it=>`<div>${it.type}: ${it.amount}</div>`).join('');
-}
-document.getElementById('claim').onclick=claim;
-load();
+const params=new URLSearchParams(location.search);
+const uid=params.get('uid');
+document.getElementById('toUsd').onclick=()=>{location.href=`/farm-usd.html?uid=${encodeURIComponent(uid)}`};
+document.getElementById('goPlayFromVop').onclick=()=>{location.href=`/index.html?uid=${encodeURIComponent(uid)}`};
+initFarm('vop');
 </script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -385,7 +385,7 @@
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
     <button class="chipbtn" id="arenaBtn">Арена</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
-    <button class="chipbtn" id="shopBtn">Магазин<span id="farmPill" style="display:none;margin-left:4px;background:#1fa36a;color:#000;border-radius:999px;padding:0 6px;font-size:12px;font-weight:700"></span></button>
+    <button class="chipbtn" id="shopBtn">Магазин<span id="farmPill" class="chip" style="display:none;margin-left:4px;background:var(--green);color:#000;font-weight:700"></span></button>
     <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
   <div id="viewerHint" style="display:none;text-align:center;color:var(--muted);font-size:13px;margin:6px 0 10px;">Зайдите через Telegram WebApp, чтобы играть.</div>

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -1,0 +1,39 @@
+(function(){
+const params=new URLSearchParams(location.search);
+const uid=params.get('uid');
+function formatMoney(n){return '$'+Number(n).toLocaleString('ru-RU');}
+function formatVop(n){return Number(n).toLocaleString('ru-RU')+' \uD83D\uDC8E';}
+function toast(msg){const t=document.createElement('div');t.textContent=msg;t.style.position='fixed';t.style.left='50%';t.style.bottom='20px';t.style.transform='translateX(-50%)';t.style.background='#333';t.style.padding='8px 12px';t.style.borderRadius='8px';document.body.appendChild(t);setTimeout(()=>t.remove(),2000);}
+function haptic(kind){try{const h=window.Telegram?.WebApp?.HapticFeedback;if(!h)return;if(kind==='success'||kind==='error')h.notificationOccurred(kind);else h.impactOccurred('light');}catch(e){}}
+async function fetchState(kind){return await fetch(`/api/farm/${kind}/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));}
+function renderUsdState(s){if(!s.ok){return;}document.getElementById('claimAmountUsd').textContent=formatMoney(s.claimable);document.getElementById('btnClaimUsd').disabled=!(s.active&&s.claimable>0);document.getElementById('rateUsd').textContent=formatMoney(s.ratePerHour).slice(1)+' $/ч';document.getElementById('fpUsd').textContent=s.fp;const pct=s.dailyCap?Math.min(100,s.claimedToday/s.dailyCap*100):0;document.getElementById('capTextUsd').textContent=`${formatMoney(s.claimedToday)} / ${formatMoney(s.dailyCap)}`;document.getElementById('capBarUsd').style.width=pct+'%';document.getElementById('usdInactiveBanner').hidden=s.active;renderUpgrades('usd',s.upgrades,document.getElementById('usdUpgrades'));renderHistory('usd',s.history,document.getElementById('usdHistory'));}
+function renderVopState(s){
+  if(!s.ok){return;}
+  if(s.locked){
+    document.getElementById('vopLocked').hidden=false;
+    document.getElementById('vopContent').hidden=true;
+    document.getElementById('vopUpgCard').hidden=true;
+    document.getElementById('vopHistCard').hidden=true;
+    return;
+  }
+  document.getElementById('vopLocked').hidden=true;
+  document.getElementById('vopContent').hidden=false;
+  document.getElementById('vopUpgCard').hidden=false;
+  document.getElementById('vopHistCard').hidden=false;
+  document.getElementById('claimAmountVop').textContent=formatVop(s.claimable);
+  document.getElementById('btnClaimVop').disabled=s.claimable<=0;
+  document.getElementById('rateVop').textContent=s.ratePerHour+' VOP/ч';
+  document.getElementById('fpVop').textContent=s.fp;
+  const pct=s.dailyCap?Math.min(100,s.claimedToday/s.dailyCap*100):0;
+  document.getElementById('capTextVop').textContent=`${s.claimedToday} / ${s.dailyCap}`;
+  document.getElementById('capBarVop').style.width=pct+'%';
+  renderUpgrades('vop',s.upgrades,document.getElementById('vopUpgrades'));
+  renderHistory('vop',s.history,document.getElementById('vopHistory'));
+}
+async function claim(kind){haptic('impact');const r=await fetch(`/api/farm/${kind}/claim`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({ok:false}));if(r.ok){toast('Получено');haptic('success');load(kind);}else{toast('Ошибка');haptic('error');}}
+function bindClaim(kind){const id=kind==='usd'?'btnClaimUsd':'btnClaimVop';const b=document.getElementById(id);b&&b.addEventListener('click',()=>claim(kind));}
+function renderUpgrades(kind,list,box){box.innerHTML='';if(!list||!list.length){box.innerHTML='<div class="muted">Нет апгрейдов</div>';return;}list.forEach(u=>{const card=document.createElement('div');card.className='upgrade card card-compact';card.innerHTML=`<div class="title">${u.title}</div><div class="row"><span class="chip">+${u.fp} FP</span><span class="price">${formatMoney(u.cost)}</span></div><div class="muted">Треб. уровень: ${u.level}</div>`;const btn=document.createElement('button');btn.className='btn btn-primary';btn.textContent='Купить';btn.disabled=!u.canBuy;btn.addEventListener('click',async()=>{haptic('impact');const resp=await fetch(`/api/farm/${kind}/upgrade`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid,upgradeId:u.id})}).then(r=>r.json()).catch(()=>({ok:false}));if(resp.ok){toast('+FP '+u.fp);haptic('success');load(kind);}else{toast('Ошибка');haptic('error');}});card.appendChild(btn);box.appendChild(card);});}
+function renderHistory(kind,items,box){box.innerHTML='';if(!items||!items.length){box.innerHTML='<li class="muted">Пока пусто.</li>';return;}items.forEach(it=>{const li=document.createElement('li');if(it.type==='claim_'+kind){li.innerHTML=`<span class="muted">${it.time||''}</span><span style="color:var(--success)">+${kind==='usd'?formatMoney(it.amount):formatVop(it.amount)}</span>`;}else{li.innerHTML=`<span>${it.title||it.type}</span><span class="muted">-${kind==='usd'?formatMoney(it.amount):formatVop(it.amount)}</span>`;}box.appendChild(li);});}
+async function load(kind){const s=await fetchState(kind);kind==='usd'?renderUsdState(s):renderVopState(s);}
+window.initFarm=function(kind){bindClaim(kind);load(kind);setInterval(()=>load(kind),15000);};
+})();


### PR DESCRIPTION
## Summary
- restyle farm pages with unified tokens and components
- add shared farm.js for claim and upgrades logic
- align main page shop pill with chip styling

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af51efba5c83288c3ee6ce697469d9