### PR TITLE
feat: move daily logic to UTC

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -6,6 +6,7 @@ import express from 'express';
 import { Telegraf, Markup } from 'telegraf';
 import pg from 'pg';
 import { grantXpOnce, XP } from '../xp.mjs';
+import { startOfUtcDay } from '../server/lib/time.js';
 
 const { BOT_TOKEN, WEBAPP_URL, DATABASE_URL, PORT = 8081 } = process.env;
 if (!BOT_TOKEN) throw new Error('BOT_TOKEN missing');
@@ -157,9 +158,8 @@ async function grantReferral(referrerTgId, referredTgId) {
   }
 }
 
-function todayUTC() {
-  const d = new Date();
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+function todayUTC(ts = Date.now()) {
+  return new Date(startOfUtcDay(ts));
 }
 
 async function grantDailyIfNeeded(telegramId) {

--- a/server/lib/time.js
+++ b/server/lib/time.js
@@ -1,0 +1,13 @@
+const MS_PER_DAY = 86_400_000;
+
+export function utcDayKey(ts = Date.now()) {
+  return Math.floor(ts / MS_PER_DAY);
+}
+
+export function startOfUtcDay(ts = Date.now()) {
+  return utcDayKey(ts) * MS_PER_DAY;
+}
+
+export function nextUtcMidnight(ts = Date.now()) {
+  return startOfUtcDay(ts) + MS_PER_DAY;
+}

--- a/server/migrations/012_add_day_key_utc.sql
+++ b/server/migrations/012_add_day_key_utc.sql
@@ -1,0 +1,5 @@
+ALTER TABLE daily_caps ADD COLUMN IF NOT EXISTS day_key_utc BIGINT;
+CREATE INDEX IF NOT EXISTS idx_daily_caps_day ON daily_caps(day_key_utc);
+
+ALTER TABLE daily_friend_activity ADD COLUMN IF NOT EXISTS day_key_utc BIGINT;
+CREATE INDEX IF NOT EXISTS idx_dfa_ref_day ON daily_friend_activity(referrer_user_id, day_key_utc);

--- a/server/migrations/013_backfill_day_key_utc.sql
+++ b/server/migrations/013_backfill_day_key_utc.sql
@@ -1,0 +1,7 @@
+UPDATE daily_caps
+SET day_key_utc = FLOOR(EXTRACT(EPOCH FROM (day_utc::timestamp AT TIME ZONE 'UTC')) / 86400)
+WHERE day_key_utc IS NULL;
+
+UPDATE daily_friend_activity
+SET day_key_utc = FLOOR(EXTRACT(EPOCH FROM (first_event_at AT TIME ZONE 'UTC')) / 86400)
+WHERE day_key_utc IS NULL;

--- a/server/public/js/daily.js
+++ b/server/public/js/daily.js
@@ -1,0 +1,16 @@
+let _cache = null;
+
+export async function loadDailySummary(force = false) {
+  if (!force && _cache) return _cache;
+  try {
+    const r = await fetch('/v1/daily/summary');
+    const data = await r.json();
+    _cache = data;
+    return data;
+  } catch (e) {
+    console.error('loadDailySummary failed', e);
+    return { tasks: [], tasks_available: false, limits: {} };
+  }
+}
+
+setInterval(() => { _cache = null; }, 60000);

--- a/server/public/js/quests.js
+++ b/server/public/js/quests.js
@@ -1,29 +1,15 @@
-let _dailyCache = null;
-
-async function fetchDaily() {
-  if (_dailyCache) return _dailyCache;
-  try {
-    const r = await fetch('/api/quests?scope=day');
-    const data = await r.json();
-    _dailyCache = data;
-    if (!data.ok) console.error('Quests API error', data);
-    return data;
-  } catch (e) {
-    console.error('Quests fetch failed', e);
-    return { ok: false, items: [], claimable: 0 };
-  }
-}
+import { loadDailySummary } from './daily.js';
 
 export async function renderDailyStrip() {
   const el = document.getElementById('dailyQuestStrip');
   if (!el) return;
-  const data = await fetchDaily();
-  if (!data.items || !data.items.length) {
-    console.error('No quests received', data);
+  const data = await loadDailySummary();
+  if (!data.tasks_available) {
     el.innerHTML = '<div class="left">Сегодня без заданий</div>';
     return;
   }
-  const quest = data.items.find(q => !q.is_claimed && q.progress < q.goal) || data.items[0];
+  const claimable = data.tasks.filter(q => !q.is_claimed && q.progress >= q.goal).length;
+  const quest = data.tasks.find(q => !q.is_claimed && q.progress < q.goal) || data.tasks[0];
   const reward = quest.reward.type === 'USD'
     ? `$${quest.reward.value}`
     : `${quest.reward.value} ${quest.reward.type}`;
@@ -31,7 +17,7 @@ export async function renderDailyStrip() {
   if (!quest.is_claimed && quest.progress >= quest.goal) {
     action = `<button class="chipbtn" id="dqClaim">CLAIM</button>`;
   }
-  const badge = data.claimable > 1 ? `<span class="badge">+${data.claimable}</span>` : '';
+  const badge = claimable > 1 ? `<span class="badge">+${claimable - 1}</span>` : '';
   el.innerHTML = `<div class="left">Ежедневка: ${quest.title} — ${quest.progress}/${quest.goal} • Награда: ${reward}</div><div class="right">${action} ${badge}</div>`;
   if (!quest.is_claimed && quest.progress >= quest.goal) {
     document.getElementById('dqClaim').onclick = async () => {
@@ -42,7 +28,7 @@ export async function renderDailyStrip() {
           body: JSON.stringify({ id: quest.id })
         });
       } catch {}
-      _dailyCache = null;
+      await loadDailySummary(true);
       renderDailyStrip();
     };
   }


### PR DESCRIPTION
## Summary
- add shared UTC time helpers and day_key_utc columns for daily tables
- expose `/v1/daily/summary` and `/v1/debug/time` for UTC-based day logic
- load daily summary on the client to show tasks and reset info

## Testing
- `node --test xp.test.mjs server/*.test.js`
- `node server/migrate.js` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68b631cb16c48328b4149c2104c765ee