### PR TITLE
Move level card above chat on main page

### DIFF
--- a/server/public/index.html
+++ b/server/public/index.html
@@ -352,6 +352,17 @@
     <button class="btn buy" id="buy">↑ BUY</button>
     <button class="btn sell" id="sell">↓ SELL</button>
   </div>
+  <div class="levelcard" id="levelCard">
+    <div class="level-head">
+      <div class="level-title">Уровень <span id="lvlNum">1</span></div>
+      <div class="level-balance">Баланс: <span id="balInline">$—</span> • VOP: <span id="vopInline">—</span> 💎</div>
+    </div>
+    <div class="level-bar">
+      <div class="level-fill" id="xpFill"></div>
+    </div>
+    <div class="level-xp" id="xpText">0 / 5 000 XP</div>
+  </div>
+
   <div class="adline ad-shimmer" id="adLine">
     <div class="ad-left">
       <div class="ad-top">
@@ -364,17 +375,6 @@
       <div class="ad-price" id="adPrice">Цена: $100</div>
       <button class="chipbtn ad-write" id="adWrite">✍️ Написать</button>
     </div>
-  </div>
-
-  <div class="levelcard" id="levelCard">
-    <div class="level-head">
-      <div class="level-title">Уровень <span id="lvlNum">1</span></div>
-      <div class="level-balance">Баланс: <span id="balInline">$—</span> • VOP: <span id="vopInline">—</span> 💎</div>
-    </div>
-    <div class="level-bar">
-      <div class="level-fill" id="xpFill"></div>
-    </div>
-    <div class="level-xp" id="xpText">0 / 5 000 XP</div>
   </div>
 
   <!-- меню: БЕЗ кнопки "Проверить" -->


### PR DESCRIPTION
## Summary
- Show level card above chat block on the main page

## Testing
- `node xp.test.mjs`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af834b7bc483289bb285978e764d98