### PR TITLE
Ensure quest schema is idempotent before seeding quests

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -19,9 +19,8 @@ import {
   utcDayKey, startOfUtcDay
 } from './utils/time.js';
 
-import {
-  ensureSchema, seedQuestTemplates
-} from './utils/schema.js';
+import { ensureSchema } from './utils/schema.js';
+import { seedQuestTemplates } from './utils/seed.js';
 
 // ===== Config =====
 const PORT = Number(process.env.PORT || 10000);

--- a/server/utils/seed.js
+++ b/server/utils/seed.js
@@ -1,0 +1,13 @@
+export async function seedQuestTemplates(pool) {
+  await pool.query(`
+    INSERT INTO quest_templates (code, title, description, reward_usd, reward_vop)
+    VALUES
+      ('ARENA_10_WINS',  'Выиграй 10 раз на Арене', 'Победи в 10 раундах Арены', 500, 0),
+      ('ARENA_100_BETS', 'Сделай 100 ставок на Арене', 'Любые направления', 500, 0),
+      ('ARENA_100_BUY',  '100 ставок BUY', 'Только BUY', 300, 0),
+      ('ARENA_100_SELL', '100 ставок SELL', 'Только SELL', 300, 0),
+      ('INVITE_3',       'Пригласи 3 друга', 'Друзья должны зайти в игру', 1000, 0)
+    ON CONFLICT (code) DO NOTHING;
+  `);
+}
+


### PR DESCRIPTION
## Summary
- ensure database schema creates/updates `quest_templates` with code and description columns
- move quest template seeding into separate utility and insert with `ON CONFLICT DO NOTHING`
- update server startup to run schema migrations before seeding

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find a config file)


------
https://chatgpt.com/codex/tasks/task_e_68ba6f94387083289b92e9ae2deba9c5