### PR TITLE
Hide upgrade hints in farm upgrade cards

### DIFF
--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -72,5 +72,5 @@ body{padding:var(--gap-m);letter-spacing:0.3px}
 .upgrade-card h3{margin:0 0 var(--gap-xs);line-height:1.25;}
 .upgrade-badge{margin-bottom:var(--gap-xxs);}
 .upgrade-price{margin-bottom:var(--gap-xxs);font-weight:700;}
-.upgrade-req{margin-bottom:var(--gap-s);color:#9AA3A8;}
+.upgrade-req{margin-bottom:0;color:#9AA3A8;}
 .upgrade-card .btn{margin-top:var(--gap-s);}

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -75,9 +75,7 @@ async function claim(type){
       card.innerHTML=`<h3>${u.title}</h3>
         <div class="upgrade-badge chip">+${u.fp} FP</div>
         <div class="upgrade-price">${formatMoney(u.price)}</div>
-        <div class="upgrade-req">Треб. уровень: ${u.reqLevel}</div>
-        <div class="muted">$ за 1 FP: ${formatMoney(u.pricePerFp).slice(1)}</div>
-        <div class="muted">${u.next_bump_in===0? 'Цена недавно выросла: +8%' : `Ещё ${u.next_bump_in} покупок до +8%`}</div>`;
+        <div class="upgrade-req">Треб. уровень: ${u.reqLevel}</div>`;
       const btn=document.createElement('button');
       if(locked){
         card.style.opacity='0.6';


### PR DESCRIPTION
## Summary
- drop price-per-FP and growth hints from farm upgrade cards
- tighten upgrade card spacing after hint removal

## Testing
- `node xp.test.mjs`
- `node server/shopMath.test.js`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68af9e4fa70083289e8b5457685a93fe