### PR TITLE
feat: add spread tracking MVP

### DIFF
--- a/server/migrations/013_spread.sql
+++ b/server/migrations/013_spread.sql
@@ -1,0 +1,34 @@
+-- Spread tracking tables
+CREATE TABLE IF NOT EXISTS spread_tracks (
+  id SERIAL PRIMARY KEY,
+  user_id INT REFERENCES users(id),
+  exchange TEXT NOT NULL,
+  symbol TEXT NOT NULL,
+  dex_pair TEXT NOT NULL,
+  chain TEXT,
+  status TEXT NOT NULL DEFAULT 'idle',
+  created_at TIMESTAMPTZ DEFAULT now(),
+  last_spread_at TIMESTAMPTZ,
+  last_converged_at TIMESTAMPTZ,
+  cooldown_until TIMESTAMPTZ,
+  UNIQUE(exchange, symbol, dex_pair)
+);
+
+CREATE TABLE IF NOT EXISTS spread_events (
+  id SERIAL PRIMARY KEY,
+  track_id INT REFERENCES spread_tracks(id),
+  kind TEXT NOT NULL,
+  cex_price NUMERIC,
+  dex_price NUMERIC,
+  spread_bps INT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS spread_rewards (
+  id SERIAL PRIMARY KEY,
+  track_id INT REFERENCES spread_tracks(id),
+  user_id INT REFERENCES users(id),
+  reward_type TEXT NOT NULL,
+  amount BIGINT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/server/public/classic.html
+++ b/server/public/classic.html
@@ -393,6 +393,7 @@
     <button class="chipbtn" id="statsBtn">Статистика</button>
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
     <button class="chipbtn" id="switchToArenaBtn">Арена</button>
+    <button class="chipbtn" id="spreadsBtn">Спреды</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
     <button class="chipbtn" id="shopBtn">Магазин<span id="farmPill" class="chip" style="display:none;margin-left:4px;background:var(--green);color:#000;font-weight:700"></span></button>
   </div>
@@ -675,6 +676,7 @@ const insBtn  = document.getElementById('insBtn');
 const statsBtn= document.getElementById('statsBtn');
 const chatFeedBtn = document.getElementById('chatFeedBtn');
 const switchToArenaBtn = document.getElementById('switchToArenaBtn');
+const spreadsBtn = document.getElementById('spreadsBtn');
 const cfgBtn  = document.getElementById('cfgBtn');
 const shopBtn = document.getElementById('shopBtn');
 const farmPill = document.getElementById('farmPill');
@@ -955,6 +957,7 @@ function bindOnce(){
       sheetShop.querySelector(`#tab-${tab}`)?.classList.add('show');
     });
     switchToArenaBtn?.addEventListener('click', ()=>go('/'));
+    spreadsBtn?.addEventListener('click', ()=>go('/spreads.html'));
   chipsBox.addEventListener('click', e=>{
     const b = e.target.closest('.chipopt'); if (!b) return;
     document.querySelectorAll('#chips .chipopt').forEach(x=>x.classList.remove('active'));

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -260,6 +260,7 @@
     <button class="chipbtn" id="topupBtn">Пополнение</button>
     <button class="chipbtn" id="chatFeedBtn">ЧАТ</button>
     <button class="chipbtn" id="rulesBtn">Правила</button>
+    <button class="chipbtn" id="spreadsBtn">Спреды</button>
     <button class="chipbtn" id="starsBtn">Купить $</button>
     <button class="chipbtn" id="shopBtn">Магазин</button>
   </div>
@@ -417,6 +418,7 @@ const rulesBtn = document.getElementById('rulesBtn');
 const starsBtn = document.getElementById('starsBtn');
 const shopBtn = document.getElementById('shopBtn');
 const switchToClassicBtn = document.getElementById('switchToClassicBtn');
+const spreadsBtn = document.getElementById('spreadsBtn');
 
 const sheetBg = document.getElementById('sheetBg');
 const sheetRules = document.getElementById('sheetRules');
@@ -442,6 +444,7 @@ const adEnter = document.getElementById('adEnter');
 const chatFeed = document.getElementById('chatFeed');
 
 switchToClassicBtn?.addEventListener('click', ()=>go('/classic.html'));
+spreadsBtn?.addEventListener('click', ()=>go('/spreads.html'));
 
 let selectedPack = null;
 let arenaPhase = 'idle';

--- a/server/public/js/spreads.js
+++ b/server/public/js/spreads.js
@@ -1,0 +1,97 @@
+function go(url){ location.href = url; }
+const exchangeSel = document.getElementById('exchange');
+const symbolInput = document.getElementById('symbol');
+const dexInput = document.getElementById('dex');
+const startBtn = document.getElementById('startBtn');
+const addError = document.getElementById('addError');
+const trackList = document.getElementById('trackList');
+const spreadRewards = document.getElementById('spreadRewards');
+const convRewards = document.getElementById('convRewards');
+const refreshBalance = document.getElementById('refreshBalance');
+const backBtn = document.getElementById('backBtn');
+
+backBtn?.addEventListener('click', ()=>go('/'));
+
+function statusText(st){
+  return { idle:'нет спреда', spread_open:'спред активен', cooldown:'конвергенция' }[st] || st;
+}
+
+function renderTrack(tr){
+  const el = document.createElement('div');
+  el.className = 'card track';
+  el.id = 'track-'+tr.id;
+  el.innerHTML = `<div><b>${tr.symbol}</b> — ${tr.exchange.toUpperCase()}</div>
+<div>CEX: <span class="cex">${tr.cexPrice?.toFixed?.(6)||''}</span> DEX: <span class="dex">${tr.dexPrice?.toFixed?.(6)||''}</span></div>
+<div>Спред: <span class="bps">${tr.bps?Math.round(tr.bps):''}</span> bps (<span class="pct">${tr.bps?(tr.bps/100).toFixed(2):''}</span>%)</div>
+<div class="status">Статус: ${statusText(tr.status)}</div>
+<div class="badge">Вы первый трекер</div>`;
+  trackList.appendChild(el);
+  const es = new EventSource(`/stream/spread?trackId=${tr.id}`);
+  es.onmessage = e => {
+    const d = JSON.parse(e.data);
+    if (d.cexPrice) el.querySelector('.cex').textContent = Number(d.cexPrice).toFixed(6);
+    if (d.dexPrice) el.querySelector('.dex').textContent = Number(d.dexPrice).toFixed(6);
+    if (typeof d.bps === 'number'){
+      el.querySelector('.bps').textContent = Math.round(d.bps);
+      el.querySelector('.pct').textContent = (d.bps/100).toFixed(2);
+    }
+    if (d.status) el.querySelector('.status').textContent = 'Статус: '+statusText(d.status);
+  };
+}
+
+async function loadTracks(){
+  trackList.innerHTML = '';
+  try{
+    const r = await fetch('/api/spread/list').then(r=>r.json());
+    if(r.ok){
+      r.tracks.forEach(renderTrack);
+    }
+  }catch{}
+}
+
+async function loadRewards(){
+  try{
+    const r = await fetch('/api/spread/rewards').then(r=>r.json());
+    if(r.ok){
+      spreadRewards.textContent = `Спреды найдены: ${r.spread} → $${r.spread*1000}`;
+      convRewards.textContent = `Конвергенции: ${r.convergence} → $${r.convergence*1000}`;
+    }
+  }catch{}
+}
+
+startBtn.addEventListener('click', async ()=>{
+  addError.textContent = '';
+  const body = {
+    exchange: exchangeSel.value,
+    symbol: symbolInput.value.trim(),
+    dexUrlOrPair: dexInput.value.trim()
+  };
+  try {
+    const r = await fetch('/api/spread/track', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(body)
+    }).then(r=>r.json());
+    if(!r.ok){
+      const map = { BAD_EXCHANGE:'Укажи биржу', BAD_SYMBOL:'Неверный символ', BAD_DEX:'Дай ссылку на конкретную пару или адрес', TRACK_LIMIT:'Лимит треков'};
+      addError.textContent = map[r.error] || 'Ошибка';
+      return;
+    }
+    if(r.creator){
+      addError.textContent = `Уже отслеживается (@${r.creator})`;
+      return;
+    }
+    symbolInput.value=''; dexInput.value='';
+    await loadTracks();
+    await loadRewards();
+  } catch {
+    addError.textContent = 'Ошибка сети';
+  }
+});
+
+refreshBalance.addEventListener('click', async ()=>{
+  try{ await fetch('/api/auth'); }catch{}
+  loadRewards();
+});
+
+loadTracks();
+loadRewards();

--- a/server/public/spreads.html
+++ b/server/public/spreads.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ru">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+<title>Спреды — BTC Game</title>
+<link rel="stylesheet" href="css/styles.css" />
+<script src="https://telegram.org/js/telegram-web-app.js"></script>
+<style>
+  .wrap{max-width:520px;margin:0 auto;}
+  .track{margin-bottom:16px;}
+  .track .status{margin-top:4px;font-size:13px;color:var(--muted);}
+  .track .badge{font-size:12px;color:var(--muted);margin-top:4px;}
+  .form-row{display:flex;gap:8px;margin-bottom:8px;flex-wrap:wrap;}
+  .form-row input, .form-row select{flex:1;min-width:120px;padding:8px;border-radius:8px;border:1px solid var(--outline);background:#121212;color:#fff;}
+  .form-row button{padding:8px 12px;border:none;border-radius:8px;background:var(--green);color:#fff;font-weight:700;}
+  #addError{color:var(--danger);font-size:13px;margin:4px 0 8px;}
+</style>
+</head>
+<body>
+<button class="back-text" id="backBtn">Назад</button>
+<div class="wrap">
+  <h1 class="page-title">Спреды</h1>
+  <section class="card" id="addTrack">
+    <h3>Добавить трекинг</h3>
+    <div class="form-row">
+      <select id="exchange">
+        <option value="binance">Binance</option>
+        <option value="mexc">MEXC</option>
+      </select>
+      <input id="symbol" placeholder="PEPEUSDT" />
+      <input id="dex" placeholder="DEX ссылка или адрес" />
+      <button id="startBtn">Начать</button>
+    </div>
+    <div id="addError"></div>
+  </section>
+  <section class="card" id="tracksSection">
+    <h3>Текущие треки</h3>
+    <div id="trackList"></div>
+  </section>
+  <section class="card" id="rewardsSection">
+    <h3>Награды за сегодня</h3>
+    <div id="spreadRewards">Спреды найдены: 0 → $0</div>
+    <div id="convRewards">Конвергенции: 0 → $0</div>
+    <button class="chipbtn" id="refreshBalance">Обновить баланс</button>
+  </section>
+</div>
+<script type="module" src="js/spreads.js"></script>
+</body>
+</html>

--- a/server/server.js
+++ b/server/server.js
@@ -16,6 +16,7 @@ import { runMigrations } from './migrate.js';
 import { seedTasks } from './scripts/seed_tasks.mjs';
 import { dailyKeyUTC, weeklyKeyUTC } from './tasks/utils.js';
 import { addTaskProgress } from './tasks/events.js';
+import { startSpreadTracker, parseDexInput, USER_TRACK_LIMIT } from './spread.js';
 
 function verifyInitData(initData, botToken) {
   try {
@@ -142,6 +143,9 @@ try {
 } catch (e) {
   console.error('migrations failed', e);
 }
+
+// start spread tracker loop
+const spread = startSpreadTracker(pool);
 
 async function seedQuestTemplates(pool){
   const { rows } = await pool.query('SELECT COUNT(*)::int AS c FROM quest_templates');
@@ -2394,6 +2398,81 @@ app.get('/api/referrals/stats/today', async (req, res) => {
   } catch (e) {
     console.error('/api/referrals/stats/today', e);
     res.status(500).json({ ok:false, error:'SERVER' });
+  }
+});
+
+// === Spread tracking ===
+app.post('/api/spread/track', requireTgAuth, async (req, res) => {
+  const { exchange, symbol, dexUrlOrPair } = req.body || {};
+  if (!/^(binance|mexc)$/.test(exchange)) return res.json({ ok:false, error:'BAD_EXCHANGE' });
+  if (!/^[A-Z0-9]+USDT$/.test(symbol)) return res.json({ ok:false, error:'BAD_SYMBOL' });
+  const parsed = parseDexInput(dexUrlOrPair);
+  if (!parsed || !parsed.pair) return res.json({ ok:false, error:'BAD_DEX' });
+  const uid = req.tgUser.id;
+  try {
+    const count = await pool.query('SELECT COUNT(*)::int AS c FROM spread_tracks WHERE user_id=$1', [uid]);
+    if (count.rows[0].c >= USER_TRACK_LIMIT) return res.json({ ok:false, error:'TRACK_LIMIT' });
+    const existing = await pool.query('SELECT st.id, u.username FROM spread_tracks st LEFT JOIN users u ON st.user_id=u.id WHERE st.exchange=$1 AND st.symbol=$2 AND st.dex_pair=$3', [exchange, symbol, parsed.pair]);
+    if (existing.rowCount > 0) {
+      const ex = existing.rows[0];
+      return res.json({ ok:true, trackId: ex.id, creator: ex.username || null });
+    }
+    const ins = await pool.query('INSERT INTO spread_tracks(user_id,exchange,symbol,dex_pair,chain) VALUES ($1,$2,$3,$4,$5) RETURNING id', [uid, exchange, symbol, parsed.pair, parsed.chain]);
+    res.json({ ok:true, trackId: ins.rows[0].id });
+  } catch (e) {
+    console.error('/api/spread/track', e);
+    res.status(500).json({ ok:false, error:'SERVER' });
+  }
+});
+
+app.get('/api/spread/list', requireTgAuth, async (req, res) => {
+  try {
+    const uid = req.tgUser.id;
+    const { rows } = await pool.query('SELECT id, exchange, symbol, dex_pair, chain, status FROM spread_tracks WHERE user_id=$1 ORDER BY id', [uid]);
+    const tracks = rows.map(r => ({ ...r, ...spread.state.get(r.id) }));
+    res.json({ ok:true, tracks });
+  } catch (e) {
+    console.error('/api/spread/list', e);
+    res.status(500).json({ ok:false, error:'SERVER' });
+  }
+});
+
+app.get('/api/spread/state', requireTgAuth, async (req, res) => {
+  const id = Number(req.query.trackId);
+  if (!id) return res.json({ ok:false, error:'NO_ID' });
+  const st = spread.state.get(id);
+  if (!st) return res.json({ ok:false, error:'NOT_FOUND' });
+  res.json({ ok:true, trackId:id, ...st });
+});
+
+app.get('/stream/spread', (req, res) => {
+  const id = Number(req.query.trackId);
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  const send = (u) => { if (u.trackId === id) res.write(`data: ${JSON.stringify(u)}\n\n`); };
+  spread.on('update', send);
+  const init = spread.state.get(id);
+  if (init) res.write(`data: ${JSON.stringify({ trackId:id, ...init })}\n\n`);
+  req.on('close', () => spread.off('update', send));
+});
+
+app.get('/api/spread/rewards', requireTgAuth, async (req, res) => {
+  try {
+    const uid = req.tgUser.id;
+    const { rows } = await pool.query(
+      `SELECT
+         SUM(CASE WHEN reward_type='spread' THEN 1 ELSE 0 END)::int AS spread,
+         SUM(CASE WHEN reward_type='convergence' THEN 1 ELSE 0 END)::int AS convergence
+       FROM spread_rewards
+       WHERE user_id=$1 AND created_at::date = now()::date`,
+      [uid],
+    );
+    const { spread = 0, convergence = 0 } = rows[0] || {};
+    res.json({ ok: true, spread, convergence });
+  } catch (e) {
+    console.error('/api/spread/rewards', e);
+    res.status(500).json({ ok: false, error: 'SERVER' });
   }
 });
 

--- a/server/spread.js
+++ b/server/spread.js
@@ -1,0 +1,117 @@
+import EventEmitter from 'events';
+import { grantXpOnce } from '../xp.mjs';
+
+const SPREAD_THRESHOLD_BPS = Number(process.env.SPREAD_THRESHOLD_BPS || 30);
+const CONVERGENCE_THRESHOLD_BPS = Number(process.env.CONVERGENCE_THRESHOLD_BPS || 10);
+const SPREAD_COOLDOWN_SEC = Number(process.env.SPREAD_COOLDOWN_SEC || 60);
+const SPREAD_REWARD = Number(process.env.SPREAD_REWARD || 1000);
+const CONVERGENCE_REWARD = Number(process.env.CONVERGENCE_REWARD || 1000);
+const SPREAD_POLL_MS = Number(process.env.SPREAD_POLL_MS || 1500);
+const USER_TRACK_LIMIT = Number(process.env.USER_TRACK_LIMIT || 5);
+
+function sleep(ms){ return new Promise(r=>setTimeout(r,ms)); }
+
+export function parseDexInput(input){
+  if (!input) return null;
+  input = input.trim();
+  if (/^0x[a-fA-F0-9]{40}$/.test(input)) return { pair: input.toLowerCase(), chain: null };
+  try {
+    const url = new URL(input);
+    if (url.hostname.includes('dexscreener.com')) {
+      const parts = url.pathname.split('/').filter(Boolean); // [chain, pair]
+      if (parts.length >= 2) return { chain: parts[0].toLowerCase(), pair: parts[1].toLowerCase() };
+    }
+    if (url.hostname.includes('dextools.io')) {
+      const parts = url.pathname.split('/').filter(Boolean);
+      // example: app/en/ether/pair-explorer/0x...
+      const idx = parts.indexOf('pair-explorer');
+      if (idx >= 0 && parts[idx+1]) {
+        const chain = parts[idx-1];
+        const pair = parts[idx+1];
+        const map = { ether:'eth', ethereum:'eth', bsc:'bsc', polygon:'polygon', avax:'avax', arb:'arbitrum', base:'base', op:'optimism' };
+        return { chain: map[chain] || chain, pair: pair.toLowerCase() };
+      }
+    }
+  } catch {}
+  return null;
+}
+
+async function fetchCexPrice(exchange, symbol){
+  const urls = {
+    binance: `https://api.binance.com/api/v3/ticker/price?symbol=${symbol}`,
+    mexc: `https://api.mexc.com/api/v3/ticker/price?symbol=${symbol}`
+  };
+  const url = urls[exchange];
+  if (!url) return null;
+  const r = await fetch(url);
+  if (!r.ok) return null;
+  const j = await r.json();
+  return Number(j.price);
+}
+
+async function fetchDexPrice(chain, pair){
+  if (!chain || !pair) return null;
+  const url = `https://api.dexscreener.com/latest/dex/pairs/${chain}/${pair}`;
+  const r = await fetch(url);
+  if (!r.ok) return null;
+  const j = await r.json();
+  const price = j.pair?.priceUsd || j.pairs?.[0]?.priceUsd || j.priceUsd;
+  return price ? Number(price) : null;
+}
+
+export function startSpreadTracker(pool){
+  const emitter = new EventEmitter();
+  const state = new Map(); // trackId -> { cexPrice, dexPrice, bps, status }
+
+  async function processTrack(track){
+    try {
+      const [cexPrice, dexPrice] = await Promise.all([
+        fetchCexPrice(track.exchange, track.symbol),
+        fetchDexPrice(track.chain, track.dex_pair)
+      ]);
+      if (!Number.isFinite(cexPrice) || !Number.isFinite(dexPrice)) return;
+      const bps = Math.abs(cexPrice - dexPrice) / ((cexPrice + dexPrice)/2) * 10000;
+      let status = track.status;
+      const now = new Date();
+      if (status === 'cooldown') {
+        if (track.cooldown_until && now > track.cooldown_until && bps < SPREAD_THRESHOLD_BPS) {
+          status = 'idle';
+          await pool.query(`UPDATE spread_tracks SET status='idle' WHERE id=$1`, [track.id]);
+        }
+      } else if (status === 'idle' && bps >= SPREAD_THRESHOLD_BPS) {
+        status = 'spread_open';
+        await pool.query(`UPDATE spread_tracks SET status='spread_open', last_spread_at=now() WHERE id=$1`, [track.id]);
+        await pool.query(`INSERT INTO spread_events(track_id,kind,cex_price,dex_price,spread_bps) VALUES ($1,'spread_open',$2,$3,$4)`, [track.id, cexPrice, dexPrice, Math.round(bps)]);
+        await pool.query(`INSERT INTO spread_rewards(track_id,user_id,reward_type,amount) VALUES ($1,$2,'spread',$3)`, [track.id, track.user_id, SPREAD_REWARD]);
+        await pool.query(`UPDATE users SET balance=balance+$1 WHERE id=$2`, [SPREAD_REWARD, track.user_id]);
+        await grantXpOnce(pool, track.user_id, 'spread_open', track.id, 300);
+      } else if (status === 'spread_open' && bps <= CONVERGENCE_THRESHOLD_BPS) {
+        status = 'cooldown';
+        await pool.query(`UPDATE spread_tracks SET status='cooldown', last_converged_at=now(), cooldown_until=now()+$2::interval WHERE id=$1`, [track.id, `${SPREAD_COOLDOWN_SEC} seconds`]);
+        await pool.query(`INSERT INTO spread_events(track_id,kind,cex_price,dex_price,spread_bps) VALUES ($1,'converged',$2,$3,$4)`, [track.id, cexPrice, dexPrice, Math.round(bps)]);
+        await pool.query(`INSERT INTO spread_rewards(track_id,user_id,reward_type,amount) VALUES ($1,$2,'convergence',$3)`, [track.id, track.user_id, CONVERGENCE_REWARD]);
+        await pool.query(`UPDATE users SET balance=balance+$1 WHERE id=$2`, [CONVERGENCE_REWARD, track.user_id]);
+        await grantXpOnce(pool, track.user_id, 'spread_converged', track.id, 300);
+      }
+      state.set(track.id, { cexPrice, dexPrice, bps, status });
+      emitter.emit('update', { trackId: track.id, cexPrice, dexPrice, bps, status });
+    } catch (e) {
+      console.error('spread processTrack', e);
+    }
+  }
+
+  async function loop(){
+    while(true){
+      try {
+        const { rows } = await pool.query(`SELECT * FROM spread_tracks`);
+        for (const tr of rows) await processTrack(tr);
+      } catch (e){ console.error('spread loop', e); }
+      await sleep(SPREAD_POLL_MS);
+    }
+  }
+  loop();
+
+  return { on: (...a)=>emitter.on(...a), off: (...a)=>emitter.off?.(...a), state, parseDexInput, USER_TRACK_LIMIT };
+}
+
+export { SPREAD_THRESHOLD_BPS, CONVERGENCE_THRESHOLD_BPS, SPREAD_POLL_MS, USER_TRACK_LIMIT };


### PR DESCRIPTION
## Summary
- add spreads page with tracking form, live track list, and reward summary
- expose daily rewards endpoint and navigation menu links
- resolve merge conflict in server.js so spread rewards API coexists with tasks API

## Testing
- `node --test xp.test.mjs server/farmUtils.test.js server/shopMath.test.js server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a91c88c83288fd4cde0cba4a011