### PR TITLE
Limit nicknames in arena leaderboard

### DIFF
--- a/server/public/arena.html
+++ b/server/public/arena.html
@@ -425,7 +425,7 @@ function shortHandle(handle){
   const hasAt = handle?.startsWith('@');
   const raw = hasAt ? handle.slice(1) : handle || '';
   const chars = Array.from(raw);
-  const cut = chars.length > 6 ? chars.slice(0,6).join('') + '…' : raw;
+  const cut = chars.length > 9 ? chars.slice(0,9).join('') + '..' : raw;
   return (hasAt ? '@' : '') + cut;
 }
 function setBalanceVal(amount, vop){


### PR DESCRIPTION
## Summary
- truncate arena leaderboard handles to 9 characters followed by two dots

## Testing
- `node xp.test.mjs`
- `node server/shopMath.test.js`
- `node server/verifyInitData.test.js`
- `node server/public/js/money.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b016de40a883289e68e0587db42737