### PR TITLE
Fix quest template merge migration

### DIFF
--- a/src/server/migrations/020_create_quest_templates_staging.sql
+++ b/src/server/migrations/020_create_quest_templates_staging.sql
@@ -2,7 +2,6 @@
 CREATE TABLE IF NOT EXISTS quest_templates_staging (
   code            TEXT NOT NULL,
   scope           TEXT NOT NULL,
-  frequency       TEXT,
   metric          TEXT NOT NULL,
   goal            INTEGER NOT NULL,
   title           TEXT NOT NULL,

--- a/src/server/migrations/021_normalize_staging.sql
+++ b/src/server/migrations/021_normalize_staging.sql
@@ -1,15 +1,5 @@
 -- 021_normalize_staging.sql
 UPDATE quest_templates_staging
-SET frequency = CASE lower(scope)
-  WHEN 'oneoff' THEN 'once'
-  WHEN 'one_time' THEN 'once'
-  WHEN 'once' THEN 'once'
-  WHEN 'daily' THEN 'daily'
-  WHEN 'weekly' THEN 'weekly'
-  ELSE 'once'
-END;
-
-UPDATE quest_templates_staging
 SET metric = CASE lower(metric)
   WHEN 'count' THEN 'count'
   WHEN 'usd' THEN 'usd'

--- a/src/server/migrations/023_merge_from_staging.sql
+++ b/src/server/migrations/023_merge_from_staging.sql
@@ -1,36 +1,36 @@
 -- 023_merge_from_staging.sql
--- Переносим данные из staging в боевую таблицу, маппим имена и типы.
--- Требования к целевой таблице: поля
--- code, frequency, metric, goal, title, description, reward_type, reward_value, cooldown_hours
 
-INSERT INTO quest_templates (
-  code,
-  frequency,
-  metric,
-  goal,
-  title,
-  description,
-  reward_type,
-  reward_value,
-  cooldown_hours
-)
+-- 1) Подготовка целевой таблицы: добавляем недостающие колонки с дефолтами
+ALTER TABLE quest_templates
+  ADD COLUMN IF NOT EXISTS active boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS type   text    NOT NULL DEFAULT 'system',
+  ADD COLUMN IF NOT EXISTS reward_type  text    NOT NULL DEFAULT 'USD',
+  ADD COLUMN IF NOT EXISTS reward_value integer NOT NULL DEFAULT 0;
+
+-- 2) Перенос из staging c явным маппингом полей
+INSERT INTO quest_templates
+  (code, scope, metric, goal, title, descr, reward_type, reward_value, cooldown_hours, active, type)
 SELECT
   s.code,
-  s.scope::text            AS frequency,      -- 'oneoff'/'daily'/'weekly' уже нормализованы на шаге 021
+  s.scope,
   s.metric,
   s.goal,
   s.title,
-  s.descr                  AS description,    -- staging.descr -> quest_templates.description
-  'USD'::text              AS reward_type,    -- у нас в staging только reward_usd
-  s.reward_usd::integer    AS reward_value,   -- не даём NULL, иначе NOT NULL нарушится
-  s.cooldown_hours::integer
+  s.descr,
+  'USD'::text               AS reward_type,   -- staging хранит reward_usd
+  s.reward_usd              AS reward_value,
+  s.cooldown_hours,
+  true                      AS active,
+  'system'::text            AS type
 FROM quest_templates_staging s
-ON CONFLICT (code) DO UPDATE SET
-  frequency      = EXCLUDED.frequency,
-  metric         = EXCLUDED.metric,
-  goal           = EXCLUDED.goal,
-  title          = EXCLUDED.title,
-  description    = EXCLUDED.description,
-  reward_type    = EXCLUDED.reward_type,
-  reward_value   = EXCLUDED.reward_value,
-  cooldown_hours = EXCLUDED.cooldown_hours;
+ON CONFLICT (code) DO UPDATE
+SET scope          = EXCLUDED.scope,
+    metric         = EXCLUDED.metric,
+    goal           = EXCLUDED.goal,
+    title          = EXCLUDED.title,
+    descr          = EXCLUDED.descr,
+    reward_type    = EXCLUDED.reward_type,
+    reward_value   = EXCLUDED.reward_value,
+    cooldown_hours = EXCLUDED.cooldown_hours,
+    active         = EXCLUDED.active,
+    type           = EXCLUDED.type;

--- a/src/server/migrations/024_validate_constraints.sql
+++ b/src/server/migrations/024_validate_constraints.sql
@@ -1,4 +1,3 @@
 -- 024_validate_constraints.sql
-ALTER TABLE quest_templates VALIDATE CONSTRAINT quest_templates_frequency_chk;
 ALTER TABLE quest_templates VALIDATE CONSTRAINT quest_templates_metric_chk;
 ALTER TABLE quest_templates VALIDATE CONSTRAINT quest_templates_reward_type_check;


### PR DESCRIPTION
## Summary
- update quest template staging schema to use canonical columns
- add merge migration that adds reward fields and active/type defaults
- drop obsolete constraint validation

## Testing
- `npm run db:test-migrations` *(fails: Missing DATABASE_URL or TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb431a41e4832896be1d8d968de45d