### PR TITLE
feat: auto refresh arena polling and disable zoom

### DIFF
--- a/server/public/classic.html
+++ b/server/public/classic.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 <title>Classic — BTC Game</title>
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <style>
@@ -12,7 +12,8 @@
     --gap-xxs:6px; --gap-xs:8px; --gap-s:12px; --gap-m:16px;
   }
   *{box-sizing:border-box}
-  html,body{height:100%;margin:0}
+  html,body{height:100%;margin:0;touch-action:pan-x pan-y}
+  button,a,.tap{touch-action:manipulation}
   body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Arial}
   .wrap{max-width:520px;margin:0 auto;padding:16px 14px 28px}
   .price{font-size:24px;font-weight:800;text-align:center;margin-top:2px}
@@ -1396,6 +1397,7 @@ const FW = (() => {
 return { start };
 })();
 </script>
+<script src="js/nozoom.js"></script>
 <script type="module" src="js/quests.js"></script>
 </body>
 </html>

--- a/server/public/css/styles.css
+++ b/server/public/css/styles.css
@@ -16,7 +16,8 @@
   --gap-m:calc(16px * var(--gap-scale));
 }
 *{box-sizing:border-box}
-html,body{margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;color:var(--text);background:var(--bg);}
+html,body{margin:0;padding:0;font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Arial;color:var(--text);background:var(--bg);touch-action:pan-x pan-y;}
+button,a,.tap{touch-action:manipulation}
 body{padding:var(--gap-m);letter-spacing:0.3px}
 .farm-page,.farm-vop{font-size:calc(1rem * var(--ui-scale));line-height:1.28;padding-bottom:calc(env(safe-area-inset-bottom,0) + 10px);}
 .btn{display:inline-flex;justify-content:center;align-items:center;font-weight:700;font-size:calc(1rem * var(--ui-scale));padding:calc(12px * var(--ui-scale)) calc(18px * var(--ui-scale));border:none;border-radius:calc(20px * var(--ui-scale));cursor:pointer;transition:transform .1s;min-height:44px}

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 <title>Real Price BTC Game</title>
 <link rel="stylesheet" href="css/styles.css" />
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
@@ -42,6 +42,7 @@
 <div class="muted info-footer" id="lockedFooter" hidden></div>
 
 <script src="js/farm.js"></script>
+<script src="js/nozoom.js"></script>
 <script>
   initFarmPage();
   const backText = document.getElementById('backText');

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
 <meta charset="utf-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
 <title>Arena — BTC Game</title>
 <script src="https://telegram.org/js/telegram-web-app.js"></script>
 <style>
@@ -11,7 +11,8 @@
     --green:#1fa36a; --red:#c6423a; --card:#0b0b0b; --border:#1e1e1e; --chip:#121212;
   }
   *{box-sizing:border-box}
-  html,body{height:100%;margin:0}
+  html,body{height:100%;margin:0;touch-action:pan-x pan-y}
+  button,a,.tap{touch-action:manipulation}
   body{background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Arial}
   .wrap{max-width:520px;margin:24px auto 0;padding:16px 14px 28px}
   .back-text{background:none;border:none;color:#fff;font-size:14px;padding:0;margin-bottom:6px;cursor:pointer}
@@ -193,6 +194,7 @@
   .sheet .share-wrap{flex:1;display:flex;flex-direction:column}
   .sheet .share-wrap .share-hint{color:var(--muted);font-size:12px;margin-top:4px;text-align:center}
   .sheet p{color:#ddd;font-size:13px;line-height:1.35;margin:6px 0}
+  .sheet .wait{color:var(--muted);font-size:12px;margin:0 0 8px;text-align:center}
 
   #sheetChatFeed .feed{max-height:60vh;overflow:auto;display:flex;flex-direction:column;gap:8px}
   .msg{background:#121212;border:1px solid var(--border);border-radius:12px;padding:10px}
@@ -335,12 +337,12 @@
 <!-- SHEET: Обновить лимит -->
 <div class="sheet" id="sheetRefresh">
   <h3>Обновить ставки в этом раунде</h3>
+  <p class="wait">Ждём друга… проверяем каждые 3 с</p>
   <p>Пригласи друга по своей ссылке. Как только он зайдёт — лимит снова 20 ставок в текущем раунде.</p>
   <div class="btnrow">
     <div class="share-wrap">
       <button class="btnsm" id="refreshShare">Поделиться</button>
     </div>
-    <button class="btnsm" id="refreshApply">Проверить</button>
     <button class="btnsm cancel" data-close>Закрыть</button>
   </div>
 </div>
@@ -434,7 +436,9 @@ const sheetShop = document.getElementById('sheetShop');
 const shopTabs = document.getElementById('shopTabs');
 const sheetRefresh = document.getElementById('sheetRefresh');
 const refreshShare = document.getElementById('refreshShare');
-const refreshApply = document.getElementById('refreshApply');
+
+let refreshTimer = null;
+let refreshDeadline = 0;
 
 const openChannel = document.getElementById('openChannel');
 const starsPacks = document.getElementById('starsPacks');
@@ -503,9 +507,12 @@ function renderArena(st){
   if(st.userLimits){
     remainingBets = st.userLimits.remainingBets;
   }
+  if(refreshTimer && (st.phase !== 'betting' || remainingBets > 0)){
+    closeAllSheets();
+  }
   betsLeftEl.textContent = `осталось ${remainingBets} ставок`;
   bidBtn.textContent = remainingBets>0 ? ('Ставка $' + Number(st.nextBid||0).toLocaleString()) : 'Обновить';
-  bidBtn.disabled = st.phase === 'pause';
+  bidBtn.disabled = st.phase === 'pause' || !!refreshTimer;
   leaderEl.textContent = 'Лидер: ' + (st.leader?.name ? normUser(st.leader.name) : '—');
 
   if(arenaPhase!==st.phase){
@@ -567,6 +574,7 @@ function closeAllSheets(){
   document.querySelectorAll('.sheet.open').forEach(s=>s.classList.remove('open'));
   sheetBg.classList.remove('show');
   if (adPriceTimer) { clearInterval(adPriceTimer); adPriceTimer = null; }
+  if (refreshTimer) { clearInterval(refreshTimer); refreshTimer = null; refreshDeadline = 0; bidBtn.disabled = arenaPhase === 'pause'; }
 }
 sheetBg.addEventListener('click', closeAllSheets);
 document.querySelectorAll('[data-close]').forEach(b=>b.addEventListener('click', closeAllSheets));
@@ -613,13 +621,35 @@ starsBtn.onclick = ()=> openSheet(sheetStars);
 // Переход в магазин аналогично главной странице
 shopBtn.onclick = ()=>{ location.href = `/farm.html?uid=${encodeURIComponent(uid)}`; };
 
-async function openRefreshSheet(){
+async function pollRefresh(){
   const r = await fetch('/api/arena/refresh-check',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify({ uid })}).then(r=>r.json()).catch(()=>null);
-  if(r?.ok){
-    remainingBets = r.remaining;
-    refreshApply.disabled = !r.eligible;
+  if(!refreshTimer) return;
+  if(r?.error === 'ROUND_ENDED' || r?.error === 'NEW_ROUND'){
+    closeAllSheets();
+    pollArena();
+    return;
   }
+  if(r?.ok && r.eligible){
+    const a = await fetch('/api/arena/refresh-apply',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify({ uid })}).then(r=>r.json()).catch(()=>null);
+    if(a?.ok){
+      remainingBets = a.remaining;
+      closeAllSheets();
+      pollArena();
+    }
+    return;
+  }
+  if(Date.now() > refreshDeadline){
+    toast('Друг ещё не зашёл. Попробуй позже.');
+    closeAllSheets();
+  }
+}
+async function openRefreshSheet(){
+  if(refreshTimer) return;
+  bidBtn.disabled = true;
+  refreshDeadline = Date.now() + 120000;
   openSheet(sheetRefresh);
+  refreshTimer = setInterval(pollRefresh,3000);
+  await pollRefresh();
 }
 refreshShare.onclick = ()=>{
   const link = `https://t.me/${BOT_USERNAME}?start=${uid}`;
@@ -634,16 +664,6 @@ refreshShare.onclick = ()=>{
     } else {
       alert(text);
     }
-  }
-};
-refreshApply.onclick = async ()=>{
-  const r = await fetch('/api/arena/refresh-apply',{method:'POST',headers:{'Content-Type':'application/json'},body: JSON.stringify({ uid })}).then(r=>r.json()).catch(()=>null);
-  if(r?.ok){
-    remainingBets = r.remaining;
-    closeAllSheets();
-    pollArena();
-  } else {
-    alert('Пригласи и дождись, когда друг зайдёт в игру');
   }
 };
 adWriteBtn.onclick = async ()=>{
@@ -745,6 +765,7 @@ pollArena();
 pollAd();
 loadLb24();
 </script>
+<script src="js/nozoom.js"></script>
 <script type="module" src="js/quests.js"></script>
 
 </body>

--- a/server/public/js/nozoom.js
+++ b/server/public/js/nozoom.js
@@ -1,0 +1,20 @@
+// Блок двойного тапа (double-tap zoom)
+let lastTouchEnd = 0;
+document.addEventListener('touchend', function (e) {
+  const now = Date.now();
+  if (now - lastTouchEnd <= 300) e.preventDefault();
+  lastTouchEnd = now;
+}, { passive: false });
+
+// Блок pinch-zoom
+document.addEventListener('gesturestart', e => e.preventDefault());
+document.addEventListener('gesturechange', e => e.preventDefault());
+document.addEventListener('gestureend', e => e.preventDefault());
+
+// На всякий случай — запрет масштабирования колесом/клавишами (десктоп WebApp)
+document.addEventListener('wheel', e => {
+  if (e.ctrlKey) e.preventDefault();
+}, { passive: false });
+document.addEventListener('keydown', e => {
+  if ((e.ctrlKey || e.metaKey) && (e.key === '+' || e.key === '-' || e.key === '=')) e.preventDefault();
+});


### PR DESCRIPTION
## Summary
- auto-check referral refresh: polling sheet every 3s, apply on success and re-enable bids
- block pinch/double-tap zoom across pages with viewport, touch-action and JS guards

## Testing
- `node xp.test.mjs`
- `node server/shopMath.test.js`
- `node server/verifyInitData.test.js`
- `node server/public/js/money.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b5df14afb08328a2ef299add2a3f9a