### PR TITLE
feat(payments): 10x USD on stars, subscribe bonus to $30k; fix arena share button visibility

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1,5 +1,5 @@
 // bot/bot.js — финал
-// Регистрация: $1000, Реферал: +$500, Подписка: +$5000 (разово), Ежедневный вход: +$1000/день
+// Регистрация: $1000, Реферал: +$500, Подписка: +$30 000 (разово), Ежедневный вход: +$1000/день
 
 import 'dotenv/config';
 import express from 'express';
@@ -19,7 +19,7 @@ const CHANNEL = '@erc20coin';
 const AMOUNTS = {
   REGISTER: 1000,
   REFERRAL: 500,    // рефереру
-  SUBSCRIBE: 5000,  // разовый бонус за подписку
+  SUBSCRIBE: 30_000,  // разовый бонус за подписку
   DAILY: 1000,      // ежедневный вход
 };
 
@@ -30,12 +30,14 @@ const pool = new pg.Pool({
 
 // Пакеты Stars (мэппинг «звёздный пакет → долларовый кредит»)
 const STARS_PACKS = {
-  '100':   { credit: 3_000 },
-  '500':   { credit: 16_000 },
-  '1000':  { credit: 35_000 },
-  '10000': { credit: 400_000 },
-  '30000': { credit: 1_500_000 },
+  '100':   { credit: 30_000 },
+  '500':   { credit: 160_000 },
+  '1000':  { credit: 350_000 },
+  '10000': { credit: 4_000_000 },
+  '30000': { credit: 15_000_000 },
 };
+
+const formatUsd = (n) => n.toLocaleString('en-US').replace(/,/g, ' ');
 
 const ADMIN_USERNAME = 'ownagez';
 const ADMIN_ID = process.env.ADMIN_ID ? Number(process.env.ADMIN_ID) : null;
@@ -209,7 +211,7 @@ async function checkAndGrantChannelBonus(ctx) {
       'UPDATE users SET balance=balance+$1, channel_bonus_claimed=TRUE WHERE telegram_id=$2',
       [AMOUNTS.SUBSCRIBE, uid]
     );
-    await ctx.reply(`✅ Подписка подтверждена! Бонус $${AMOUNTS.SUBSCRIBE} начислён.`);
+    await ctx.reply(`✅ Подписка подтверждена! Бонус $${formatUsd(AMOUNTS.SUBSCRIBE)} начислён.`);
   } else {
     await ctx.reply('Бонус за подписку уже начислялся ранее ✅');
   }
@@ -300,10 +302,10 @@ bot.start(async (ctx) => {
 
   const url = WEBAPP_URL + `?uid=${uid}`;
   await ctx.reply(
-    `Добро пожаловать! Тебе начислено $${AMOUNTS.REGISTER} на старт.\n` +
-      (dailyGiven ? `Ежедневный бонус +$${AMOUNTS.DAILY} уже начислён сегодня.\n` : '') +
-      `За подписку на канал ${CHANNEL} — +$${AMOUNTS.SUBSCRIBE} (разово).\n` +
-      `За каждого друга — +$${AMOUNTS.REFERRAL}.`,
+    `Добро пожаловать! Тебе начислено $${formatUsd(AMOUNTS.REGISTER)} на старт.\n` +
+      (dailyGiven ? `Ежедневный бонус +$${formatUsd(AMOUNTS.DAILY)} уже начислён сегодня.\n` : '') +
+      `За подписку на канал ${CHANNEL} — +$${formatUsd(AMOUNTS.SUBSCRIBE)} (разово).\n` +
+      `За каждого друга — +$${formatUsd(AMOUNTS.REFERRAL)}.`,
     { ...mainMenu(url) }
   );
 });

--- a/server/public/classic.html
+++ b/server/public/classic.html
@@ -429,7 +429,7 @@
 <!-- SHEET: пополнение (подписка/проверка/ежедневка/реф) -->
 <div class="sheet" id="sheetTopup">
   <h3>Пополнение баланса</h3>
-  <p>• +$5000 — за подписку на канал @erc20coin (один раз)</p>
+  <p>• +$30 000 — за подписку на канал @erc20coin (один раз)</p>
   <p>• +$1000 — за ежедневный вход</p>
   <p>• +$500 — за каждого друга по реф-ссылке</p>
   <div class="btnrow">
@@ -446,11 +446,11 @@
   <h3>Купить звёзды ⭐</h3>
   <p>Выбери пакет, оплати в Telegram Stars — баланс обновится автоматически.</p>
   <div class="rowchips" id="starsPacks">
-    <button class="chipopt" data-pack="100">100⭐ → $3 000</button>
-    <button class="chipopt" data-pack="500">500⭐ → $16 000</button>
-    <button class="chipopt" data-pack="1000">1000⭐ → $35 000</button>
-    <button class="chipopt" data-pack="10000">10000⭐ → $400 000</button>
-    <button class="chipopt" data-pack="30000">30000⭐ → $1 500 000</button>
+    <button class="chipopt" data-pack="100">100⭐ → $30 000</button>
+    <button class="chipopt" data-pack="500">500⭐ → $160 000</button>
+    <button class="chipopt" data-pack="1000">1000⭐ → $350 000</button>
+    <button class="chipopt" data-pack="10000">10000⭐ → $4 000 000</button>
+    <button class="chipopt" data-pack="30000">30000⭐ → $15 000 000</button>
   </div>
   <div class="btnrow">
     <button class="btnsm cancel" data-close>Отмена</button>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -190,6 +190,8 @@
   .sheet .btnrow .btnsm{flex:1;background:var(--green);border:none;border-radius:12px;color:#fff;padding:10px 0;font-weight:700}
   .sheet .btnrow .btnsm.cancel{background:#333}
   .btnsm[disabled]{ background:#333 !important; opacity:0.8; cursor:not-allowed; }
+  .sheet .btnrow .btn{flex:1;width:auto;border-radius:14px;padding:0 18px;font-weight:600;min-height:44px;font-size:16px}
+  .btn-primary{background:var(--green);color:#000;border:none}
   .sheet .share-wrap{flex:1;display:flex;flex-direction:column}
   .sheet .share-wrap .share-hint{color:var(--muted);font-size:12px;margin-top:4px;text-align:center}
   .sheet p{color:#ddd;font-size:13px;line-height:1.35;margin:6px 0}
@@ -280,7 +282,7 @@
 <!-- SHEET: Пополнение -->
 <div class="sheet" id="sheetTopup">
   <h3>Пополнение баланса</h3>
-  <p>• +$5000 — за подписку на канал @erc20coin (один раз)</p>
+  <p>• +$30 000 — за подписку на канал @erc20coin (один раз)</p>
   <p>• +$1000 — за ежедневный вход</p>
   <p>• +$500 — за каждого друга по реф-ссылке</p>
   <div class="btnrow">
@@ -297,11 +299,11 @@
   <h3>Купить звёзды ⭐</h3>
   <p>Выбери пакет, оплати в Telegram Stars — баланс обновится автоматически.</p>
   <div class="rowchips" id="starsPacks">
-    <button class="chipopt" data-pack="100">100⭐ → $3 000</button>
-    <button class="chipopt" data-pack="500">500⭐ → $16 000</button>
-    <button class="chipopt" data-pack="1000">1000⭐ → $35 000</button>
-    <button class="chipopt" data-pack="10000">10000⭐ → $400 000</button>
-    <button class="chipopt" data-pack="30000">30000⭐ → $1 500 000</button>
+    <button class="chipopt" data-pack="100">100⭐ → $30 000</button>
+    <button class="chipopt" data-pack="500">500⭐ → $160 000</button>
+    <button class="chipopt" data-pack="1000">1000⭐ → $350 000</button>
+    <button class="chipopt" data-pack="10000">10000⭐ → $4 000 000</button>
+    <button class="chipopt" data-pack="30000">30000⭐ → $15 000 000</button>
   </div>
   <div class="btnrow">
     <button class="btnsm cancel" data-close>Отмена</button>
@@ -339,7 +341,7 @@
   <p>Пригласи друга по своей ссылке. Как только он зайдёт — лимит снова 20 ставок в текущем раунде.</p>
   <div class="btnrow">
     <div class="share-wrap">
-      <button class="btnsm" id="refreshShare">Поделиться</button>
+      <button class="btn btn-primary" id="refreshShare">Поделиться</button>
     </div>
     <button class="btnsm cancel" data-close>Закрыть</button>
   </div>

--- a/server/server.js
+++ b/server/server.js
@@ -80,7 +80,7 @@ const ONLINE_WINDOW_SEC = 60;  // окно (секунд) для подсчёт�
 
 // бонусы и канал для проверки подписки
 const CHANNEL = process.env.CHANNEL || '@erc20coin';
-const SUBSCRIBE_BONUS = 5000; // разовый за подписку
+const SUBSCRIBE_BONUS_USD = 30_000; // разовый за подписку
 const DAILY_BONUS = 1000;     // ежедневный бонус
 
 // ==== FARM $ ====
@@ -651,11 +651,11 @@ await ensureBots();
 
 // ✅ Пакеты Stars: amount = число звёзд
 const STARS_PACKS = {
-  '100':   { stars: 100,    credit: 3_000 },
-  '500':   { stars: 500,    credit: 16_000 },
-  '1000':  { stars: 1000,   credit: 35_000 },
-  '10000': { stars: 10000,  credit: 400_000 },
-  '30000': { stars: 30000,  credit: 1_500_000 },
+  '100':   { stars: 100,    credit: 30_000 },
+  '500':   { stars: 500,    credit: 160_000 },
+  '1000':  { stars: 1000,   credit: 350_000 },
+  '10000': { stars: 10000,  credit: 4_000_000 },
+  '30000': { stars: 30000,  credit: 15_000_000 },
 };
 
 const INSURANCE_PACK = { count: 100, stars: 1000 };
@@ -2047,9 +2047,9 @@ app.post('/api/bonus/check', requireTgAuth, async (req, res) => {
       if (!claimed) {
         await pool.query(
           'UPDATE users SET balance=balance+$1, channel_bonus_claimed=TRUE WHERE telegram_id=$2',
-          [SUBSCRIBE_BONUS, uid]
+          [SUBSCRIBE_BONUS_USD, uid]
         );
-        added += SUBSCRIBE_BONUS;
+        added += SUBSCRIBE_BONUS_USD;
       }
     }
 


### PR DESCRIPTION
## Summary
- multiply all Stars→USD conversion rates by 10 across frontend and backend
- raise one-time channel subscription bonus to $30,000
- restyle arena share button for clearer contrast on dark themes

## Testing
- `npm test` *(fails: Missing script "test")*
- `node farmUtils.test.js`
- `node shopMath.test.js`
- `node verifyInitData.test.js`
- `node xp.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b609d85b8c83289c9203275c708ef9