### PR TITLE
Fix quest templates migrations

### DIFF
--- a/src/server/migrations/021_drop_scope_check_if_exists.sql
+++ b/src/server/migrations/021_drop_scope_check_if_exists.sql
@@ -1,5 +1,0 @@
--- 021_drop_scope_check_if_exists.sql
-ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_scope_check;
-ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_scope_chk;
-ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_frequency_check;
-ALTER TABLE quest_templates DROP CONSTRAINT IF EXISTS quest_templates_frequency_chk;

--- a/src/server/migrations/021_normalize_staging.sql
+++ b/src/server/migrations/021_normalize_staging.sql
@@ -1,0 +1,4 @@
+-- 021_normalize_staging.sql
+-- Normalize scope values in staging table to match production enum
+UPDATE quest_templates_staging
+   SET scope = CASE scope WHEN 'oneoff' THEN 'once' ELSE scope END;

--- a/src/server/migrations/021b_drop_qkey_triggers.sql
+++ b/src/server/migrations/021b_drop_qkey_triggers.sql
@@ -1,0 +1,19 @@
+-- 021b_drop_qkey_triggers.sql
+DO $$
+DECLARE
+  r RECORD;
+BEGIN
+  FOR r IN
+    SELECT tg.tgname,
+           tg.tgrelid::regclass AS tbl,
+           p.oid::regprocedure AS proc_regproc
+    FROM pg_trigger tg
+    JOIN pg_proc p ON p.oid = tg.tgfoid
+    WHERE tg.tgrelid = 'public.quest_templates'::regclass
+      AND NOT tg.tgisinternal
+      AND pg_get_functiondef(p.oid) ILIKE '%qkey%'
+  LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON %s;', r.tgname, r.tbl);
+    EXECUTE format('DROP FUNCTION IF EXISTS %s;', r.proc_regproc);
+  END LOOP;
+END $$;

--- a/src/server/migrations/023_merge_from_staging.sql
+++ b/src/server/migrations/023_merge_from_staging.sql
@@ -1,45 +1,41 @@
 -- 023_merge_from_staging.sql
 
--- Приводим целевую таблицу к минимально нужной схеме (безопасно)
+-- Ensure quest_templates has required columns
 DO $$
 BEGIN
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='description') THEN
-    ALTER TABLE quest_templates ADD COLUMN description TEXT;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='scope') THEN
+    ALTER TABLE quest_templates ADD COLUMN scope TEXT NOT NULL DEFAULT 'once';
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='type') THEN
-    ALTER TABLE quest_templates ADD COLUMN type TEXT NOT NULL DEFAULT 'oneoff';
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='metric') THEN
+    ALTER TABLE quest_templates ADD COLUMN metric TEXT NOT NULL DEFAULT 'count';
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='active') THEN
-    ALTER TABLE quest_templates ADD COLUMN active BOOLEAN NOT NULL DEFAULT TRUE;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='type') THEN
+    ALTER TABLE quest_templates ADD COLUMN type TEXT NOT NULL DEFAULT 'count';
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='reward_type') THEN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='title') THEN
+    ALTER TABLE quest_templates ADD COLUMN title TEXT NOT NULL DEFAULT '';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='description') THEN
+    ALTER TABLE quest_templates ADD COLUMN description TEXT NOT NULL DEFAULT '';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='reward_type') THEN
     ALTER TABLE quest_templates ADD COLUMN reward_type TEXT NOT NULL DEFAULT 'USD';
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='reward_value') THEN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='reward_value') THEN
     ALTER TABLE quest_templates ADD COLUMN reward_value INTEGER NOT NULL DEFAULT 0;
   END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='frequency') THEN
-    ALTER TABLE quest_templates ADD COLUMN frequency TEXT NOT NULL DEFAULT 'once';
-  END IF;
-
-  IF NOT EXISTS (SELECT 1 FROM information_schema.columns
-                 WHERE table_name='quest_templates' AND column_name='cooldown_hours') THEN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='cooldown_hours') THEN
     ALTER TABLE quest_templates ADD COLUMN cooldown_hours INTEGER NOT NULL DEFAULT 0;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='active') THEN
+    ALTER TABLE quest_templates ADD COLUMN active BOOLEAN NOT NULL DEFAULT TRUE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='updated_at') THEN
+    ALTER TABLE quest_templates ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
   END IF;
 END $$;
 
--- Уникальность кода (если ещё нет)
+-- Ensure unique constraint on code
 DO $$
 BEGIN
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='quest_templates_code_uniq') THEN
@@ -47,54 +43,43 @@ BEGIN
   END IF;
 END $$;
 
--- Нормализация значений в staging перед мёрджем
-UPDATE quest_templates_staging
-   SET scope = CASE scope WHEN 'oneoff' THEN 'once' ELSE scope END;
-
--- Собственно мёрдж (апсерт)
-INSERT INTO quest_templates (
-  code, title, description, metric, goal,
-  reward_type, reward_value, frequency, cooldown_hours,
-  active, type
-)
+-- Merge from staging
+INSERT INTO quest_templates
+  (code, scope, metric, type, title, description,
+   reward_type, reward_value, cooldown_hours, active, updated_at)
 SELECT
   s.code,
-  s.title,
-  s.descr,
+  CASE WHEN s.scope = 'oneoff' THEN 'once' ELSE s.scope END AS scope,
   s.metric,
-  s.goal,
-  'USD'::text,
-  COALESCE(s.reward_usd, 0),
-  s.scope,
-  COALESCE(s.cooldown_hours, 0),
-  TRUE,
-  CASE WHEN s.scope = 'once' THEN 'oneoff' ELSE 'recurring' END
+  s.metric AS type,
+  s.title,
+  s.descr AS description,
+  'USD'        AS reward_type,
+  s.reward_usd AS reward_value,
+  s.cooldown_hours,
+  TRUE         AS active,
+  NOW()        AS updated_at
 FROM quest_templates_staging s
-ON CONFLICT (code) DO UPDATE SET
+ON CONFLICT (code)
+DO UPDATE SET
+  scope          = EXCLUDED.scope,
+  metric         = EXCLUDED.metric,
+  type           = EXCLUDED.type,
   title          = EXCLUDED.title,
   description    = EXCLUDED.description,
-  metric         = EXCLUDED.metric,
-  goal           = EXCLUDED.goal,
   reward_type    = EXCLUDED.reward_type,
   reward_value   = EXCLUDED.reward_value,
-  frequency      = EXCLUDED.frequency,
   cooldown_hours = EXCLUDED.cooldown_hours,
-  active         = EXCLUDED.active,
-  type           = EXCLUDED.type;
+  active         = TRUE,
+  updated_at     = NOW();
 
--- Удаляем устаревшие колонки, если они остались
+-- Remove obsolete columns
 DO $$
 BEGIN
-  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='scope') THEN
-    ALTER TABLE quest_templates DROP COLUMN scope;
-  END IF;
   IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='reward_usd') THEN
     ALTER TABLE quest_templates DROP COLUMN reward_usd;
   END IF;
-  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='qkey') THEN
-    ALTER TABLE quest_templates DROP COLUMN qkey;
-  END IF;
-  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='descr') THEN
-    ALTER TABLE quest_templates DROP COLUMN descr;
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name='quest_templates' AND column_name='frequency') THEN
+    ALTER TABLE quest_templates DROP COLUMN frequency;
   END IF;
 END $$;

--- a/src/server/migrations/024_reinstate_frequency_check.sql
+++ b/src/server/migrations/024_reinstate_frequency_check.sql
@@ -1,9 +1,0 @@
--- 024_reinstate_frequency_check.sql
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='quest_templates_frequency_chk') THEN
-    ALTER TABLE quest_templates
-      ADD CONSTRAINT quest_templates_frequency_chk
-      CHECK (frequency = ANY (ARRAY['once','daily','weekly']::text[]));
-  END IF;
-END $$;

--- a/src/server/migrations/024_reinstate_scope_check.sql
+++ b/src/server/migrations/024_reinstate_scope_check.sql
@@ -1,0 +1,9 @@
+-- 024_reinstate_scope_check.sql
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname='quest_templates_scope_chk') THEN
+    ALTER TABLE quest_templates
+      ADD CONSTRAINT quest_templates_scope_chk
+      CHECK (scope = ANY (ARRAY['once','daily','weekly']::text[]));
+  END IF;
+END $$;

--- a/src/server/scripts/smoke-quests.mjs
+++ b/src/server/scripts/smoke-quests.mjs
@@ -17,9 +17,9 @@ async function main() {
         throw new Error('duplicate code: ' + JSON.stringify(dupRes.rows));
       }
 
-      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR frequency IS NULL`);
+      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR scope IS NULL`);
       if (nullRes.rows[0]?.cnt > 0) {
-        throw new Error('NULL description/frequency rows: ' + nullRes.rows[0].cnt);
+        throw new Error('NULL description/scope rows: ' + nullRes.rows[0].cnt);
       }
 
     console.log('[smoke] ok');

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -66,8 +66,8 @@ app.get('/admin/db/health', async (req, res) => {
       JOIN pg_class t ON c.conrelid = t.oid
       WHERE t.relname = 'quest_templates';
     `);
-      const frequencies = await client.query(`SELECT DISTINCT frequency FROM quest_templates ORDER BY frequency`);
-      res.json({ tables: tables.rows[0], constraints: constraints.rows, frequencies: frequencies.rows.map(r => r.frequency) });
+      const scopes = await client.query(`SELECT DISTINCT scope FROM quest_templates ORDER BY scope`);
+      res.json({ tables: tables.rows[0], constraints: constraints.rows, scopes: scopes.rows.map(r => r.scope) });
   } finally {
     client.release();
   }

--- a/src/server/utils/schema.js
+++ b/src/server/utils/schema.js
@@ -10,7 +10,7 @@ export async function ensureSchema(pool) {
         goal           INTEGER     NOT NULL,
         reward_type    TEXT        NOT NULL DEFAULT 'USD',
         reward_value   INTEGER     NOT NULL DEFAULT 0,
-        frequency      TEXT        NOT NULL DEFAULT 'once',
+        scope          TEXT        NOT NULL DEFAULT 'once',
         cooldown_hours INTEGER     NOT NULL DEFAULT 0,
         active         BOOLEAN     NOT NULL DEFAULT TRUE,
         type           TEXT        NOT NULL DEFAULT 'oneoff',
@@ -66,9 +66,9 @@ export async function ensureSchema(pool) {
 
         IF NOT EXISTS (
           SELECT 1 FROM information_schema.columns
-          WHERE table_name='quest_templates' AND column_name='frequency'
+          WHERE table_name='quest_templates' AND column_name='scope'
         ) THEN
-          ALTER TABLE quest_templates ADD COLUMN frequency TEXT NOT NULL DEFAULT 'once';
+          ALTER TABLE quest_templates ADD COLUMN scope TEXT NOT NULL DEFAULT 'once';
         END IF;
 
         IF NOT EXISTS (
@@ -101,9 +101,9 @@ export async function ensureSchema(pool) {
 
         IF EXISTS (
           SELECT 1 FROM information_schema.columns
-          WHERE table_name='quest_templates' AND column_name='qkey'
+          WHERE table_name='quest_templates' AND column_name='frequency'
         ) THEN
-          ALTER TABLE quest_templates DROP COLUMN qkey;
+          ALTER TABLE quest_templates DROP COLUMN frequency;
         END IF;
     END $$;
   `);


### PR DESCRIPTION
## Summary
- remove legacy quest_templates triggers referencing qkey
- normalize staging and merge quests with required fields filled
- switch schema and scripts from frequency to scope, dropping qkey remnants

## Testing
- `npm run db:test-migrations` *(fails: connect ECONNREFUSED ::1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5223a4408328b96aa44ebaa4e7d1