### PR TITLE
Fix quest template migration and seeding

### DIFF
--- a/server/migrations/014_fix_quest_templates.sql
+++ b/server/migrations/014_fix_quest_templates.sql
@@ -1,0 +1,38 @@
+-- 014_fix_quest_templates.sql
+
+-- 1. Добавляем отсутствующие столбцы, безопасно
+ALTER TABLE quest_templates
+  ADD COLUMN IF NOT EXISTS description TEXT,
+  ADD COLUMN IF NOT EXISTS scope TEXT,
+  ADD COLUMN IF NOT EXISTS code TEXT;
+
+-- 2. Дефолты и NOT NULL
+ALTER TABLE quest_templates
+  ALTER COLUMN description SET DEFAULT '',
+  ALTER COLUMN scope SET DEFAULT 'user';
+
+UPDATE quest_templates SET description = '' WHERE description IS NULL;
+UPDATE quest_templates SET scope       = 'user' WHERE scope IS NULL;
+
+-- 3. Гарантируем qkey: unique, нижний регистр
+-- если qkey пуст — собираем из type/code или из title
+UPDATE quest_templates
+SET qkey = LOWER(
+  COALESCE(qkey,
+           CASE
+             WHEN code IS NOT NULL AND code <> '' THEN CONCAT(type, ':', code)
+             ELSE CONCAT(type, ':', REGEXP_REPLACE(LOWER(title), '\\s+', '_', 'g'))
+           END))
+WHERE qkey IS NULL OR qkey = '';
+
+-- 4. Индекс по qkey
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+     WHERE schemaname = 'public' AND indexname = 'idx_quest_templates_qkey_unique'
+  ) THEN
+    CREATE UNIQUE INDEX idx_quest_templates_qkey_unique
+      ON quest_templates (qkey);
+  END IF;
+END $$;

--- a/server/scripts/smoke-quests.mjs
+++ b/server/scripts/smoke-quests.mjs
@@ -1,0 +1,35 @@
+import 'dotenv/config';
+import pg from 'pg';
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.PGSSL === 'disable' ? false : { rejectUnauthorized: false }
+});
+
+async function main() {
+  const client = await pool.connect();
+  try {
+    const countRes = await client.query('SELECT COUNT(*)::int AS cnt FROM quest_templates');
+    console.log('[smoke] quest_templates count:', countRes.rows[0]?.cnt);
+
+    const dupRes = await client.query(`SELECT qkey, COUNT(*) AS c FROM quest_templates GROUP BY qkey HAVING COUNT(*) > 1`);
+    if (dupRes.rows.length > 0) {
+      throw new Error('duplicate qkey: ' + JSON.stringify(dupRes.rows));
+    }
+
+    const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR scope IS NULL`);
+    if (nullRes.rows[0]?.cnt > 0) {
+      throw new Error('NULL description/scope rows: ' + nullRes.rows[0].cnt);
+    }
+
+    console.log('[smoke] ok');
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+main().catch((e) => {
+  console.error('[smoke] failed', e);
+  process.exit(1);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -48,8 +48,22 @@ app.get('/v1/debug/time', async (_req, res) => {
 });
 
 async function boot() {
-  await runMigrations(pool);
-  await seedQuestTemplates(pool);
+  try {
+    console.log('[migrations] start');
+    await runMigrations(pool);
+    console.log('[migrations] done');
+  } catch (e) {
+    console.error('[migrations] failed', e);
+    process.exit(1);
+  }
+
+  try {
+    console.log('[seed] start');
+    await seedQuestTemplates(pool);
+  } catch (e) {
+    console.error('[seed] failed', e);
+    process.exit(1);
+  }
 
   // ... тут ваши остальные роуты / логика ...
 

--- a/server/utils/seed.js
+++ b/server/utils/seed.js
@@ -3,74 +3,84 @@ export async function seedQuestTemplates(pool) {
   try {
     await client.query('BEGIN');
 
-    /** минимальный пул шаблонов */
     const templates = [
       {
         qkey: 'daily:arena_10_wins',
         title: 'Выиграй 10 раз на арене',
         description: 'Победи 10 раз за сутки на арене',
         type: 'daily',
+        scope: 'user',
         reward_usd: 1000,
         reward_vop: 0,
         limit_usd_delta: 500,
+        code: 'arena_10_wins',
       },
       {
         qkey: 'daily:place_100_bets',
         title: 'Сделай 100 ставок',
         description: 'Любые ставки в любом режиме за сутки',
         type: 'daily',
+        scope: 'user',
         reward_usd: 800,
         reward_vop: 0,
         limit_usd_delta: 500,
+        code: 'place_100_bets',
       },
       {
         qkey: 'oneoff:subscribe_channel',
         title: 'Подписка на канал',
         description: 'Подпишись на @erc20coin',
         type: 'oneoff',
-        reward_usd: 30000,      // по вашим последним правилам
+        scope: 'user',
+        reward_usd: 30000,
         reward_vop: 0,
         limit_usd_delta: 0,
+        code: 'subscribe_channel',
       },
       {
         qkey: 'daily:invite_1_friend',
         title: 'Пригласи 1 друга',
         description: 'Друг должен зайти в игру',
         type: 'daily',
+        scope: 'user',
         reward_usd: 500,
         reward_vop: 0,
-        limit_usd_delta: 500,   // +$ к дневному лимиту
+        limit_usd_delta: 500,
+        code: 'invite_1_friend',
       },
     ];
 
-    const upsert = `
-      INSERT INTO quest_templates
-        (qkey, title, description, type, reward_usd, reward_vop, limit_usd_delta, code)
-      VALUES ($1,$2,$3,$4,$5,$6,$7,$1)
-      ON CONFLICT (qkey) DO UPDATE SET
-        title = EXCLUDED.title,
-        description = EXCLUDED.description,
-        type = EXCLUDED.type,
-        reward_usd = EXCLUDED.reward_usd,
-        reward_vop = EXCLUDED.reward_vop,
-        limit_usd_delta = EXCLUDED.limit_usd_delta,
-        code = EXCLUDED.code;
-    `;
+    const UPSERT = `
+INSERT INTO quest_templates
+(qkey, title, description, type, scope, reward_usd, reward_vop, limit_usd_delta, code)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+ON CONFLICT (qkey) DO UPDATE SET
+  title = EXCLUDED.title,
+  description = EXCLUDED.description,
+  type = EXCLUDED.type,
+  scope = EXCLUDED.scope,
+  reward_usd = EXCLUDED.reward_usd,
+  reward_vop = EXCLUDED.reward_vop,
+  limit_usd_delta = EXCLUDED.limit_usd_delta,
+  code = EXCLUDED.code;
+`;
 
+    let count = 0;
     for (const t of templates) {
-      // защита от случайных undefined
-      await client.query(upsert, [
-        t.qkey,
-        t.title,
-        t.description ?? '',
-        t.type ?? 'daily',
-        t.reward_usd ?? 0,
-        t.reward_vop ?? 0,
-        t.limit_usd_delta ?? 0,
+      const qkey = String(t.qkey || '').toLowerCase();
+      const scope = t.scope || 'user';
+      const desc = t.description || '';
+      await client.query(UPSERT, [
+        qkey, t.title, desc, t.type, scope,
+        t.reward_usd|0, t.reward_vop|0, t.limit_usd_delta|0,
+        t.code || qkey.split(':')[1] || null,
       ]);
+      count++;
     }
 
     await client.query('COMMIT');
+    console.log(`[seed] quest_templates upserted: ${count}`);
+    return count;
   } catch (e) {
     await client.query('ROLLBACK');
     throw e;


### PR DESCRIPTION
## Summary
- add idempotent migration to normalize `quest_templates`
- seed quest templates with scope and lowercase qkeys; log upserts
- run migrations before seeding with clear startup logging
- add smoke test for quest templates

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `node scripts/smoke-quests.mjs` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68ba77c0bd78832880df4d829910f025