### PR TITLE
Handle optional WebSocket dependency in price feed modules

### DIFF
--- a/src/server/priceFeed/legacy.js
+++ b/src/server/priceFeed/legacy.js
@@ -1,5 +1,11 @@
-import WebSocket from 'ws';
+import { createRequire } from 'module';
 import EventEmitter from 'events';
+
+const require = createRequire(import.meta.url);
+let WebSocket = globalThis.WebSocket;
+try {
+  if (!WebSocket) WebSocket = require('ws');
+} catch {}
 
 export function createLegacyFeed(){
   const emitter = new EventEmitter();

--- a/src/server/priceFeed/providers/binance.js
+++ b/src/server/priceFeed/providers/binance.js
@@ -1,4 +1,10 @@
-import WebSocket from 'ws';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+let WebSocket = globalThis.WebSocket;
+try {
+  if (!WebSocket) WebSocket = require('ws');
+} catch {}
 
 export const name = 'binance';
 export const symbol = process.env.PRICE_SYMBOL_BINANCE || 'BTCUSDT';

--- a/src/server/priceFeed/providers/bitstamp.js
+++ b/src/server/priceFeed/providers/bitstamp.js
@@ -1,4 +1,10 @@
-import WebSocket from 'ws';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+let WebSocket = globalThis.WebSocket;
+try {
+  if (!WebSocket) WebSocket = require('ws');
+} catch {}
 
 export const name = 'bitstamp';
 export const symbol = process.env.PRICE_SYMBOL_BITSTAMP || 'btcusd';

--- a/src/server/priceFeed/providers/coinbase.js
+++ b/src/server/priceFeed/providers/coinbase.js
@@ -1,4 +1,10 @@
-import WebSocket from 'ws';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+let WebSocket = globalThis.WebSocket;
+try {
+  if (!WebSocket) WebSocket = require('ws');
+} catch {}
 
 export const name = 'coinbase';
 export const symbol = process.env.PRICE_SYMBOL_COINBASE || 'BTC-USD';


### PR DESCRIPTION
## Summary
- avoid hard dependency on `ws` by lazily requiring it in price feed providers and legacy feed

## Testing
- `node --test`
- `npm run build` *(fails: error TS5083: Cannot read file '/workspace/btc-game-mvp/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f5cea188328aee7c1886faefff4