### PR TITLE
chore: normalize quest template seeding

### DIFF
--- a/server/migrations/015_normalize_quest_templates_descr.sql
+++ b/server/migrations/015_normalize_quest_templates_descr.sql
@@ -1,0 +1,69 @@
+-- 015_normalize_quest_templates_descr.sql
+
+DO $$
+BEGIN
+  -- Если осталась старая колонка `descr`:
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='quest_templates' AND column_name='descr'
+  ) THEN
+    -- Если новой `description` ещё нет — просто переименуем
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='quest_templates' AND column_name='description'
+    ) THEN
+      ALTER TABLE quest_templates RENAME COLUMN descr TO description;
+    ELSE
+      -- Иначе перенесём данные и удалим старую
+      ALTER TABLE quest_templates ALTER COLUMN descr DROP NOT NULL;
+      UPDATE quest_templates
+         SET description = COALESCE(description, descr)
+       WHERE descr IS NOT NULL;
+      ALTER TABLE quest_templates DROP COLUMN descr;
+    END IF;
+  END IF;
+
+  -- Гарантируем, что `description` есть и не NULL
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='quest_templates' AND column_name='description'
+  ) THEN
+    ALTER TABLE quest_templates ADD COLUMN description TEXT;
+  END IF;
+
+  -- Заполним пустоты и зададим дефолт
+  UPDATE quest_templates SET description = '' WHERE description IS NULL;
+  ALTER TABLE quest_templates ALTER COLUMN description SET DEFAULT '';
+
+  -- Остальные поля тоже добьём (на случай старых баз)
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='quest_templates' AND column_name='scope'
+  ) THEN
+    ALTER TABLE quest_templates ADD COLUMN scope TEXT;
+  END IF;
+  UPDATE quest_templates SET scope = 'user' WHERE scope IS NULL;
+  ALTER TABLE quest_templates ALTER COLUMN scope SET DEFAULT 'user';
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='quest_templates' AND column_name='code'
+  ) THEN
+    ALTER TABLE quest_templates ADD COLUMN code TEXT;
+  END IF;
+
+  -- Единый уникальный ключ по qkey
+  DO $uniq$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1 FROM pg_indexes WHERE schemaname='public'
+        AND indexname='idx_quest_templates_qkey_unique'
+    ) THEN
+      CREATE UNIQUE INDEX idx_quest_templates_qkey_unique
+        ON quest_templates (qkey);
+    END IF;
+  END
+  $uniq$;
+
+END
+$$;

--- a/server/utils/seed.js
+++ b/server/utils/seed.js
@@ -3,77 +3,72 @@ export async function seedQuestTemplates(pool) {
   try {
     await client.query('BEGIN');
 
+    const tpl = ({ qkey, title, type, reward_usd, limit_usd_delta = 0, scope = 'user', description = '' }) => ({
+      qkey: qkey.toLowerCase(),
+      title,
+      type,
+      reward_usd,
+      limit_usd_delta,
+      scope,
+      description,
+    });
+
     const templates = [
-      {
+      tpl({
         qkey: 'daily:arena_10_wins',
         title: 'Выиграй 10 раз на арене',
         description: 'Победи 10 раз за сутки на арене',
         type: 'daily',
-        scope: 'user',
         reward_usd: 1000,
-        reward_vop: 0,
         limit_usd_delta: 500,
-        code: 'arena_10_wins',
-      },
-      {
+      }),
+      tpl({
         qkey: 'daily:place_100_bets',
         title: 'Сделай 100 ставок',
         description: 'Любые ставки в любом режиме за сутки',
         type: 'daily',
-        scope: 'user',
         reward_usd: 800,
-        reward_vop: 0,
         limit_usd_delta: 500,
-        code: 'place_100_bets',
-      },
-      {
+      }),
+      tpl({
         qkey: 'oneoff:subscribe_channel',
         title: 'Подписка на канал',
         description: 'Подпишись на @erc20coin',
         type: 'oneoff',
-        scope: 'user',
         reward_usd: 30000,
-        reward_vop: 0,
         limit_usd_delta: 0,
-        code: 'subscribe_channel',
-      },
-      {
+      }),
+      tpl({
         qkey: 'daily:invite_1_friend',
         title: 'Пригласи 1 друга',
         description: 'Друг должен зайти в игру',
         type: 'daily',
-        scope: 'user',
         reward_usd: 500,
-        reward_vop: 0,
         limit_usd_delta: 500,
-        code: 'invite_1_friend',
-      },
+      }),
     ];
 
     const UPSERT = `
-INSERT INTO quest_templates
-(qkey, title, description, type, scope, reward_usd, reward_vop, limit_usd_delta, code)
-VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
-ON CONFLICT (qkey) DO UPDATE SET
-  title = EXCLUDED.title,
-  description = EXCLUDED.description,
-  type = EXCLUDED.type,
-  scope = EXCLUDED.scope,
-  reward_usd = EXCLUDED.reward_usd,
-  reward_vop = EXCLUDED.reward_vop,
-  limit_usd_delta = EXCLUDED.limit_usd_delta,
-  code = EXCLUDED.code;
-`;
+INSERT INTO quest_templates (qkey, title, type, reward_usd, limit_usd_delta, scope, description)
+VALUES ($1,$2,$3,$4,$5,$6,$7)
+ON CONFLICT (qkey) DO UPDATE
+SET title=EXCLUDED.title,
+    type=EXCLUDED.type,
+    reward_usd=EXCLUDED.reward_usd,
+    limit_usd_delta=EXCLUDED.limit_usd_delta,
+    scope=EXCLUDED.scope,
+    description=EXCLUDED.description;`;
 
     let count = 0;
     for (const t of templates) {
-      const qkey = String(t.qkey || '').toLowerCase();
-      const scope = t.scope || 'user';
-      const desc = t.description || '';
       await client.query(UPSERT, [
-        qkey, t.title, desc, t.type, scope,
-        t.reward_usd|0, t.reward_vop|0, t.limit_usd_delta|0,
-        t.code || qkey.split(':')[1] || null,
+        t.qkey,
+        t.title,
+        t.type,
+        t.reward_usd | 0,
+        t.limit_usd_delta | 0,
+        t.scope,
+        t.description,
       ]);
       count++;
     }


### PR DESCRIPTION
## Summary
- add idempotent migration to normalize quest template description column
- seed quest templates with normalized data defaults

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba7bc87b8083289346922436175279