### PR TITLE
style: increase spacing on farm screens

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -8,6 +8,10 @@
   --warn:#ff8c00;
   --danger:#c6423a;
   --outline:#1e1e1e;
+  --gap-xxs:6px;
+  --gap-xs:8px;
+  --gap-s:12px;
+  --gap-m:16px;
 }
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;color:var(--text);background:var(--bg);}
@@ -21,15 +25,15 @@ body{padding:16px;letter-spacing:0.3px}
 .btn-danger{background:var(--danger);color:#fff}
 .btn[disabled]{opacity:.5;cursor:not-allowed}
 .back-text{background:none;border:none;color:#fff;font-size:14px;padding:0;margin-bottom:6px;cursor:pointer}
-.card{background:var(--card);border:1px solid var(--outline);border-radius:16px;padding:16px;margin:16px 0;box-shadow:0 0 4px rgba(0,0,0,.2)}
-.claim-card{margin:24px 0;}
-.upgrades-card{margin:32px 0 48px;}
+.card{background:var(--card);border:1px solid var(--outline);border-radius:16px;padding:var(--gap-m);margin:var(--gap-m) 0;box-shadow:0 0 4px rgba(0,0,0,.2)}
+.claim-card{margin:var(--gap-m) 0;line-height:1.25;}
+.upgrades-card{margin-top:var(--gap-m);line-height:1.25;}
 .progress{height:6px;background:var(--outline);border-radius:6px;overflow:hidden}
 .progress .bar{height:100%;background:var(--accent);border-radius:inherit}
 .progress.success .bar{background:var(--success)}
 .chip{display:inline-block;background:var(--outline);border-radius:999px;padding:6px 10px;font-size:12px}
+.row{display:flex;gap:var(--gap-m);align-items:center}
 .grid-2{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px}
-.row{display:flex;gap:16px;align-items:center}
 .col{flex:1}
 .label{color:var(--muted);font-size:12px}
 .val{font-weight:700}
@@ -40,5 +44,27 @@ body{padding:16px;letter-spacing:0.3px}
 .upgrade .title{font-weight:700;margin-bottom:6px}
 .upgrade .row{justify-content:space-between}
 .price{font-weight:700}
-.safe-bottom{padding-bottom:calc(40px + env(safe-area-inset-bottom))}
+.safe-bottom{padding-bottom:calc(env(safe-area-inset-bottom,0) + 12px)}
 .sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(1px,1px,1px,1px)}
+
+/* farm stats card */
+.farm-stats{display:flex;flex-direction:column;row-gap:var(--gap-xs);}
+.farm-stats .row{justify-content:space-between;gap:var(--gap-s);}
+.farm-claim{margin-left:auto;}
+.cap{display:flex;flex-direction:column;row-gap:var(--gap-xs);}
+.claim-amount b,.farm-stats .val,.cap-row span:last-child{white-space:nowrap;}
+
+/* farm tabs */
+.farm-tabs{margin:0 0 var(--gap-m);}
+
+/* upgrades */
+.upgrades-grid{display:grid;grid-template-columns:1fr 1fr;gap:var(--gap-m);}
+@media (max-width:360px){
+  .upgrades-grid{grid-template-columns:1fr;}
+}
+.upgrade-card{padding:var(--gap-m);border-radius:16px;}
+.upgrade-card h3{margin:0 0 var(--gap-xs);line-height:1.25;}
+.upgrade-badge{margin-bottom:var(--gap-xxs);}
+.upgrade-price{margin-bottom:var(--gap-xxs);font-weight:700;}
+.upgrade-req{margin-bottom:var(--gap-s);color:#9AA3A8;}
+.upgrade-card .btn{margin-top:var(--gap-s);}

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -10,22 +10,21 @@
 <body class="safe-bottom">
 <h1 class="sr-only">Real Price BTC Game</h1>
 <button class="back-text" id="backText">Назад</button>
-<div class="tabs row" style="margin-top:0">
+<div class="farm-tabs tabs row">
   <button class="tab btn btn-primary" data-type="usd">Фарм $</button>
   <button class="tab btn btn-ghost" data-type="vop">Фарм VOP</button>
 </div>
-
-<section class="card claim-card" id="statusCard">
-  <div class="claim-top row" style="justify-content:space-between;align-items:center">
+<section class="card claim-card farm-stats" id="statusCard">
+  <div class="claim-top row">
     <div class="claim-amount">Доступно к получению: <b id="claimAmount">$0</b></div>
-    <button class="btn btn-success" id="btnClaim" disabled>CLAIM</button>
+    <button class="btn btn-success farm-claim" id="btnClaim" disabled>CLAIM</button>
   </div>
   <div class="metrics row">
     <div class="col"><div class="label">Скорость</div><div class="val" id="rate">0 $/ч</div></div>
     <div class="col"><div class="label">FP</div><div class="val" id="fp">0</div></div>
   </div>
   <div class="cap">
-    <div class="cap-row row" style="justify-content:space-between"><span>Лимит сегодня</span><span id="capText">$0 / $0</span></div>
+    <div class="cap-row row"><span>Лимит сегодня</span><span id="capText">$0 / $0</span></div>
     <div class="progress success"><div class="bar" id="capBar" style="width:0%"></div></div>
     <div class="muted">Оффлайн-лимит: до 12 ч</div>
   </div>
@@ -37,7 +36,7 @@
 
 <section class="card upgrades-card" id="upgradesCard">
   <h3>Апгрейды</h3>
-  <div class="grid-2" id="upgrades"></div>
+  <div class="upgrades-grid" id="upgrades"></div>
 </section>
 
 <script src="js/farm.js"></script>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -5,10 +5,11 @@
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Real Price ETH Game</title>
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
-<style>
+  <style>
   :root{
     --bg:#000; --text:#fff; --muted:#b9b9b9; --ring:#ff8c00;
     --green:#1fa36a; --red:#c6423a; --card:#0b0b0b; --border:#1e1e1e; --chip:#121212;
+    --gap-xxs:6px; --gap-xs:8px; --gap-s:12px; --gap-m:16px;
   }
   *{box-sizing:border-box}
   html,body{height:100%;margin:0}

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -56,7 +56,29 @@ async function claim(type){
     }
   }
 
-  function renderUpgrades(type,list){const box=document.getElementById('upgrades');box.innerHTML='';if(!list||!list.length){box.innerHTML='<div class="muted">Нет апгрейдов</div>';return;}list.forEach(u=>{const card=document.createElement('div');card.className='upgrade card card-compact';card.innerHTML=`<div class="title">${u.title}</div><div class="row"><span class="chip">+${u.fp} FP</span><span class="price">${formatMoney(u.cost)}</span></div><div class="muted">Треб. уровень: ${u.reqLevel}</div>`;const btn=document.createElement('button');btn.className='btn btn-primary';btn.textContent='Купить';btn.disabled=!u.canBuy;btn.addEventListener('click',()=>buyUpgrade(type,u));card.appendChild(btn);box.appendChild(card);});}
+  function renderUpgrades(type,list){
+    const box=document.getElementById('upgrades');
+    box.innerHTML='';
+    if(!list||!list.length){
+      box.innerHTML='<div class="muted">Нет апгрейдов</div>';
+      return;
+    }
+    list.forEach(u=>{
+      const card=document.createElement('div');
+      card.className='card upgrade-card';
+      card.innerHTML=`<h3>${u.title}</h3>
+        <div class="upgrade-badge chip">+${u.fp} FP</div>
+        <div class="upgrade-price">${formatMoney(u.cost)}</div>
+        <div class="upgrade-req">Треб. уровень: ${u.reqLevel}</div>`;
+      const btn=document.createElement('button');
+      btn.className='btn btn-primary';
+      btn.textContent='Купить';
+      btn.disabled=!u.canBuy;
+      btn.addEventListener('click',()=>buyUpgrade(type,u));
+      card.appendChild(btn);
+      box.appendChild(card);
+    });
+  }
 
     function renderState(type,s){
     if(!s.ok)return;


### PR DESCRIPTION
## Summary
- add gap variables and layout classes for farm cards and upgrades
- introduce grid layout and spacing improvements in farm markup and scripts
- ensure safe-area padding and tab spacing

## Testing
- `npm test` *(fails: Missing script "test" in server package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af73c108348328abc824912ae788bc