### PR TITLE
feat: add spread tracking MVP

### DIFF
--- a/server/migrations/013_spread.sql
+++ b/server/migrations/013_spread.sql
@@ -1,0 +1,34 @@
+-- Spread tracking tables
+CREATE TABLE IF NOT EXISTS spread_tracks (
+  id SERIAL PRIMARY KEY,
+  user_id INT REFERENCES users(id),
+  exchange TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  dex_pair TEXT NOT NULL,
+  chain TEXT,
+  status TEXT NOT NULL DEFAULT 'idle',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  last_spread_at TIMESTAMPTZ,
+  last_converged_at TIMESTAMPTZ,
+  cooldown_until TIMESTAMPTZ,
+  UNIQUE(exchange, symbol, dex_pair)
+);
+
+CREATE TABLE IF NOT EXISTS spread_events (
+  id SERIAL PRIMARY KEY,
+  track_id INT REFERENCES spread_tracks(id),
+  kind TEXT NOT NULL,
+  cex_price NUMERIC,
+  dex_price NUMERIC,
+  spread_bps INT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS spread_rewards (
+  id SERIAL PRIMARY KEY,
+  track_id INT REFERENCES spread_tracks(id),
+  user_id INT REFERENCES users(id),
+  reward_type TEXT NOT NULL,
+  amount BIGINT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ import { runMigrations } from './migrate.js';
 import { seedTasks } from './scripts/seed_tasks.mjs';
 import { dailyKeyUTC, weeklyKeyUTC } from './tasks/utils.js';
 import { addTaskProgress } from './tasks/events.js';
+import { startSpreadTracker, parseDexInput, USER_TRACK_LIMIT } from './spread.js';
 
 function verifyInitData(initData, botToken) {
   try {
@@ -142,6 +143,9 @@ try {
 } catch (e) {
   console.error('migrations failed', e);
 }
+
+// start spread tracker loop
+const spread = startSpreadTracker(pool);
 
 async function seedQuestTemplates(pool){
   const { rows } = await pool.query('SELECT COUNT(*)::int AS c FROM quest_templates');
@@ -2395,6 +2399,62 @@ app.get('/api/referrals/stats/today', async (req, res) => {
     console.error('/api/referrals/stats/today', e);
     res.status(500).json({ ok:false, error:'SERVER' });
   }
+});
+
+// === Spread tracking ===
+app.post('/api/spread/track', requireTgAuth, async (req, res) => {
+  const { exchange, symbol, dexUrlOrPair } = req.body || {};
+  if (!/^(binance|mexc)$/.test(exchange)) return res.json({ ok:false, error:'BAD_EXCHANGE' });
+  if (!/^[A-Z0-9]+USDT$/.test(symbol)) return res.json({ ok:false, error:'BAD_SYMBOL' });
+  const parsed = parseDexInput(dexUrlOrPair);
+  if (!parsed || !parsed.pair) return res.json({ ok:false, error:'BAD_DEX' });
+  const uid = req.tgUser.id;
+  try {
+    const count = await pool.query('SELECT COUNT(*)::int AS c FROM spread_tracks WHERE user_id=$1', [uid]);
+    if (count.rows[0].c >= USER_TRACK_LIMIT) return res.json({ ok:false, error:'TRACK_LIMIT' });
+    const existing = await pool.query('SELECT st.id, u.username FROM spread_tracks st LEFT JOIN users u ON st.user_id=u.id WHERE st.exchange=$1 AND st.symbol=$2 AND st.dex_pair=$3', [exchange, symbol, parsed.pair]);
+    if (existing.rowCount > 0) {
+      const ex = existing.rows[0];
+      return res.json({ ok:true, trackId: ex.id, creator: ex.username || null });
+    }
+    const ins = await pool.query('INSERT INTO spread_tracks(user_id,exchange,symbol,dex_pair,chain) VALUES ($1,$2,$3,$4,$5) RETURNING id', [uid, exchange, symbol, parsed.pair, parsed.chain]);
+    res.json({ ok:true, trackId: ins.rows[0].id });
+  } catch (e) {
+    console.error('/api/spread/track', e);
+    res.status(500).json({ ok:false, error:'SERVER' });
+  }
+});
+
+app.get('/api/spread/list', requireTgAuth, async (req, res) => {
+  try {
+    const uid = req.tgUser.id;
+    const { rows } = await pool.query('SELECT id, exchange, symbol, dex_pair, chain, status FROM spread_tracks WHERE user_id=$1 ORDER BY id', [uid]);
+    const tracks = rows.map(r => ({ ...r, ...spread.state.get(r.id) }));
+    res.json({ ok:true, tracks });
+  } catch (e) {
+    console.error('/api/spread/list', e);
+    res.status(500).json({ ok:false, error:'SERVER' });
+  }
+});
+
+app.get('/api/spread/state', requireTgAuth, async (req, res) => {
+  const id = Number(req.query.trackId);
+  if (!id) return res.json({ ok:false, error:'NO_ID' });
+  const st = spread.state.get(id);
+  if (!st) return res.json({ ok:false, error:'NOT_FOUND' });
+  res.json({ ok:true, trackId:id, ...st });
+});
+
+app.get('/stream/spread', (req, res) => {
+  const id = Number(req.query.trackId);
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  const send = (u) => { if (u.trackId === id) res.write(`data: ${JSON.stringify(u)}\n\n`); };
+  spread.on('update', send);
+  const init = spread.state.get(id);
+  if (init) res.write(`data: ${JSON.stringify({ trackId:id, ...init })}\n\n`);
+  req.on('close', () => spread.off('update', send));
 });
 
 app.get('/api/tasks/active', requireTgAuth, async (req, res) => {

--- a/server/spread.js
+++ b/server/spread.js
@@ -1,0 +1,117 @@
+import EventEmitter from 'events';
+import { grantXpOnce } from '../xp.mjs';
+
+const SPREAD_THRESHOLD_BPS = Number(process.env.SPREAD_THRESHOLD_BPS || 30);
+const CONVERGENCE_THRESHOLD_BPS = Number(process.env.CONVERGENCE_THRESHOLD_BPS || 10);
+const SPREAD_COOLDOWN_SEC = Number(process.env.SPREAD_COOLDOWN_SEC || 60);
+const SPREAD_REWARD = Number(process.env.SPREAD_REWARD || 1000);
+const CONVERGENCE_REWARD = Number(process.env.CONVERGENCE_REWARD || 1000);
+const SPREAD_POLL_MS = Number(process.env.SPREAD_POLL_MS || 1500);
+const USER_TRACK_LIMIT = Number(process.env.USER_TRACK_LIMIT || 5);
+
+function sleep(ms){ return new Promise(r=>setTimeout(r,ms)); }
+
+export function parseDexInput(input){
+  if (!input) return null;
+  input = input.trim();
+  if (/^0x[a-fA-F0-9]{40}$/.test(input)) return { pair: input.toLowerCase(), chain: null };
+  try {
+    const url = new URL(input);
+    if (url.hostname.includes('dexscreener.com')) {
+      const parts = url.pathname.split('/').filter(Boolean); // [chain, pair]
+      if (parts.length >= 2) return { chain: parts[0].toLowerCase(), pair: parts[1].toLowerCase() };
+    }
+    if (url.hostname.includes('dextools.io')) {
+      const parts = url.pathname.split('/').filter(Boolean);
+      // example: app/en/ether/pair-explorer/0x...
+      const idx = parts.indexOf('pair-explorer');
+      if (idx >= 0 && parts[idx+1]) {
+        const chain = parts[idx-1];
+        const pair = parts[idx+1];
+        const map = { ether:'eth', ethereum:'eth', bsc:'bsc', polygon:'polygon', avax:'avax', arb:'arbitrum', base:'base', op:'optimism' };
+        return { chain: map[chain] || chain, pair: pair.toLowerCase() };
+      }
+    }
+  } catch {}
+  return null;
+}
+
+async function fetchCexPrice(exchange, symbol){
+  const urls = {
+    binance: `https://api.binance.com/api/v3/ticker/price?symbol=${symbol}`,
+    mexc: `https://api.mexc.com/api/v3/ticker/price?symbol=${symbol}`
+  };
+  const url = urls[exchange];
+  if (!url) return null;
+  const r = await fetch(url);
+  if (!r.ok) return null;
+  const j = await r.json();
+  return Number(j.price);
+}
+
+async function fetchDexPrice(chain, pair){
+  if (!chain || !pair) return null;
+  const url = `https://api.dexscreener.com/latest/dex/pairs/${chain}/${pair}`;
+  const r = await fetch(url);
+  if (!r.ok) return null;
+  const j = await r.json();
+  const price = j.pair?.priceUsd || j.pairs?.[0]?.priceUsd || j.priceUsd;
+  return price ? Number(price) : null;
+}
+
+export function startSpreadTracker(pool){
+  const emitter = new EventEmitter();
+  const state = new Map(); // trackId -> { cexPrice, dexPrice, bps, status }
+
+  async function processTrack(track){
+    try {
+      const [cexPrice, dexPrice] = await Promise.all([
+        fetchCexPrice(track.exchange, track.symbol),
+        fetchDexPrice(track.chain, track.dex_pair)
+      ]);
+      if (!Number.isFinite(cexPrice) || !Number.isFinite(dexPrice)) return;
+      const bps = Math.abs(cexPrice - dexPrice) / ((cexPrice + dexPrice)/2) * 10000;
+      let status = track.status;
+      const now = new Date();
+      if (status === 'cooldown') {
+        if (track.cooldown_until && now > track.cooldown_until && bps < SPREAD_THRESHOLD_BPS) {
+          status = 'idle';
+          await pool.query(`UPDATE spread_tracks SET status='idle' WHERE id=$1`, [track.id]);
+        }
+      } else if (status === 'idle' && bps >= SPREAD_THRESHOLD_BPS) {
+        status = 'spread_open';
+        await pool.query(`UPDATE spread_tracks SET status='spread_open', last_spread_at=now() WHERE id=$1`, [track.id]);
+        await pool.query(`INSERT INTO spread_events(track_id,kind,cex_price,dex_price,spread_bps) VALUES ($1,'spread_open',$2,$3,$4)`, [track.id, cexPrice, dexPrice, Math.round(bps)]);
+        await pool.query(`INSERT INTO spread_rewards(track_id,user_id,reward_type,amount) VALUES ($1,$2,'spread',$3)`, [track.id, track.user_id, SPREAD_REWARD]);
+        await pool.query(`UPDATE users SET balance=balance+$1 WHERE id=$2`, [SPREAD_REWARD, track.user_id]);
+        await grantXpOnce(pool, track.user_id, 'spread_open', track.id, 300);
+      } else if (status === 'spread_open' && bps <= CONVERGENCE_THRESHOLD_BPS) {
+        status = 'cooldown';
+        await pool.query(`UPDATE spread_tracks SET status='cooldown', last_converged_at=now(), cooldown_until=now()+$2::interval WHERE id=$1`, [track.id, `${SPREAD_COOLDOWN_SEC} seconds`]);
+        await pool.query(`INSERT INTO spread_events(track_id,kind,cex_price,dex_price,spread_bps) VALUES ($1,'converged',$2,$3,$4)`, [track.id, cexPrice, dexPrice, Math.round(bps)]);
+        await pool.query(`INSERT INTO spread_rewards(track_id,user_id,reward_type,amount) VALUES ($1,$2,'convergence',$3)`, [track.id, track.user_id, CONVERGENCE_REWARD]);
+        await pool.query(`UPDATE users SET balance=balance+$1 WHERE id=$2`, [CONVERGENCE_REWARD, track.user_id]);
+        await grantXpOnce(pool, track.user_id, 'spread_converged', track.id, 300);
+      }
+      state.set(track.id, { cexPrice, dexPrice, bps, status });
+      emitter.emit('update', { trackId: track.id, cexPrice, dexPrice, bps, status });
+    } catch (e) {
+      console.error('spread processTrack', e);
+    }
+  }
+
+  async function loop(){
+    while(true){
+      try {
+        const { rows } = await pool.query(`SELECT * FROM spread_tracks`);
+        for (const tr of rows) await processTrack(tr);
+      } catch (e){ console.error('spread loop', e); }
+      await sleep(SPREAD_POLL_MS);
+    }
+  }
+  loop();
+
+  return { on: (...a)=>emitter.on(...a), off: (...a)=>emitter.off?.(...a), state, parseDexInput, USER_TRACK_LIMIT };
+}
+
+export { SPREAD_THRESHOLD_BPS, CONVERGENCE_THRESHOLD_BPS, SPREAD_POLL_MS, USER_TRACK_LIMIT };


### PR DESCRIPTION
## Summary
- add spread tracking tables and poller
- expose API endpoints and SSE stream for spreads

## Testing
- `node --test xp.test.mjs server/farmUtils.test.js server/shopMath.test.js server/verifyInitData.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a91c88c83288fd4cde0cba4a011