### PR TITLE
Remove duplicate farm page title

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -41,3 +41,4 @@ body{padding:16px;letter-spacing:0.3px}
 .price{font-weight:700}
 .list.history li{display:flex;justify-content:space-between}
 .safe-bottom{padding-bottom:calc(16px + env(safe-area-inset-bottom))}
+.sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(1px,1px,1px,1px)}

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -8,11 +8,8 @@
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
 <body class="safe-bottom">
-<header class="row" style="justify-content:space-between;align-items:center">
-  <button id="backBtn" class="back-text">Назад</button>
-  <h1 style="margin:0;font-size:20px">Real Price BTC Game</h1>
-</header>
-<div class="tabs row" style="margin-top:16px">
+<h1 class="sr-only">Real Price BTC Game</h1>
+<div class="tabs row" style="margin-top:0">
   <button class="tab btn btn-primary" data-type="usd">Фарм $</button>
   <button class="tab btn btn-ghost" data-type="vop">Фарм VOP</button>
 </div>

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -70,6 +70,6 @@ async function loadCurrent(){const s=await loadFarmState(currentType);renderStat
 
 function switchTab(type){currentType=type;document.querySelectorAll('.tab').forEach(b=>{if(b.dataset.type===type){b.classList.remove('btn-ghost');b.classList.add('btn-primary');}else{b.classList.remove('btn-primary');b.classList.add('btn-ghost');}});loadCurrent();}
 
-window.initFarmPage=function(){document.getElementById('backBtn').onclick=()=>{location.href=`/index.html?uid=${encodeURIComponent(uid)}`};document.querySelectorAll('.tab').forEach(b=>b.addEventListener('click',()=>switchTab(b.dataset.type)));document.getElementById('btnClaim').addEventListener('click',()=>claim(currentType));document.getElementById('goPlay').addEventListener('click',()=>{location.href=`/index.html?uid=${encodeURIComponent(uid)}`});switchTab('usd');setInterval(loadCurrent,15000);};
+window.initFarmPage=function(){document.querySelectorAll('.tab').forEach(b=>b.addEventListener('click',()=>switchTab(b.dataset.type)));document.getElementById('btnClaim').addEventListener('click',()=>claim(currentType));document.getElementById('goPlay').addEventListener('click',()=>{location.href=`/index.html?uid=${encodeURIComponent(uid)}`});switchTab('usd');setInterval(loadCurrent,15000);};
 })();
 


### PR DESCRIPTION
## Summary
- Remove duplicate heading from farm page and position tabs at top
- Add screen-reader only heading and styles
- Drop back button handling from farm script

## Testing
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af64e901d48328bf98143b9658f4fd