### PR TITLE
feat: dynamic usd limit from active friends

### DIFF
--- a/server/migrations/011_referral_activity.sql
+++ b/server/migrations/011_referral_activity.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS referral_activity (
+  referrer_id BIGINT NOT NULL,
+  friend_id   BIGINT NOT NULL,
+  last_active_at TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (referrer_id, friend_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_referral_activity_referrer
+  ON referral_activity (referrer_id);
+
+CREATE INDEX IF NOT EXISTS idx_referral_activity_friend
+  ON referral_activity (friend_id);

--- a/server/public/js/farm.js
+++ b/server/public/js/farm.js
@@ -154,8 +154,8 @@ async function onIncreaseLimitClick(){
     if(type==='usd'){
       const claimable = s.available_to_claim ?? s.claimable;
       const ratePerHour = s.speed_usd_per_hour ?? s.speed_per_hour ?? s.ratePerHour;
-      const used = s.used_usd_today ?? s.limit_today_used ?? s.claimedToday;
-      const total = s.cap_usd_effective ?? s.limit_today_total ?? s.dailyCap;
+      const used = s.limitToday?.used ?? s.used_usd_today ?? s.limit_today_used ?? s.claimedToday;
+      const total = s.limitToday?.max ?? s.cap_usd_effective ?? s.limit_today_total ?? s.dailyCap;
       claimAmount.textContent=formatMoney(claimable);
       btnClaim.disabled=!(s.active&&claimable>0);
       btnClaim.classList.add('btn-success');
@@ -169,12 +169,10 @@ async function onIncreaseLimitClick(){
       fp.textContent=s.fp;
       const pct = total?Math.min(100,used/total*100):0;
       capBar.style.width=pct+'%';
-      const n = s.active_friends_today||0;
+      const n = s.limitToday?.friends ?? s.active_friends_today || 0;
       const bpf = s.friend_bonus_per_friend_usd || s.bonus_per_friend || 0;
       const bonus = bpf*n;
-      let bonusText = `Активные друзья сегодня: ${n}  •  +$${bpf} за каждого`;
-      if(n>0) bonusText += `  <span style="color:var(--success)">+$${bonus} к лимиту</span>`;
-      friendsBonus.innerHTML = bonusText;
+      friendsBonus.innerHTML = `Активные друзья сегодня: ${n}  •  +$${bpf} за каждого  •  +$${bonus} к лимиту`;
       incLimitBtn.onclick=(e)=>{e.preventDefault();openSheet(sheetShare);};
       renderUpgrades(type,s.upgrades);
       return;


### PR DESCRIPTION
## Summary
- track referral activity and log first daily bet
- compute USD farming cap as $5000 base plus $500 per active friend
- show dynamic daily limit and friend bonus in farm UI

## Testing
- `node server/farmUtils.test.js`
- `node xp.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68b60ce94df08328a5bca9c9f73e7a5f