### PR TITLE
Fix arena chat message payload

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -551,7 +551,7 @@ adSend.onclick = async ()=>{
   const r = await fetch('/api/shout/bid',{
     method:'POST',
     headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({ initData: tg?.initData || '', text })
+    body: JSON.stringify({ initData: tg?.initData || '', message: text })
   }).then(r=>r.json()).catch(()=>({ok:false}));
   if(!r.ok){
     alert(r.error==='INSUFFICIENT' ? 'Недостаточно средств' : 'Цена изменилась, попробуйте снова');


### PR DESCRIPTION
## Summary
- fix arena ad send payload key `message` to match server expectations

## Testing
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af7c4048dc8328b85c95ef20caef86