### PR TITLE
fix: ensure quest goals are defaulted and seeded

### DIFF
--- a/server/migrations/016_fix_goal_default.sql
+++ b/server/migrations/016_fix_goal_default.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+-- временно позволим NULL, чтобы обновить старые строки
+ALTER TABLE quest_templates
+  ALTER COLUMN goal DROP NOT NULL;
+
+-- проставим goal=1 там, где NULL
+UPDATE quest_templates
+SET goal = 1
+WHERE goal IS NULL;
+
+-- зафиксируем дефолт и вернём NOT NULL
+ALTER TABLE quest_templates
+  ALTER COLUMN goal SET DEFAULT 1,
+  ALTER COLUMN goal SET NOT NULL;
+
+COMMIT;

--- a/server/server.js
+++ b/server/server.js
@@ -47,6 +47,12 @@ app.get('/v1/debug/time', async (_req, res) => {
   });
 });
 
+async function start() {
+  app.listen(PORT, '0.0.0.0', () => {
+    console.log(`[srv] listening on :${PORT} (UTC day ${utcDayKey()})`);
+  });
+}
+
 async function boot() {
   try {
     console.log('[migrations] start');
@@ -65,11 +71,7 @@ async function boot() {
     process.exit(1);
   }
 
-  // ... тут ваши остальные роуты / логика ...
-
-  app.listen(PORT, '0.0.0.0', () => {
-    console.log(`[srv] listening on :${PORT} (UTC day ${utcDayKey()})`);
-  });
+  await start();
 }
 
 boot().catch((e) => {


### PR DESCRIPTION
## Summary
- add migration to backfill missing quest goals and set default
- normalize quest template seeding with explicit goal values and fallback
- start server only after migrations and seeding complete

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: ESLint couldn't find a config file)
- `node -e "import('./server/utils/seed.js').then(()=>console.log('loaded'))"`


------
https://chatgpt.com/codex/tasks/task_e_68ba8029c6088328823e613ef31929ba