### PR TITLE
feat: fix quest template migrations and seed

### DIFF
--- a/server/migrations/006_quest_templates_v3.sql
+++ b/server/migrations/006_quest_templates_v3.sql
@@ -1,0 +1,46 @@
+-- create if missing
+CREATE TABLE IF NOT EXISTS quest_templates (
+  id BIGSERIAL PRIMARY KEY,
+  qkey TEXT UNIQUE NOT NULL,                 -- наш стабильный ключ
+  title TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  type TEXT NOT NULL CHECK (type IN ('daily','weekly','oneoff')),
+  reward_usd INTEGER NOT NULL DEFAULT 0,
+  reward_vop INTEGER NOT NULL DEFAULT 0,
+  limit_usd_delta INTEGER NOT NULL DEFAULT 0, -- +$ к дневному лимиту
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- апгрейд существующей таблицы под текущую модель (идемпотентно)
+ALTER TABLE quest_templates
+  ADD COLUMN IF NOT EXISTS qkey TEXT,
+  ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '',
+  ADD COLUMN IF NOT EXISTS reward_vop INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS limit_usd_delta INTEGER DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS type TEXT;
+
+-- на случай старой логики — оставляем code, но делаем backfill из qkey
+ALTER TABLE quest_templates ADD COLUMN IF NOT EXISTS code TEXT;
+
+-- backfill значений, чтобы не было NULL
+UPDATE quest_templates
+SET
+  qkey        = COALESCE(qkey, CONCAT(COALESCE(type,'daily'),':',COALESCE(code, regexp_replace(title,'\s+','_','g')))),
+  description = COALESCE(description, ''),
+  type        = COALESCE(type, 'daily'),
+  code        = COALESCE(code, qkey);
+
+-- ограничения после backfill
+ALTER TABLE quest_templates
+  ALTER COLUMN qkey SET NOT NULL,
+  ALTER COLUMN description SET NOT NULL,
+  ALTER COLUMN type SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname='quest_templates_qkey_key'
+  ) THEN
+    ALTER TABLE quest_templates ADD CONSTRAINT quest_templates_qkey_key UNIQUE (qkey);
+  END IF;
+END $$;

--- a/server/utils/seed.js
+++ b/server/utils/seed.js
@@ -1,13 +1,80 @@
 export async function seedQuestTemplates(pool) {
-  await pool.query(`
-    INSERT INTO quest_templates (code, title, description, reward_usd, reward_vop)
-    VALUES
-      ('ARENA_10_WINS',  'Выиграй 10 раз на Арене', 'Победи в 10 раундах Арены', 500, 0),
-      ('ARENA_100_BETS', 'Сделай 100 ставок на Арене', 'Любые направления', 500, 0),
-      ('ARENA_100_BUY',  '100 ставок BUY', 'Только BUY', 300, 0),
-      ('ARENA_100_SELL', '100 ставок SELL', 'Только SELL', 300, 0),
-      ('INVITE_3',       'Пригласи 3 друга', 'Друзья должны зайти в игру', 1000, 0)
-    ON CONFLICT (code) DO NOTHING;
-  `);
-}
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
 
+    /** минимальный пул шаблонов */
+    const templates = [
+      {
+        qkey: 'daily:arena_10_wins',
+        title: 'Выиграй 10 раз на арене',
+        description: 'Победи 10 раз за сутки на арене',
+        type: 'daily',
+        reward_usd: 1000,
+        reward_vop: 0,
+        limit_usd_delta: 500,
+      },
+      {
+        qkey: 'daily:place_100_bets',
+        title: 'Сделай 100 ставок',
+        description: 'Любые ставки в любом режиме за сутки',
+        type: 'daily',
+        reward_usd: 800,
+        reward_vop: 0,
+        limit_usd_delta: 500,
+      },
+      {
+        qkey: 'oneoff:subscribe_channel',
+        title: 'Подписка на канал',
+        description: 'Подпишись на @erc20coin',
+        type: 'oneoff',
+        reward_usd: 30000,      // по вашим последним правилам
+        reward_vop: 0,
+        limit_usd_delta: 0,
+      },
+      {
+        qkey: 'daily:invite_1_friend',
+        title: 'Пригласи 1 друга',
+        description: 'Друг должен зайти в игру',
+        type: 'daily',
+        reward_usd: 500,
+        reward_vop: 0,
+        limit_usd_delta: 500,   // +$ к дневному лимиту
+      },
+    ];
+
+    const upsert = `
+      INSERT INTO quest_templates
+        (qkey, title, description, type, reward_usd, reward_vop, limit_usd_delta, code)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$1)
+      ON CONFLICT (qkey) DO UPDATE SET
+        title = EXCLUDED.title,
+        description = EXCLUDED.description,
+        type = EXCLUDED.type,
+        reward_usd = EXCLUDED.reward_usd,
+        reward_vop = EXCLUDED.reward_vop,
+        limit_usd_delta = EXCLUDED.limit_usd_delta,
+        code = EXCLUDED.code;
+    `;
+
+    for (const t of templates) {
+      // защита от случайных undefined
+      await client.query(upsert, [
+        t.qkey,
+        t.title,
+        t.description ?? '',
+        t.type ?? 'daily',
+        t.reward_usd ?? 0,
+        t.reward_vop ?? 0,
+        t.limit_usd_delta ?? 0,
+      ]);
+    }
+
+    await client.query('COMMIT');
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
## Summary
- normalize quest_templates schema with idempotent migration
- seed quest templates via qkey upsert
- run DB migrations before quest seeding at startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test`
- `npm run lint` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba72906ad88328ad2775815208c0d2