### PR TITLE
feat: show VOP balance and restrict claim

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -197,7 +197,7 @@
   <div class="levelcard" id="levelCard">
     <div class="level-head">
       <div class="level-title">Уровень <span id="lvlNum">1</span></div>
-      <div class="level-balance">Баланс: <span id="balInline">$—</span></div>
+      <div class="level-balance">Баланс: <span id="balInline">$—</span> • VOP: <span id="vopInline">—</span> 💎</div>
     </div>
     <div class="level-bar">
       <div class="level-fill" id="xpFill"></div>
@@ -223,7 +223,6 @@
     <button class="chipbtn" id="rulesBtn">Правила</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
     <button class="chipbtn" id="shopBtn">Магазин</button>
-    <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
   <div class="lb-head">Топ за 24 часа</div>
   <div class="podium" id="lbPodium"></div>
@@ -287,17 +286,6 @@
   </div>
 </div>
 
-<!-- SHEET: CLAIM -->
-<div class="sheet" id="sheetClaim">
-  <h3>CLAIM</h3>
-  <p style="margin-top:6px;">Ты можешь склеймить</p>
-  <div id="claimVop" style="font-size:22px;font-weight:800;margin:4px 0 10px;">— VOP</div>
-  <div class="btnrow">
-    <button class="btnsm cancel" data-close>Закрыть</button>
-    <button class="btnsm" id="claimDo" disabled>CLAIM</button>
-  </div>
-</div>
-
 <!-- SHEET: история чата -->
   <div class="sheet" id="sheetChatFeed">
     <h3>история чата</h3>
@@ -358,6 +346,7 @@ const bidBtn = document.getElementById('bidBtn');
 const leaderEl = document.getElementById('leader');
 const lvlNum = document.getElementById('lvlNum');
 const balInline = document.getElementById('balInline');
+const vopInline = document.getElementById('vopInline');
 const xpFill = document.getElementById('xpFill');
 const xpText = document.getElementById('xpText');
 
@@ -372,7 +361,6 @@ const topupBtn = document.getElementById('topupBtn');
 const chatFeedBtn = document.getElementById('chatFeedBtn');
 const rulesBtn = document.getElementById('rulesBtn');
 const starsBtn = document.getElementById('starsBtn');
-const claimBtn = document.getElementById('claimBtn');
 const shopBtn = document.getElementById('shopBtn');
 
 const sheetBg = document.getElementById('sheetBg');
@@ -380,7 +368,6 @@ const sheetRules = document.getElementById('sheetRules');
 const sheetTopup = document.getElementById('sheetTopup');
 const sheetStars = document.getElementById('sheetStars');
 const sheetAd = document.getElementById('sheetAd');
-const sheetClaim = document.getElementById('sheetClaim');
 const sheetChatFeed = document.getElementById('sheetChatFeed');
 const sheetShop = document.getElementById('sheetShop');
 const shopTabs = document.getElementById('shopTabs');
@@ -393,8 +380,6 @@ const adSend = document.getElementById('adSend');
 const adCount = document.getElementById('adCount');
 const adEnter = document.getElementById('adEnter');
 const chatFeed = document.getElementById('chatFeed');
-const claimVopEl = document.getElementById('claimVop');
-const claimDo = document.getElementById('claimDo');
 
 let selectedPack = null;
 let arenaPhase = 'idle';
@@ -404,14 +389,17 @@ let adState = {};
 
 function fmt(n){ return '$'+Number(n||0).toLocaleString(); }
 function normUser(u){ return '@'+String(u||'anon').replace(/^@+/, ''); }
-function setBalanceVal(amount){ if(balInline) balInline.textContent = fmt(amount); }
+function setBalanceVal(amount, vop){
+  if(balInline) balInline.textContent = fmt(amount);
+  if(vopInline) vopInline.textContent = Number(vop||0).toLocaleString('ru-RU');
+}
 function renderProfile(p){
   if(!p) return;
   lvlNum.textContent = p.level;
   const prog = Math.max(0, Math.min(1, (p.level_progress||0)/(p.level_threshold||1)));
   xpFill.style.width = (prog*100).toFixed(1)+'%';
   xpText.textContent = `${Number(p.level_progress||0).toLocaleString()} / ${Number(p.level_threshold||0).toLocaleString()} XP`;
-  setBalanceVal(p.balance);
+  setBalanceVal(p.balance, p.vop_balance);
 }
 async function loadProfile(){
   if(!uid) return;
@@ -525,7 +513,6 @@ chatFeedBtn.onclick = async ()=>{ await loadChatHistory(); openSheet(sheetChatFe
 rulesBtn.onclick = ()=> openSheet(sheetRules);
 starsBtn.onclick = ()=> openSheet(sheetStars);
 shopBtn.onclick = ()=> openSheet(sheetShop);
-claimBtn.onclick = async ()=>{ openSheet(sheetClaim); claimVopEl.textContent='… VOP'; await fetchClaimInfo(); };
 adWriteBtn.onclick = ()=>{ adInput.value=''; adCount.textContent='0/50'; adSend.disabled=true; openSheet(sheetAd); };
 
 adInput.addEventListener('input', ()=>{
@@ -585,13 +572,6 @@ buyStars.onclick = async ()=>{
   if(!resp.ok){ alert('Не удалось создать платёж.'); return; }
   Telegram?.WebApp?.openInvoice?.(resp.link, async status => { if(status==='paid'){ await loadProfile(); } });
 };
-
-async function fetchClaimInfo(){
-  const r = await fetch('/api/claim/info',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify({ uid })}).then(r=>r.json()).catch(()=>({ok:false}));
-  if(r.ok){ claimVopEl.textContent = (Number(r.claimable_vop)||0).toLocaleString()+' VOP'; }
-  else { claimVopEl.textContent='— VOP'; }
-  claimDo.disabled = true;
-}
 
 setInterval(pollArena,1000);
 setInterval(pollAd,4000);

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -314,7 +314,7 @@
 </head>
 <body>
 <div class="wrap">
-  <div class="balance flash-target" id="bal">Баланс: $—</div>
+  <div class="balance flash-target" id="bal">Баланс: $— • VOP: — 💎</div>
   <div id="viewerBanner" style="display:none;text-align:center;margin:6px 0 10px;">
     <div style="margin-bottom:6px">Открой в Telegram, чтобы играть</div>
     <a id="viewerOpen" href="https://t.me/realpricebtc_bot?startapp=go" style="background:#1fa36a;color:#fff;padding:6px 12px;border-radius:8px;text-decoration:none;font-weight:700;font-size:14px;">Открыть бота</a>
@@ -368,7 +368,7 @@
   <div class="levelcard" id="levelCard">
     <div class="level-head">
       <div class="level-title">Уровень <span id="lvlNum">1</span></div>
-      <div class="level-balance">Баланс: <span id="balInline">$—</span></div>
+      <div class="level-balance">Баланс: <span id="balInline">$—</span> • VOP: <span id="vopInline">—</span> 💎</div>
     </div>
     <div class="level-bar">
       <div class="level-fill" id="xpFill"></div>
@@ -386,7 +386,6 @@
     <button class="chipbtn" id="arenaBtn">Арена</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
     <button class="chipbtn" id="shopBtn">Магазин<span id="farmPill" class="chip" style="display:none;margin-left:4px;background:var(--green);color:#000;font-weight:700"></span></button>
-    <button class="chipbtn" id="claimBtn" style="display:none">CLAIM</button>
   </div>
   <div id="viewerHint" style="display:none;text-align:center;color:var(--muted);font-size:13px;margin:6px 0 10px;">Зайдите через Telegram WebApp, чтобы играть.</div>
 
@@ -489,17 +488,6 @@
   <div class="btnrow">
     <button class="btnsm cancel" data-close>Отмена</button>
     <button class="btnsm" id="adSend" disabled>Отправить</button>
-  </div>
-</div>
-
-<!-- SHEET: CLAIM -->
-<div class="sheet" id="sheetClaim">
-  <h3>CLAIM</h3>
-  <p style="margin-top:6px;">Ты можешь склеймить</p>
-  <div id="claimVop" style="font-size:22px;font-weight:800;margin:4px 0 10px;">— VOP</div>
-  <div class="btnrow">
-    <button class="btnsm cancel" data-close>Закрыть</button>
-    <button class="btnsm" id="claimDo" disabled>CLAIM</button>
   </div>
 </div>
 
@@ -642,6 +630,7 @@ const ringTimer   = document.getElementById('ringTimer');
 const ringPhase   = document.getElementById('ringPhase');
 const balEl   = document.getElementById('bal');
 const balInline = document.getElementById('balInline');
+const vopInline = document.getElementById('vopInline');
 const ring    = document.getElementById('ring');
 const betArc  = document.getElementById('betArc');
 const bankEl  = document.getElementById('bank');
@@ -664,7 +653,6 @@ const statsBtn= document.getElementById('statsBtn');
 const chatFeedBtn = document.getElementById('chatFeedBtn');
 const arenaBtn = document.getElementById('arenaBtn');
 const cfgBtn  = document.getElementById('cfgBtn');
-const claimBtn   = document.getElementById('claimBtn');
 const shopBtn = document.getElementById('shopBtn');
 const farmPill = document.getElementById('farmPill');
 
@@ -676,13 +664,10 @@ const sheetStars  = document.getElementById('sheetStars');
 const sheetIns    = document.getElementById('sheetIns');
 const sheetStats  = document.getElementById('sheetStats');
 const sheetAd     = document.getElementById('sheetAd');
-const sheetClaim  = document.getElementById('sheetClaim');
 const sheetChatFeed = document.getElementById('sheetChatFeed');
 const sheetShop  = document.getElementById('sheetShop');
 const shopTabs   = document.getElementById('shopTabs');
 const chatFeed      = document.getElementById('chatFeed');
-const claimVopEl  = document.getElementById('claimVop');
-const claimDo     = document.getElementById('claimDo');
 
 // stake controls
 const chipsBox  = document.getElementById('chips');
@@ -715,7 +700,7 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 if (IS_VIEWER) {
-  [buyBtn, sellBtn, cfgBtn, refBtn, topupBtn, insBtn, statsBtn, chatFeedBtn, arenaBtn, starsBtn, claimBtn, adWriteBtn, buyStars, buyIns, adSend, claimDo].forEach(b => b && (b.disabled = true));
+  [buyBtn, sellBtn, cfgBtn, refBtn, topupBtn, insBtn, statsBtn, chatFeedBtn, arenaBtn, starsBtn, adWriteBtn, buyStars, buyIns, adSend].forEach(b => b && (b.disabled = true));
   viewerBanner.style.display = 'block';
   viewerHint.style.display   = 'block';
   viewerOpen.onclick = (e)=>{ e.preventDefault(); const link = `https://t.me/${BOT_USERNAME}?startapp=go`; try{ if(window.Telegram?.WebApp?.openTelegramLink) Telegram.WebApp.openTelegramLink(link); else window.location.href = link; } catch{ window.location.href = link; } };
@@ -838,10 +823,12 @@ function floatAmount(parent, text, plus /*true for +, false for -*/) {
 
 // helpers
 function fmt(n){ return '$'+Number(n||0).toLocaleString(); }
-function setBalanceVal(amount){
-  const txt = 'Баланс: ' + fmt(amount);
+function setBalanceVal(amount, vop){
+  const vopFmt = Number(vop||0).toLocaleString('ru-RU');
+  const txt = 'Баланс: ' + fmt(amount) + ' • VOP: ' + vopFmt + ' 💎';
   if (balEl) balEl.textContent = txt;
   if (balInline) balInline.textContent = fmt(amount);
+  if (vopInline) vopInline.textContent = vopFmt;
 }
 function renderProfile(p){
   if (!p) return;
@@ -931,12 +918,6 @@ function bindOnce(){
   insBtn.onclick   = ()=>{ insCountEl.textContent = 'Доступно: ' + INS_COUNT; openSheet(sheetIns); };
   starsBtn.onclick = ()=> openSheet(sheetStars);
   statsBtn.onclick = ()=>{ loadMyStats(); openSheet(sheetStats); };
-  claimBtn.onclick = async ()=>{
-    openSheet(sheetClaim);
-    claimVopEl.textContent = '… VOP';
-    claimDo.disabled = true;
-    await fetchClaimInfo();
-  };
     chatFeedBtn.onclick = async ()=>{
       await loadChatFeed();
       openSheet(sheetChatFeed);
@@ -1064,12 +1045,9 @@ async function auth(){
     body: JSON.stringify({ uid, username })
   }).then(r=>r.json()).catch(()=>({ok:false}));
   if (r.ok) {
-    setBalanceVal(r.user.balance);
+    setBalanceVal(r.user.balance, r.user.vop_balance);
     INS_COUNT = Number(r.user.insurance || 0);
     if (insCountEl) insCountEl.textContent = 'Доступно: ' + INS_COUNT;
-    if (typeof r.user.ref_count === 'number') {
-      claimBtn.style.display = r.user.ref_count >= 30 ? 'inline-block' : 'none';
-    }
     renderProfile(r.user);
   }
 }
@@ -1079,30 +1057,11 @@ async function refreshBalance(){
     body: JSON.stringify({ uid, username })
   }).then(r=>r.json()).catch(()=>({ok:false}));
   if (r.ok) {
-    setBalanceVal(r.user.balance);
+    setBalanceVal(r.user.balance, r.user.vop_balance);
     INS_COUNT = Number(r.user.insurance || 0);
     if (insCountEl) insCountEl.textContent = 'Доступно: ' + INS_COUNT;
-    if (typeof r.user.ref_count === 'number') {
-      claimBtn.style.display = r.user.ref_count >= 30 ? 'inline-block' : 'none';
-    }
     renderProfile(r.user);
   }
-}
-
-async function fetchClaimInfo(){
-  const r = await fetch('/api/claim/info', {
-    method:'POST',
-    headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({ uid })
-  }).then(r=>r.json()).catch(()=>({ ok:false }));
-
-  if (!r.ok) { claimVopEl.textContent = '— VOP'; return; }
-
-  // текст: "<число> VOP"
-  claimVopEl.textContent = (Number(r.claimable_vop)||0).toLocaleString() + ' VOP';
-
-  // Кнопка по ТЗ остаётся серой/disabled (боевой клейм добавим потом)
-  claimDo.disabled = true;
 }
 
 async function refreshFarmUsdPill(){

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -3,13 +3,30 @@ const params = new URLSearchParams(location.search);
 const uid = params.get('uid');
 
 function formatMoney(n){return '$'+Number(n).toLocaleString('ru-RU');}
-function formatVop(n){return Number(n).toLocaleString('ru-RU')+' \uD83D\uDC8E';}
+function formatVop(n){return Number(n).toLocaleString('ru-RU')+' 💎';}
 function toast(msg){const t=document.createElement('div');t.textContent=msg;t.style.position='fixed';t.style.left='50%';t.style.bottom='20px';t.style.transform='translateX(-50%)';t.style.background='#333';t.style.padding='8px 12px';t.style.borderRadius='8px';document.body.appendChild(t);setTimeout(()=>t.remove(),2000);}
 function haptic(kind){try{const h=window.Telegram?.WebApp?.HapticFeedback;if(!h)return;if(kind==='success'||kind==='error')h.notificationOccurred(kind);else h.impactOccurred('light');}catch(e){}}
 
 async function loadFarmState(type){return await fetch(`/api/farm/${type}/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));}
 
-async function claim(type){haptic('impact');const r=await fetch(`/api/farm/${type}/claim`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({ok:false}));if(r.ok){toast('Получено');haptic('success');loadCurrent();}else{toast('Ошибка');haptic('error');}}
+async function claim(type){
+  haptic('impact');
+  const r=await fetch(`/api/farm/${type}/claim`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid})}).then(r=>r.json()).catch(()=>({error:true}));
+  if(r && r.claimed!==undefined){
+    toast('Получено: '+formatVop(r.claimed));
+    haptic('success');
+    loadCurrent();
+  }else if(r && r.code==='NOT_ENOUGH_REFERRALS'){
+    toast('Нужно 30 приглашённых');
+    haptic('error');
+  }else if(r && r.code==='NOTHING_TO_CLAIM'){
+    toast('Пока нечего забирать');
+    haptic('error');
+  }else{
+    toast('Ошибка');
+    haptic('error');
+  }
+}
 
 async function buyUpgrade(type,id){haptic('impact');const r=await fetch(`/api/farm/${type}/upgrade`,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({uid,upgradeId:id})}).then(r=>r.json()).catch(()=>({ok:false}));if(r.ok){toast('OK');haptic('success');loadCurrent();}else{toast('Ошибка');haptic('error');}}
 
@@ -17,7 +34,36 @@ function renderUpgrades(type,list){const box=document.getElementById('upgrades')
 
 function renderHistory(type,items){const box=document.getElementById('history');box.innerHTML='';if(!items||!items.length){box.innerHTML='<li class="muted">Пока пусто.</li>';return;}items.forEach(it=>{const li=document.createElement('li');if(it.type==='claim_'+type){li.innerHTML=`<span class="muted">${it.time||''}</span><span style="color:var(--success)">+${type==='usd'?formatMoney(it.amount):formatVop(it.amount)}</span>`;}else{li.innerHTML=`<span>${it.title||it.type}</span><span class="muted">-${type==='usd'?formatMoney(it.amount):formatVop(it.amount)}</span>`;}box.appendChild(li);});}
 
-function renderState(type,s){if(!s.ok)return;const claimAmount=document.getElementById('claimAmount');const btnClaim=document.getElementById('btnClaim');const rate=document.getElementById('rate');const fp=document.getElementById('fp');const capText=document.getElementById('capText');const capBar=document.getElementById('capBar');const inactive=document.getElementById('inactiveBanner');if(type==='usd'){claimAmount.textContent=formatMoney(s.claimable);btnClaim.disabled=!(s.active&&s.claimable>0);rate.textContent=formatMoney(s.ratePerHour).slice(1)+' $/ч';capText.textContent=`${formatMoney(s.claimedToday)} / ${formatMoney(s.dailyCap)}`;inactive.hidden=s.active;}else{claimAmount.textContent=formatVop(s.claimable);btnClaim.disabled=s.claimable<=0;rate.textContent=s.ratePerHour+' VOP/ч';capText.textContent=`${s.claimedToday} / ${s.dailyCap}`;inactive.hidden=true;}fp.textContent=s.fp;const pct=s.dailyCap?Math.min(100,s.claimedToday/s.dailyCap*100):0;capBar.style.width=pct+'%';renderUpgrades(type,s.upgrades);renderHistory(type,s.history);}
+  function renderState(type,s){
+    if(!s.ok)return;
+    const claimAmount=document.getElementById('claimAmount');
+    const btnClaim=document.getElementById('btnClaim');
+    const rate=document.getElementById('rate');
+    const fp=document.getElementById('fp');
+    const capText=document.getElementById('capText');
+    const capBar=document.getElementById('capBar');
+    const inactive=document.getElementById('inactiveBanner');
+    if(type==='usd'){
+      claimAmount.textContent=formatMoney(s.claimable);
+      btnClaim.disabled=!(s.active&&s.claimable>0);
+      rate.textContent=formatMoney(s.ratePerHour).slice(1)+' $/ч';
+      capText.textContent=`${formatMoney(s.claimedToday)} / ${formatMoney(s.dailyCap)}`;
+      inactive.hidden=s.active;
+    }else{
+      claimAmount.textContent=formatVop(s.available);
+      btnClaim.disabled=!(s.can_claim&&s.available>0);
+      rate.textContent=s.speed_per_hour+' VOP/ч';
+      capText.textContent=`${s.daily_progress} / ${s.daily_limit}`;
+      inactive.hidden=true;
+    }
+    fp.textContent=s.fp;
+    const pct = type==='usd'
+      ? (s.dailyCap?Math.min(100,s.claimedToday/s.dailyCap*100):0)
+      : (s.daily_limit?Math.min(100,s.daily_progress/s.daily_limit*100):0);
+    capBar.style.width=pct+'%';
+    renderUpgrades(type,s.upgrades);
+    renderHistory(type,s.history);
+  }
 
 let currentType='usd';
 async function loadCurrent(){const s=await loadFarmState(currentType);renderState(currentType,s);}


### PR DESCRIPTION
## Summary
- include VOP balance in auth responses and expose referral-gated VOP farm API
- enforce referral threshold and nothing-to-claim errors on VOP claims
- show VOP balance in main and arena screens and handle VOP farm claim UI

## Testing
- `npm test` *(fails: missing package.json)*
- `node --test xp.test.mjs`
- `node --test server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af5f34ed4c8328a88855f9cfae18ec