### PR TITLE
Handle VOP claim state and add farm navigation

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -22,6 +22,7 @@ body{padding:16px;letter-spacing:0.3px}
 .btn[disabled]{opacity:.5;cursor:not-allowed}
 .back-text{background:none;border:none;color:#fff;font-size:14px;padding:0;margin-bottom:6px;cursor:pointer}
 .card{background:var(--card);border:1px solid var(--outline);border-radius:16px;padding:16px;margin:16px 0;box-shadow:0 0 4px rgba(0,0,0,.2)}
+.claim-card,.upgrades-card,.history-card{margin:24px 0;}
 .progress{height:6px;background:var(--outline);border-radius:6px;overflow:hidden}
 .progress .bar{height:100%;background:var(--accent);border-radius:inherit}
 .progress.success .bar{background:var(--success)}

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -9,6 +9,7 @@
 </head>
 <body class="safe-bottom">
 <h1 class="sr-only">Real Price BTC Game</h1>
+<button class="back-text" id="backText">Назад</button>
 <div class="tabs row" style="margin-top:0">
   <button class="tab btn btn-primary" data-type="usd">Фарм $</button>
   <button class="tab btn btn-ghost" data-type="vop">Фарм VOP</button>
@@ -48,6 +49,16 @@
 <script src="js/farm.js"></script>
 <script>
   initFarmPage();
+  const backText = document.getElementById('backText');
+  backText.addEventListener('click',()=>{
+    if(history.length>1) history.back(); else location.href='/';
+  });
+  if(window.Telegram?.WebApp?.BackButton){
+    Telegram.WebApp.BackButton.show();
+    Telegram.WebApp.onEvent('backButtonClicked',()=>{
+      if(history.length>1) history.back(); else location.href='/';
+    });
+  }
 </script>
 </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -1073,6 +1073,11 @@ async function refreshFarmUsdPill(){
     farmPill.style.display='none';
   }
 }
+
+async function refreshState(){
+  await refreshBalance();
+  await refreshFarmUsdPill();
+}
 async function leaderboard(){
   const r = await fetch(`/api/leaderboard?initData=${encodeURIComponent(initData)}`).then(r=>r.json()).catch(()=>({ok:false}));
   if (!r.ok) return;
@@ -1290,8 +1295,14 @@ function escapeHtml(s){
 
 // init
 bindOnce();
-if (!IS_VIEWER) await auth();
-await refreshFarmUsdPill();
+if (!IS_VIEWER) await refreshState();
+
+window.addEventListener('storage', e=>{
+  if (e.key==='stateUpdated') refreshState();
+});
+document.addEventListener('visibilitychange', ()=>{
+  if (document.visibilityState==='visible') refreshState();
+});
 poll();
 setInterval(poll, 1000);
 setInterval(maybeCelebrateWin, 3000);


### PR DESCRIPTION
## Summary
- sync `vop_balance` from DB and add `/api/farm/claim_vop` endpoint returning updated farm stats
- refresh main page on storage/visibility events for live VOP balance
- rework farm claim logic with referral checks, local state sync and back navigation

## Testing
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af69256f9c832880c13e6ecef77e73