### PR TITLE
Add dynamic USD farming limit based on active friends

### DIFF
--- a/server/farmUtils.js
+++ b/server/farmUtils.js
@@ -1,0 +1,12 @@
+export const FARM_TZ = process.env.FARM_TZ || 'UTC';
+export const BASE_USD_LIMIT = Number(process.env.BASE_USD_LIMIT || 5000);
+export const BONUS_PER_ACTIVE_FRIEND_USD = Number(process.env.BONUS_PER_ACTIVE_FRIEND_USD || 500);
+export const FEATURE_DYNAMIC_LIMIT_USD = process.env.FEATURE_DYNAMIC_LIMIT_USD !== 'false';
+
+export function dayString(date = new Date(), tz = FARM_TZ) {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' }).format(date);
+}
+
+export function dailyUsdLimit(activeFriends) {
+  return BASE_USD_LIMIT + BONUS_PER_ACTIVE_FRIEND_USD * activeFriends;
+}

--- a/server/farmUtils.test.js
+++ b/server/farmUtils.test.js
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { dailyUsdLimit, BASE_USD_LIMIT, BONUS_PER_ACTIVE_FRIEND_USD } from './farmUtils.js';
+
+test('dailyUsdLimit with various friend counts', () => {
+  assert.equal(dailyUsdLimit(0), BASE_USD_LIMIT);
+  assert.equal(dailyUsdLimit(1), BASE_USD_LIMIT + BONUS_PER_ACTIVE_FRIEND_USD);
+  assert.equal(dailyUsdLimit(5), BASE_USD_LIMIT + 5 * BONUS_PER_ACTIVE_FRIEND_USD);
+  assert.equal(dailyUsdLimit(50), BASE_USD_LIMIT + 50 * BONUS_PER_ACTIVE_FRIEND_USD);
+});

--- a/server/migrations/008_daily_friend_activity.sql
+++ b/server/migrations/008_daily_friend_activity.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS daily_friend_activity (
+  id SERIAL PRIMARY KEY,
+  friend_user_id INT NOT NULL REFERENCES users(id),
+  referrer_user_id INT NOT NULL REFERENCES users(id),
+  activity_date DATE NOT NULL,
+  first_event_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (friend_user_id, activity_date)
+);

--- a/server/public/farm.html
+++ b/server/public/farm.html
@@ -26,8 +26,9 @@
     <div class="col"><div class="label">FP</div><div class="val" id="fp">0</div></div>
   </div>
   <div class="cap">
-    <div class="cap-row row"><span>Лимит сегодня</span><span id="capText">$0 / $0</span></div>
+    <div class="cap-row row"><span>Лимит сегодня</span><span id="capText">$0 / $0</span><button class="chipbtn" id="incLimitBtn">+ увеличить</button></div>
     <div class="progress success"><div class="bar" id="capBar" style="width:0%"></div></div>
+    <div class="muted" id="friendsBonus"></div>
     <div class="muted" id="offlineLimit">Оффлайн-лимит: до 12 ч</div>
   </div>
   <div class="banner warn" id="inactiveBanner" hidden>

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -107,21 +107,33 @@ async function claim(type){
     const claimNote=document.getElementById('claimNote');
     const footer=document.getElementById('lockedFooter');
     const offlineLimit=document.getElementById('offlineLimit');
+    const friendsBonus=document.getElementById('friendsBonus');
+    const incLimitBtn=document.getElementById('incLimitBtn');
 
     if(type==='usd'){
-      claimAmount.textContent=formatMoney(s.claimable);
-      btnClaim.disabled=!(s.active&&s.claimable>0);
+      const claimable = s.available_to_claim ?? s.claimable;
+      const ratePerHour = s.speed_per_hour ?? s.ratePerHour;
+      const used = s.limit_today_used ?? s.claimedToday;
+      const total = s.limit_today_total ?? s.dailyCap;
+      claimAmount.textContent=formatMoney(claimable);
+      btnClaim.disabled=!(s.active&&claimable>0);
       btnClaim.classList.add('btn-success');
       btnClaim.classList.remove('btn-secondary');
       claimNote.textContent='';
-      rate.textContent=formatMoney(s.ratePerHour).slice(1)+' $/ч';
-      capText.textContent=`${formatMoney(s.claimedToday)} / ${formatMoney(s.dailyCap)}`;
+      rate.textContent=formatMoney(ratePerHour).slice(1)+' $/ч';
+      capText.textContent=`${formatMoney(used)} / ${formatMoney(total)}`;
       inactive.hidden=s.active;
       footer.hidden=true;
       offlineLimit.textContent='Оффлайн-лимит: до 12 ч';
       fp.textContent=s.fp;
-      const pct = s.dailyCap?Math.min(100,s.claimedToday/s.dailyCap*100):0;
+      const pct = total?Math.min(100,used/total*100):0;
       capBar.style.width=pct+'%';
+      const n = s.active_friends_today||0;
+      const bonus = (s.bonus_per_friend||0)*n;
+      let bonusText = `Активные друзья сегодня: ${n}  •  +$${s.bonus_per_friend||0} за каждого`;
+      if(n>0) bonusText += `  <span style="color:var(--success)">+$${bonus} к лимиту</span>`;
+      friendsBonus.innerHTML = bonusText;
+      incLimitBtn.onclick=()=>{location.href=`/shop.html?uid=${encodeURIComponent(uid)}`;};
       renderUpgrades(type,s.upgrades);
       return;
     }


### PR DESCRIPTION
## Summary
- track daily friend activity and compute USD farming limit bonus
- expose active friend stats and dynamic limit in farm and referral APIs
- display friend bonus and limit growth on farm page

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_e_68b5f8a2734883289edc9aa7deab6da1