### PR TITLE
Handle locked VOP farm state and referral gating

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -41,6 +41,8 @@ body{padding:var(--gap-m);letter-spacing:0.3px}
 .label{color:var(--muted);font-size:calc(12px * var(--ui-scale))}
 .val{font-weight:700}
 .muted{color:var(--muted);font-size:calc(12px * var(--ui-scale))}
+.claim-note{text-align:right;margin-top:var(--gap-xxs);}
+.info-footer{text-align:center;margin-top:var(--gap-m);}
 .banner{padding:calc(12px * var(--gap-scale));border-radius:calc(12px * var(--ui-scale));margin-top:calc(12px * var(--gap-scale))}
 .banner.warn{background:#332;color:#ffb}
 .card-compact{padding:calc(12px * var(--gap-scale));margin:0}

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -19,6 +19,7 @@
     <div class="claim-amount">Доступно к получению: <b id="claimAmount">$0</b></div>
     <button class="btn btn-success farm-claim" id="btnClaim" disabled>CLAIM</button>
   </div>
+  <div class="muted claim-note" id="claimNote"></div>
   <div class="metrics row">
     <div class="col"><div class="label">Скорость</div><div class="val" id="rate">0 $/ч</div></div>
     <div class="col"><div class="label">FP</div><div class="val" id="fp">0</div></div>
@@ -26,18 +27,18 @@
   <div class="cap">
     <div class="cap-row row"><span>Лимит сегодня</span><span id="capText">$0 / $0</span></div>
     <div class="progress success"><div class="bar" id="capBar" style="width:0%"></div></div>
-    <div class="muted">Оффлайн-лимит: до 12 ч</div>
+    <div class="muted" id="offlineLimit">Оффлайн-лимит: до 12 ч</div>
   </div>
   <div class="banner warn" id="inactiveBanner" hidden>
     Чтобы активировать фарм, сделай ставку от $50 за 24 часа
     <button class="btn btn-secondary" id="goPlay">Играть</button>
   </div>
 </section>
-
 <section class="card upgrades-card" id="upgradesCard">
   <h3>Апгрейды</h3>
   <div class="upgrades-grid" id="upgrades"></div>
 </section>
+<div class="muted info-footer" id="lockedFooter" hidden></div>
 
 <script src="js/farm.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- expose VOP farm API with level, unlock status and referral gating info
- show locked VOP farm UI with disabled upgrades and claim hint
- add claim restriction message and footer for low level players

## Testing
- `node server/verifyInitData.test.js`
- `node xp.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68af8e3fb93883289ee1f573f8647e0d