### PR TITLE
feat: expose friend bonus caps for USD farm

### DIFF
--- a/server/migrations/010_daily_caps.sql
+++ b/server/migrations/010_daily_caps.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS daily_caps (
+  id BIGSERIAL PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  day_utc DATE NOT NULL,
+  cap_usd_base INT NOT NULL,
+  cap_usd_bonus INT NOT NULL DEFAULT 0,
+  used_usd INT NOT NULL DEFAULT 0,
+  UNIQUE (user_id, day_utc)
+);
+
+CREATE INDEX IF NOT EXISTS idx_daily_caps_user_day
+  ON daily_caps (user_id, day_utc);

--- a/server/public/classic.html
+++ b/server/public/classic.html
@@ -1083,7 +1083,7 @@ async function refreshBalance(){
 }
 
 async function refreshFarmUsdPill(){
-  const r = await fetch(`/api/farm/usd/state?uid=${uid}`).then(r=>r.json()).catch(()=>({ok:false}));
+  const r = await fetch(`/api/farm/usd?uid=${uid}`,{cache:'no-store',headers:{'Cache-Control':'no-store'}}).then(r=>r.json()).catch(()=>({ok:false}));
   if (r.ok && Number(r.claimable)>0){
     farmPill.textContent = '+ $' + Number(r.claimable);
     farmPill.style.display='inline';


### PR DESCRIPTION
## Summary
- return separate base and friend bonus caps in `/api/farm/usd`
- track daily cap usage in new `daily_caps` table
- refresh farm card after referral checks and fetch farm state without caching

## Testing
- `node xp.test.mjs`
- `node server/farmUtils.test.js`
- `node server/shopMath.test.js`
- `node server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b606c140288328b0310049f0157edf