### PR TITLE
feat: update quest templates schema

### DIFF
--- a/scripts/quests.definitions.json
+++ b/scripts/quests.definitions.json
@@ -1,6 +1,5 @@
 [
   {
-    "qkey": "arena_bets_20",
     "code": "arena_bets_20",
     "title": "Сделай 20 ставок на Арене",
     "description": "",
@@ -13,7 +12,6 @@
     "meta": {}
   },
   {
-    "qkey": "classic_buys_100",
     "code": "classic_buys_100",
     "title": "Сделай 100 покупок в Классике",
     "description": "",
@@ -26,7 +24,6 @@
     "meta": {}
   },
   {
-    "qkey": "classic_sells_100",
     "code": "classic_sells_100",
     "title": "Сделай 100 продаж в Классике",
     "description": "",
@@ -39,7 +36,6 @@
     "meta": {}
   },
   {
-    "qkey": "arena_wins_10",
     "code": "arena_wins_10",
     "title": "Выиграй 10 раз на Арене",
     "description": "",
@@ -52,7 +48,6 @@
     "meta": {}
   },
   {
-    "qkey": "invite_3_friends",
     "code": "invite_3_friends",
     "title": "Пригласи 3 друзей",
     "description": "",
@@ -65,7 +60,6 @@
     "meta": {}
   },
   {
-    "qkey": "refresh_round_by_1_friend",
     "code": "refresh_round_by_1_friend",
     "title": "Обнови раунд другом",
     "description": "",
@@ -78,7 +72,6 @@
     "meta": {}
   },
   {
-    "qkey": "daily_login",
     "code": "daily_login",
     "title": "Зайди в игру",
     "description": "",
@@ -91,7 +84,6 @@
     "meta": {}
   },
   {
-    "qkey": "subscribe_channel",
     "code": "subscribe_channel",
     "title": "Подпишись на канал",
     "description": "",

--- a/scripts/seed-quests.js
+++ b/scripts/seed-quests.js
@@ -38,7 +38,7 @@ export async function seedQuests(pool) {
     await client.query('BEGIN');
     for (const q of quests) {
       const scope = normalizeScope(q.scope);
-      const code = q.code || q.qkey;
+      const code = q.code;
       await client.query(
         `INSERT INTO quest_templates_staging
          (code, scope, metric, goal, title, descr, reward_usd, cooldown_hours)

--- a/src/server/migrations/006_quest_templates_v3.sql
+++ b/src/server/migrations/006_quest_templates_v3.sql
@@ -1,11 +1,14 @@
 -- remove legacy scope constraint so backfills won't fail
 ALTER TABLE IF EXISTS quest_templates
-  DROP CONSTRAINT IF EXISTS quest_templates_scope_chk;
+  DROP CONSTRAINT IF EXISTS quest_templates_scope_chk,
+  DROP CONSTRAINT IF EXISTS quest_templates_scope_check,
+  DROP CONSTRAINT IF EXISTS quest_templates_frequency_chk,
+  DROP CONSTRAINT IF EXISTS quest_templates_frequency_check;
 
 -- create if missing
 CREATE TABLE IF NOT EXISTS quest_templates (
   id BIGSERIAL PRIMARY KEY,
-  qkey TEXT UNIQUE NOT NULL,                 -- наш стабильный ключ
+  code TEXT UNIQUE NOT NULL,
   title TEXT NOT NULL,
   description TEXT NOT NULL DEFAULT '',
   type TEXT NOT NULL CHECK (type IN ('daily','weekly','oneoff')),
@@ -17,26 +20,23 @@ CREATE TABLE IF NOT EXISTS quest_templates (
 
 -- апгрейд существующей таблицы под текущую модель (идемпотентно)
 ALTER TABLE quest_templates
-  ADD COLUMN IF NOT EXISTS qkey TEXT,
+  ADD COLUMN IF NOT EXISTS code TEXT,
   ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '',
   ADD COLUMN IF NOT EXISTS reward_vop INTEGER DEFAULT 0,
   ADD COLUMN IF NOT EXISTS limit_usd_delta INTEGER DEFAULT 0,
   ADD COLUMN IF NOT EXISTS type TEXT;
 
--- keep legacy column `code` for backward compatibility
-ALTER TABLE quest_templates ADD COLUMN IF NOT EXISTS code TEXT;
-
 -- ensure critical columns are NOT NULL
 ALTER TABLE quest_templates
-  ALTER COLUMN qkey SET NOT NULL,
+  ALTER COLUMN code SET NOT NULL,
   ALTER COLUMN description SET NOT NULL,
   ALTER COLUMN type SET NOT NULL;
 
 DO $$
 BEGIN
   IF NOT EXISTS (
-    SELECT 1 FROM pg_constraint WHERE conname='quest_templates_qkey_key'
+    SELECT 1 FROM pg_constraint WHERE conname='quest_templates_code_key'
   ) THEN
-    ALTER TABLE quest_templates ADD CONSTRAINT quest_templates_qkey_key UNIQUE (qkey);
+    ALTER TABLE quest_templates ADD CONSTRAINT quest_templates_code_key UNIQUE (code);
   END IF;
 END $$;

--- a/src/server/migrations/014_fix_quest_templates.sql
+++ b/src/server/migrations/014_fix_quest_templates.sql
@@ -1,38 +1,19 @@
 -- 014_fix_quest_templates.sql
 
 -- 1. Добавляем отсутствующие столбцы, безопасно
-ALTER TABLE quest_templates
-  ADD COLUMN IF NOT EXISTS description TEXT,
-  ADD COLUMN IF NOT EXISTS scope TEXT,
-  ADD COLUMN IF NOT EXISTS code TEXT;
+  ALTER TABLE quest_templates
+    ADD COLUMN IF NOT EXISTS description TEXT,
+    ADD COLUMN IF NOT EXISTS frequency TEXT,
+    ADD COLUMN IF NOT EXISTS code TEXT;
 
 -- 2. Дефолты и NOT NULL
-ALTER TABLE quest_templates
-  ALTER COLUMN description SET DEFAULT '',
-  ALTER COLUMN scope SET DEFAULT 'user';
+  ALTER TABLE quest_templates
+    ALTER COLUMN description SET DEFAULT '',
+    ALTER COLUMN frequency SET DEFAULT 'user';
 
-UPDATE quest_templates SET description = '' WHERE description IS NULL;
-UPDATE quest_templates SET scope       = 'user' WHERE scope IS NULL;
+  UPDATE quest_templates SET description = '' WHERE description IS NULL;
+  UPDATE quest_templates SET frequency   = 'user' WHERE frequency IS NULL;
 
--- 3. Гарантируем qkey: unique, нижний регистр
--- если qkey пуст — собираем из type/code или из title
-UPDATE quest_templates
-SET qkey = LOWER(
-  COALESCE(qkey,
-           CASE
-             WHEN code IS NOT NULL AND code <> '' THEN CONCAT(type, ':', code)
-             ELSE CONCAT(type, ':', REGEXP_REPLACE(LOWER(title), '\\s+', '_', 'g'))
-           END))
-WHERE qkey IS NULL OR qkey = '';
-
--- 4. Индекс по qkey
-DO $$
-BEGIN
-  IF NOT EXISTS (
-    SELECT 1 FROM pg_indexes
-     WHERE schemaname = 'public' AND indexname = 'idx_quest_templates_qkey_unique'
-  ) THEN
-    CREATE UNIQUE INDEX idx_quest_templates_qkey_unique
-      ON quest_templates (qkey);
-  END IF;
-END $$;
+-- 3. Уникальность кода
+CREATE UNIQUE INDEX IF NOT EXISTS idx_quest_templates_code_unique
+  ON quest_templates (code);

--- a/src/server/migrations/015_normalize_quest_templates_descr.sql
+++ b/src/server/migrations/015_normalize_quest_templates_descr.sql
@@ -36,14 +36,14 @@ BEGIN
   ALTER TABLE quest_templates ALTER COLUMN description SET DEFAULT '';
 
   -- Остальные поля тоже добьём (на случай старых баз)
-  IF NOT EXISTS (
-    SELECT 1 FROM information_schema.columns
-    WHERE table_name='quest_templates' AND column_name='scope'
-  ) THEN
-    ALTER TABLE quest_templates ADD COLUMN scope TEXT;
-  END IF;
-  UPDATE quest_templates SET scope = 'user' WHERE scope IS NULL;
-  ALTER TABLE quest_templates ALTER COLUMN scope SET DEFAULT 'user';
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='quest_templates' AND column_name='frequency'
+    ) THEN
+      ALTER TABLE quest_templates ADD COLUMN frequency TEXT;
+    END IF;
+    UPDATE quest_templates SET frequency = 'user' WHERE frequency IS NULL;
+    ALTER TABLE quest_templates ALTER COLUMN frequency SET DEFAULT 'user';
 
   IF NOT EXISTS (
     SELECT 1 FROM information_schema.columns
@@ -52,18 +52,7 @@ BEGIN
     ALTER TABLE quest_templates ADD COLUMN code TEXT;
   END IF;
 
-  -- Единый уникальный ключ по qkey
-  DO $uniq$
-  BEGIN
-    IF NOT EXISTS (
-      SELECT 1 FROM pg_indexes WHERE schemaname='public'
-        AND indexname='idx_quest_templates_qkey_unique'
-    ) THEN
-      CREATE UNIQUE INDEX idx_quest_templates_qkey_unique
-        ON quest_templates (qkey);
-    END IF;
-  END
-  $uniq$;
+
 
 END
 $$;

--- a/src/server/migrations/017_drop_scope_check.sql
+++ b/src/server/migrations/017_drop_scope_check.sql
@@ -1,1 +1,4 @@
 ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_scope_chk;
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_scope_check;
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_frequency_chk;
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_frequency_check;

--- a/src/server/migrations/020_create_quest_templates_staging.sql
+++ b/src/server/migrations/020_create_quest_templates_staging.sql
@@ -7,6 +7,8 @@ CREATE TABLE IF NOT EXISTS quest_templates_staging (
   title           TEXT NOT NULL,
   descr           TEXT NOT NULL,
   reward_usd      INTEGER NOT NULL,
-  cooldown_hours  INTEGER NOT NULL,
-  CONSTRAINT quest_templates_staging_code_key UNIQUE (code)
+  cooldown_hours  INTEGER NOT NULL
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS quest_templates_staging_code_idx
+  ON quest_templates_staging(code);

--- a/src/server/migrations/021_drop_scope_check_if_exists.sql
+++ b/src/server/migrations/021_drop_scope_check_if_exists.sql
@@ -1,0 +1,5 @@
+-- 021_drop_scope_check_if_exists.sql
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_scope_check;
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_scope_chk;
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_frequency_check;
+ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_frequency_chk;

--- a/src/server/migrations/021_normalize_staging.sql
+++ b/src/server/migrations/021_normalize_staging.sql
@@ -1,8 +1,0 @@
--- 021_normalize_staging.sql
-UPDATE quest_templates_staging
-SET metric = CASE lower(metric)
-  WHEN 'count' THEN 'count'
-  WHEN 'usd' THEN 'usd'
-  WHEN 'vop' THEN 'vop'
-  ELSE 'count'
-END;

--- a/src/server/migrations/022_ensure_unique_code.sql
+++ b/src/server/migrations/022_ensure_unique_code.sql
@@ -1,8 +1,0 @@
--- 022_ensure_unique_code.sql
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='quest_templates_code_key') THEN
-    ALTER TABLE quest_templates
-      ADD CONSTRAINT quest_templates_code_key UNIQUE (code);
-  END IF;
-END $$;

--- a/src/server/migrations/022_seed_staging.sql
+++ b/src/server/migrations/022_seed_staging.sql
@@ -1,0 +1,9 @@
+-- 022_seed_staging.sql
+-- ВСТАВЛЯТЬ ТОЛЬКО В STAGING!
+-- Пример — замени на свои записи
+INSERT INTO quest_templates_staging (code, scope, metric, goal, title, descr, reward_usd, cooldown_hours) VALUES
+('JOIN_TG',      'oneoff', 'count', 1,   'Join our TG',      'user joins telegram', 200, 0),
+('CLASSIC_10',   'daily',  'count', 10,  'Classic 10',       'make 10 classic bets', 50,  0),
+('ARENA_5',      'daily',  'count', 5,   'Arena 5',          '5 arena bids',         75,  0),
+('INVITE_1',     'oneoff', 'count', 1,   'Invite a friend',  'bring a friend',       100, 0)
+ON CONFLICT (code) DO NOTHING;

--- a/src/server/migrations/023_merge_from_staging.sql
+++ b/src/server/migrations/023_merge_from_staging.sql
@@ -1,36 +1,100 @@
 -- 023_merge_from_staging.sql
 
--- 1) Подготовка целевой таблицы: добавляем недостающие колонки с дефолтами
-ALTER TABLE quest_templates
-  ADD COLUMN IF NOT EXISTS active boolean NOT NULL DEFAULT true,
-  ADD COLUMN IF NOT EXISTS type   text    NOT NULL DEFAULT 'system',
-  ADD COLUMN IF NOT EXISTS reward_type  text    NOT NULL DEFAULT 'USD',
-  ADD COLUMN IF NOT EXISTS reward_value integer NOT NULL DEFAULT 0;
+-- Приводим целевую таблицу к минимально нужной схеме (безопасно)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='description') THEN
+    ALTER TABLE quest_templates ADD COLUMN description TEXT;
+  END IF;
 
--- 2) Перенос из staging c явным маппингом полей
-INSERT INTO quest_templates
-  (code, scope, metric, goal, title, descr, reward_type, reward_value, cooldown_hours, active, type)
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='type') THEN
+    ALTER TABLE quest_templates ADD COLUMN type TEXT NOT NULL DEFAULT 'oneoff';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='active') THEN
+    ALTER TABLE quest_templates ADD COLUMN active BOOLEAN NOT NULL DEFAULT TRUE;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='reward_type') THEN
+    ALTER TABLE quest_templates ADD COLUMN reward_type TEXT NOT NULL DEFAULT 'USD';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='reward_value') THEN
+    ALTER TABLE quest_templates ADD COLUMN reward_value INTEGER NOT NULL DEFAULT 0;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='frequency') THEN
+    ALTER TABLE quest_templates ADD COLUMN frequency TEXT NOT NULL DEFAULT 'once';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
+                 WHERE table_name='quest_templates' AND column_name='cooldown_hours') THEN
+    ALTER TABLE quest_templates ADD COLUMN cooldown_hours INTEGER NOT NULL DEFAULT 0;
+  END IF;
+END $$;
+
+-- Уникальность кода (если ещё нет)
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='quest_templates_code_uniq') THEN
+    ALTER TABLE quest_templates ADD CONSTRAINT quest_templates_code_uniq UNIQUE (code);
+  END IF;
+END $$;
+
+-- Нормализация значений в staging перед мёрджем
+UPDATE quest_templates_staging
+   SET scope = CASE scope WHEN 'oneoff' THEN 'once' ELSE scope END;
+
+-- Собственно мёрдж (апсерт)
+INSERT INTO quest_templates (
+  code, title, description, metric, goal,
+  reward_type, reward_value, frequency, cooldown_hours,
+  active, type
+)
 SELECT
   s.code,
-  s.scope,
-  s.metric,
-  s.goal,
   s.title,
   s.descr,
-  'USD'::text               AS reward_type,   -- staging хранит reward_usd
-  s.reward_usd              AS reward_value,
-  s.cooldown_hours,
-  true                      AS active,
-  'system'::text            AS type
+  s.metric,
+  s.goal,
+  'USD'::text,
+  COALESCE(s.reward_usd, 0),
+  s.scope,
+  COALESCE(s.cooldown_hours, 0),
+  TRUE,
+  CASE WHEN s.scope = 'once' THEN 'oneoff' ELSE 'recurring' END
 FROM quest_templates_staging s
-ON CONFLICT (code) DO UPDATE
-SET scope          = EXCLUDED.scope,
-    metric         = EXCLUDED.metric,
-    goal           = EXCLUDED.goal,
-    title          = EXCLUDED.title,
-    descr          = EXCLUDED.descr,
-    reward_type    = EXCLUDED.reward_type,
-    reward_value   = EXCLUDED.reward_value,
-    cooldown_hours = EXCLUDED.cooldown_hours,
-    active         = EXCLUDED.active,
-    type           = EXCLUDED.type;
+ON CONFLICT (code) DO UPDATE SET
+  title          = EXCLUDED.title,
+  description    = EXCLUDED.description,
+  metric         = EXCLUDED.metric,
+  goal           = EXCLUDED.goal,
+  reward_type    = EXCLUDED.reward_type,
+  reward_value   = EXCLUDED.reward_value,
+  frequency      = EXCLUDED.frequency,
+  cooldown_hours = EXCLUDED.cooldown_hours,
+  active         = EXCLUDED.active,
+  type           = EXCLUDED.type;
+
+-- Удаляем устаревшие колонки, если они остались
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='scope') THEN
+    ALTER TABLE quest_templates DROP COLUMN scope;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='reward_usd') THEN
+    ALTER TABLE quest_templates DROP COLUMN reward_usd;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='qkey') THEN
+    ALTER TABLE quest_templates DROP COLUMN qkey;
+  END IF;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='descr') THEN
+    ALTER TABLE quest_templates DROP COLUMN descr;
+  END IF;
+END $$;

--- a/src/server/migrations/024_reinstate_frequency_check.sql
+++ b/src/server/migrations/024_reinstate_frequency_check.sql
@@ -1,0 +1,9 @@
+-- 024_reinstate_frequency_check.sql
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='quest_templates_frequency_chk') THEN
+    ALTER TABLE quest_templates
+      ADD CONSTRAINT quest_templates_frequency_chk
+      CHECK (frequency = ANY (ARRAY['once','daily','weekly']::text[]));
+  END IF;
+END $$;

--- a/src/server/migrations/024_validate_constraints.sql
+++ b/src/server/migrations/024_validate_constraints.sql
@@ -1,3 +1,0 @@
--- 024_validate_constraints.sql
-ALTER TABLE quest_templates VALIDATE CONSTRAINT quest_templates_metric_chk;
-ALTER TABLE quest_templates VALIDATE CONSTRAINT quest_templates_reward_type_check;

--- a/src/server/migrations/025_cleanup_staging.sql
+++ b/src/server/migrations/025_cleanup_staging.sql
@@ -1,2 +1,2 @@
 -- 025_cleanup_staging.sql
-TRUNCATE TABLE IF EXISTS quest_templates_staging;
+DROP TABLE IF EXISTS quest_templates_staging;

--- a/src/server/scripts/smoke-quests.mjs
+++ b/src/server/scripts/smoke-quests.mjs
@@ -12,15 +12,15 @@ async function main() {
     const countRes = await client.query('SELECT COUNT(*)::int AS cnt FROM quest_templates');
     console.log('[smoke] quest_templates count:', countRes.rows[0]?.cnt);
 
-    const dupRes = await client.query(`SELECT qkey, COUNT(*) AS c FROM quest_templates GROUP BY qkey HAVING COUNT(*) > 1`);
-    if (dupRes.rows.length > 0) {
-      throw new Error('duplicate qkey: ' + JSON.stringify(dupRes.rows));
-    }
+      const dupRes = await client.query(`SELECT code, COUNT(*) AS c FROM quest_templates GROUP BY code HAVING COUNT(*) > 1`);
+      if (dupRes.rows.length > 0) {
+        throw new Error('duplicate code: ' + JSON.stringify(dupRes.rows));
+      }
 
-    const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR scope IS NULL`);
-    if (nullRes.rows[0]?.cnt > 0) {
-      throw new Error('NULL description/scope rows: ' + nullRes.rows[0].cnt);
-    }
+      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR frequency IS NULL`);
+      if (nullRes.rows[0]?.cnt > 0) {
+        throw new Error('NULL description/frequency rows: ' + nullRes.rows[0].cnt);
+      }
 
     console.log('[smoke] ok');
   } finally {

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -66,8 +66,8 @@ app.get('/admin/db/health', async (req, res) => {
       JOIN pg_class t ON c.conrelid = t.oid
       WHERE t.relname = 'quest_templates';
     `);
-    const scopes = await client.query(`SELECT DISTINCT scope FROM quest_templates ORDER BY scope`);
-    res.json({ tables: tables.rows[0], constraints: constraints.rows, scopes: scopes.rows.map(r => r.scope) });
+      const frequencies = await client.query(`SELECT DISTINCT frequency FROM quest_templates ORDER BY frequency`);
+      res.json({ tables: tables.rows[0], constraints: constraints.rows, frequencies: frequencies.rows.map(r => r.frequency) });
   } finally {
     client.release();
   }


### PR DESCRIPTION
## Summary
- overhaul quest template migrations with frequency and reward mapping
- remove legacy qkey usage and align server code with new schema
- seed staging table and reinstate frequency checks

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run db:test-migrations` *(fails: Missing DATABASE_URL or TEST_DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4b8d456083288f1331d6667560fd