### PR TITLE
Stabilize server startup and schema init

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -6,8 +6,6 @@
   "packages": {
     "": {
       "name": "btc-game-server",
-      "version": "1.0.0",
-      "license": "UNLICENSED",
       "dependencies": {
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
@@ -16,7 +14,7 @@
         "ws": "^8.17.1"
       },
       "engines": {
-        "node": ">=18.17 <21"
+        "node": ">=20.10.0"
       }
     },
     "node_modules/accepts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,15 +1,12 @@
 {
   "name": "btc-game-server",
-  "version": "1.0.0",
   "private": true,
   "type": "module",
-  "license": "UNLICENSED",
-  "engines": { "node": ">=18.17 <21" },
+  "engines": { "node": ">=20.10.0" },
   "scripts": {
     "start": "node server.js",
-    "build": "echo \"no build step\"",
-    "render-build": "echo \"Render build\"",
-    "dev": "nodemon server.js"
+    "dev": "nodemon server.js",
+    "build": "echo \"no build step\""
   },
   "dependencies": {
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
- load env vars via dotenv without overriding Render secrets and validate required vars
- ensure schema creation before seeding quest templates and expose `/health`
- enforce Node 20+ and clean npm scripts with committed lockfile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba6804df748328a66dfaceab9bdecf