### PR TITLE
Add compact 24h arena leaderboard

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -137,16 +137,18 @@
   .lb-grid{
     display:grid;
     grid-template-columns:repeat(3,1fr);
-    gap:12px;
+    gap:8px;
   }
   .lb-card{
+    position:relative;
     background:#1C1C1E;
     border-radius:16px;
-    padding:14px 14px 12px;
-    min-height:72px;
+    padding:8px 12px;
+    height:56px;
     display:flex;
     flex-direction:column;
     justify-content:center;
+    overflow:hidden;
   }
   .lb-name,.lb-meta{
     white-space:nowrap;
@@ -155,18 +157,21 @@
   }
   .lb-name{
     font-weight:600;
-    font-size:16px;
-    line-height:20px;
-    margin-bottom:6px;
+    font-size:13px;
+    margin-bottom:2px;
+    margin-right:20px;
   }
   .lb-meta{
+    font-size:12px;
     opacity:.8;
-    font-size:14px;
-    line-height:18px;
   }
-  .place-1{ box-shadow:0 0 0 1px rgba(255,215,0,.18) inset; }
-  .place-2{ box-shadow:0 0 0 1px rgba(192,192,192,.14) inset; }
-  .place-3{ box-shadow:0 0 0 1px rgba(205,127,50,.14) inset; }
+  .medal{position:absolute;top:4px;right:4px;font-size:14px;line-height:1}
+  .place-1,.place-2,.place-3{filter:brightness(1.06)}
+  .lb-empty{grid-column:1/-1;text-align:center;color:var(--muted);font-size:13px;padding:8px 0}
+  @media (max-width:360px){
+    .lb-name{font-size:12px}
+    .lb-meta{font-size:11px}
+  }
 
   /* bottom sheets */
   .sheet{position:fixed;left:0;right:0;bottom:0;background:#0b0b0b;border-top:1px solid var(--border);border-radius:16px 16px 0 0;transform:translateY(100%);transition:transform .25s ease;padding:14px 14px calc(18px + env(safe-area-inset-bottom));z-index:1000}
@@ -348,7 +353,8 @@
     </div>
   </div>
 
-<script>
+<script type="module">
+import { formatUsdShort } from './js/money.mjs';
 const BOT_USERNAME = 'realpricebtc_bot';
 const CHANNEL_LINK = 'https://t.me/erc20coin';
 const tg = window.Telegram?.WebApp; tg?.expand();
@@ -608,18 +614,23 @@ async function loadLb24(){
   const r = await fetch('/api/arena/leaderboard?window=24h').then(r=>r.json()).catch(()=>null);
   if(!r?.ok) return;
   const items = r.items || [];
-  let html = '';
-  for(let i=0;i<3;i++){
-    const it = items[i];
-    const full = it ? normUser(it.username) : '—';
-    const short = it ? shortHandle(full) : '—';
-    const wins = it ? it.wins : 0;
-    const total = fmt(it ? it.total_won : 0);
-    html += `<div class="lb-card place-${i+1}">
-      <div class="lb-name user-name" title="${full}">${short}</div>
-      <div class="lb-meta">${wins} побед • ${total}</div>
-    </div>`;
+  if(items.length === 0){
+    lb24.innerHTML = '<div class="lb-empty">Пока нет победителей за 24 часа.</div>';
+    return;
   }
+  const html = items.map((it,i)=>{
+    const full = normUser(it.username);
+    const short = shortHandle(full);
+    const wins = it.wins_count;
+    const total = formatUsdShort(it.wins_sum);
+    const medal = i===0?'🥇':i===1?'🥈':i===2?'🥉':'';
+    const placeCls = i<3? ` place-${i+1}` : '';
+    return `<div class="lb-card${placeCls}">`+
+      (medal?`<div class="medal">${medal}</div>`:'')+
+      `<div class="lb-name user-name" title="${full}">${short}</div>`+
+      `<div class="lb-meta">${wins}×🏆 • ${total}</div>`+
+    `</div>`;
+  }).join('');
   lb24.innerHTML = html;
 }
 
@@ -647,7 +658,7 @@ buyStars.onclick = async ()=>{
 setInterval(pollArena,1000);
 setInterval(pollAd,4000);
 setInterval(loadProfile,5000);
-setInterval(loadLb24,25000);
+setInterval(loadLb24,30000);
 loadProfile();
 pollArena();
 pollAd();

--- a/server/public/js/money.mjs
+++ b/server/public/js/money.mjs
@@ -1,0 +1,18 @@
+export function formatUsdShort(n){
+  const num = Number(n) || 0;
+  const abs = Math.abs(num);
+  if(abs < 1000) return '$'+abs.toLocaleString();
+  const units = [
+    { v: 1e9, s: 'B' },
+    { v: 1e6, s: 'M' },
+    { v: 1e3, s: 'K' }
+  ];
+  for(const u of units){
+    if(abs >= u.v){
+      const val = abs / u.v;
+      const dec = val >= 100 ? 0 : val >= 10 ? 1 : 2;
+      return '$'+val.toFixed(dec).replace(/\.0+$|0+$/,'')+u.s;
+    }
+  }
+  return '$'+abs.toLocaleString();
+}

--- a/server/public/js/money.test.mjs
+++ b/server/public/js/money.test.mjs
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatUsdShort } from './money.mjs';
+
+test('formatUsdShort examples', () => {
+  assert.equal(formatUsdShort(987), '$987');
+  assert.equal(formatUsdShort(12345), '$12.3K');
+  assert.equal(formatUsdShort(4360914), '$4.36M');
+  assert.equal(formatUsdShort(1200000000), '$1.2B');
+});


### PR DESCRIPTION
## Summary
- aggregate arena winners for last 24h sorted by wins then payout
- show leaderboard as 3-column mini cards with medals and short money format
- add utility to abbreviate USD amounts with tests

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68affb5f568483289d4ab5f35768dab8