### PR TITLE
Implement dynamic price bumps for farm boosts

### DIFF
--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -50,6 +50,12 @@ async function claim(type){
       toast(`Скорость +${up.fp} FP. Баланс: ${formatMoney(r.newBalance)}`);
       haptic('success');
       loadCurrent();
+    }else if(r.error==='BALANCE'){
+      toast('Не хватает денег');
+      haptic('error');
+    }else if(r.error==='LEVEL'){
+      toast('Недостаточный уровень');
+      haptic('error');
     }else{
       toast('Ошибка');
       haptic('error');
@@ -68,8 +74,10 @@ async function claim(type){
       card.className='card upgrade-card';
       card.innerHTML=`<h3>${u.title}</h3>
         <div class="upgrade-badge chip">+${u.fp} FP</div>
-        <div class="upgrade-price">${formatMoney(u.cost)}</div>
-        <div class="upgrade-req">Треб. уровень: ${u.reqLevel}</div>`;
+        <div class="upgrade-price">${formatMoney(u.price)}</div>
+        <div class="upgrade-req">Треб. уровень: ${u.reqLevel}</div>
+        <div class="muted">$ за 1 FP: ${formatMoney(u.pricePerFp).slice(1)}</div>
+        <div class="muted">${u.next_bump_in===0? 'Цена недавно выросла: +8%' : `Ещё ${u.next_bump_in} покупок до +8%`}</div>`;
       const btn=document.createElement('button');
       if(locked){
         card.style.opacity='0.6';

--- a/server/shopMath.js
+++ b/server/shopMath.js
@@ -1,0 +1,7 @@
+export const PRICE_BUMP_STEP = 5;   // каждые 5 покупок
+export const PRICE_BUMP_RATE = 0.08;// +8%
+
+export function calcPrice(base, purchases){
+  const bumps = Math.floor(purchases / PRICE_BUMP_STEP);
+  return Math.round(base * (1 + PRICE_BUMP_RATE * bumps));
+}

--- a/server/shopMath.test.js
+++ b/server/shopMath.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { calcPrice } from './shopMath.js';
+
+test('price bump multiples', () => {
+  const base = 100;
+  assert.equal(calcPrice(base,0),100);
+  assert.equal(calcPrice(base,5),108);
+  assert.equal(calcPrice(base,10),116);
+  assert.equal(calcPrice(base,15),124);
+});


### PR DESCRIPTION
## Summary
- add shared price bump utility with 8% increase every 5 purchases
- track per-tier booster/extractor purchases and compute dynamic pricing
- show $/FP and price bump progress in farm shop UI

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68af975229b08328871e732d7849ed5a