### PR TITLE
feat: add compact farm UI scaling

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -1,4 +1,6 @@
 :root{
+  --ui-scale:.95;
+  --gap-scale:.95;
   --bg:#000;
   --card:#0b0b0b;
   --text:#fff;
@@ -8,15 +10,16 @@
   --warn:#ff8c00;
   --danger:#c6423a;
   --outline:#1e1e1e;
-  --gap-xxs:6px;
-  --gap-xs:8px;
-  --gap-s:12px;
-  --gap-m:16px;
+  --gap-xxs:calc(6px * var(--gap-scale));
+  --gap-xs:calc(8px * var(--gap-scale));
+  --gap-s:calc(12px * var(--gap-scale));
+  --gap-m:calc(16px * var(--gap-scale));
 }
 *{box-sizing:border-box}
 html,body{margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;color:var(--text);background:var(--bg);}
-body{padding:16px;letter-spacing:0.3px}
-.btn{display:inline-flex;justify-content:center;align-items:center;height:48px;padding:0 16px;border:none;border-radius:16px;font-weight:700;font-size:16px;cursor:pointer;transition:transform .1s}
+body{padding:var(--gap-m);letter-spacing:0.3px}
+.farm-page,.farm-vop{font-size:calc(1rem * var(--ui-scale));line-height:1.28;padding-bottom:calc(env(safe-area-inset-bottom,0) + 10px);}
+.btn{display:inline-flex;justify-content:center;align-items:center;font-weight:700;font-size:calc(1rem * var(--ui-scale));padding:calc(12px * var(--ui-scale)) calc(18px * var(--ui-scale));border:none;border-radius:calc(20px * var(--ui-scale));cursor:pointer;transition:transform .1s;min-height:44px}
 .btn:active{transform:scale(.98)}
 .btn-primary{background:var(--accent);color:#000}
 .btn-secondary{background:#333;color:var(--text)}
@@ -24,26 +27,27 @@ body{padding:16px;letter-spacing:0.3px}
 .btn-success{background:var(--success);color:#000}
 .btn-danger{background:var(--danger);color:#fff}
 .btn[disabled]{opacity:.5;cursor:not-allowed}
-.back-text{background:none;border:none;color:#fff;font-size:14px;padding:0;margin-bottom:6px;cursor:pointer}
-.card{background:var(--card);border:1px solid var(--outline);border-radius:16px;padding:var(--gap-m);margin:var(--gap-m) 0;box-shadow:0 0 4px rgba(0,0,0,.2)}
+.back-text{background:none;border:none;color:#fff;font-size:calc(14px * var(--ui-scale));padding:0;margin-bottom:var(--gap-xxs);cursor:pointer}
+.card{background:var(--card);border:1px solid var(--outline);border-radius:calc(16px * var(--ui-scale));padding:calc(16px * var(--ui-scale));margin:var(--gap-m) 0;box-shadow:0 0 4px rgba(0,0,0,.2)}
 .claim-card{margin:var(--gap-m) 0;line-height:1.25;}
 .upgrades-card{margin-top:var(--gap-m);line-height:1.25;}
-.progress{height:6px;background:var(--outline);border-radius:6px;overflow:hidden}
+.progress{height:calc(6px * var(--ui-scale));background:var(--outline);border-radius:calc(6px * var(--ui-scale));overflow:hidden}
 .progress .bar{height:100%;background:var(--accent);border-radius:inherit}
 .progress.success .bar{background:var(--success)}
-.chip{display:inline-block;background:var(--outline);border-radius:999px;padding:6px 10px;font-size:12px}
+.chip{display:inline-block;background:var(--outline);border-radius:999px;padding:calc(6px * var(--gap-scale)) calc(10px * var(--gap-scale));font-size:calc(12px * var(--ui-scale))}
 .row{display:flex;gap:var(--gap-m);align-items:center}
-.grid-2{display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:12px}
+.grid-2{display:grid;grid-template-columns:repeat(auto-fill,minmax(calc(160px * var(--ui-scale)),1fr));gap:var(--gap-s)}
 .col{flex:1}
-.label{color:var(--muted);font-size:12px}
+.label{color:var(--muted);font-size:calc(12px * var(--ui-scale))}
 .val{font-weight:700}
-.muted{color:var(--muted);font-size:12px}
-.banner{padding:12px;border-radius:12px;margin-top:12px}
+.muted{color:var(--muted);font-size:calc(12px * var(--ui-scale))}
+.banner{padding:calc(12px * var(--gap-scale));border-radius:calc(12px * var(--ui-scale));margin-top:calc(12px * var(--gap-scale))}
 .banner.warn{background:#332;color:#ffb}
-.card-compact{padding:12px;margin:0}
-.upgrade .title{font-weight:700;margin-bottom:6px}
+.card-compact{padding:calc(12px * var(--gap-scale));margin:0}
+.upgrade .title{font-weight:700;margin-bottom:var(--gap-xxs)}
 .upgrade .row{justify-content:space-between}
 .price{font-weight:700}
+
 .safe-bottom{padding-bottom:calc(env(safe-area-inset-bottom,0) + 12px)}
 .sr-only{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(1px,1px,1px,1px)}
 
@@ -62,7 +66,7 @@ body{padding:16px;letter-spacing:0.3px}
 @media (max-width:360px){
   .upgrades-grid{grid-template-columns:1fr;}
 }
-.upgrade-card{padding:var(--gap-m);border-radius:16px;}
+.upgrade-card{padding:calc(16px * var(--ui-scale));border-radius:calc(16px * var(--ui-scale));}
 .upgrade-card h3{margin:0 0 var(--gap-xs);line-height:1.25;}
 .upgrade-badge{margin-bottom:var(--gap-xxs);}
 .upgrade-price{margin-bottom:var(--gap-xxs);font-weight:700;}

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="css/styles.css" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 </head>
-<body class="safe-bottom">
+<body class="farm-page">
 <h1 class="sr-only">Real Price BTC Game</h1>
 <button class="back-text" id="backText">Назад</button>
 <div class="farm-tabs tabs row">


### PR DESCRIPTION
## Summary
- reduce farm UI scale by 5% using CSS variables
- shrink buttons, cards, and gaps for farm pages

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af7d0004d88328841c78f64de74448