### PR TITLE
Harden quest template schema and seeding

### DIFF
--- a/server/migrations/017_quest_templates_full_shape.sql
+++ b/server/migrations/017_quest_templates_full_shape.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+-- Базовые столбцы
+ALTER TABLE quest_templates
+  ADD COLUMN IF NOT EXISTS qkey        TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS title       TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS description TEXT NOT NULL DEFAULT '',
+  ADD COLUMN IF NOT EXISTS scope       TEXT NOT NULL DEFAULT 'user',
+  ADD COLUMN IF NOT EXISTS goal        INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS metric      TEXT NOT NULL DEFAULT 'count',
+  ADD COLUMN IF NOT EXISTS reward_usd  NUMERIC(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS reward_vop  INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS frequency   TEXT NOT NULL DEFAULT 'daily',
+  ADD COLUMN IF NOT EXISTS is_enabled  BOOLEAN NOT NULL DEFAULT TRUE,
+  ADD COLUMN IF NOT EXISTS expires_at  TIMESTAMPTZ;
+
+-- Ограничения-договённости
+ALTER TABLE quest_templates
+  ADD CONSTRAINT quest_templates_scope_chk    CHECK (scope IN ('user','global'))    NOT VALID;
+ALTER TABLE quest_templates
+  ADD CONSTRAINT quest_templates_metric_chk   CHECK (metric IN ('count','usd','vop')) NOT VALID;
+ALTER TABLE quest_templates
+  ADD CONSTRAINT quest_templates_frequency_chk CHECK (frequency IN ('once','daily','weekly')) NOT VALID;
+
+-- Уникальность по qkey
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+     WHERE tablename='quest_templates' AND indexname='uq_quest_templates_qkey'
+  ) THEN
+    CREATE UNIQUE INDEX uq_quest_templates_qkey ON quest_templates (qkey);
+  END IF;
+END $$;
+
+COMMIT;

--- a/server/migrations/018_backfill_goal.sql
+++ b/server/migrations/018_backfill_goal.sql
@@ -1,0 +1,5 @@
+BEGIN;
+ALTER TABLE quest_templates ALTER COLUMN goal DROP NOT NULL;
+UPDATE quest_templates SET goal = 1 WHERE goal IS NULL;
+ALTER TABLE quest_templates ALTER COLUMN goal SET NOT NULL;
+COMMIT;

--- a/server/server.js
+++ b/server/server.js
@@ -11,7 +11,7 @@ import pg from 'pg';
 const { Pool } = pg;
 
 import { utcDayKey } from './utils/time.js';
-import { seedQuestTemplates } from './utils/seed.js';
+import { seedQuestTemplates, assertQuestTemplateShape } from './utils/seed.js';
 import { runMigrations } from './migrate.js';
 
 // ===== Config =====
@@ -57,6 +57,7 @@ async function boot() {
   try {
     console.log('[migrations] start');
     await runMigrations(pool);
+    await assertQuestTemplateShape(pool);
     console.log('[migrations] done');
   } catch (e) {
     console.error('[migrations] failed', e);


### PR DESCRIPTION
## Summary
- add migration to enforce full quest_templates schema and indexes
- backfill any missing goal values
- refactor quest template seeder and check schema before seeding

## Testing
- `npm test` *(fails: command not found)*
- `npm run lint` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba82005e688328a69ea4f50b3c408a