### PR TITLE
refactor: alias quest scope to frequency

### DIFF
--- a/src/server/scripts/smoke-quests.mjs
+++ b/src/server/scripts/smoke-quests.mjs
@@ -17,9 +17,9 @@ async function main() {
         throw new Error('duplicate code: ' + JSON.stringify(dupRes.rows));
       }
 
-      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR scope IS NULL`);
+      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR frequency IS NULL`);
       if (nullRes.rows[0]?.cnt > 0) {
-        throw new Error('NULL description/scope rows: ' + nullRes.rows[0].cnt);
+        throw new Error('NULL description/frequency rows: ' + nullRes.rows[0].cnt);
       }
 
     console.log('[smoke] ok');

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -66,7 +66,7 @@ app.get('/admin/db/health', async (req, res) => {
       JOIN pg_class t ON c.conrelid = t.oid
       WHERE t.relname = 'quest_templates';
     `);
-      const scopes = await client.query(`SELECT DISTINCT scope FROM quest_templates ORDER BY scope`);
+      const scopes = await client.query(`SELECT DISTINCT frequency AS scope FROM quest_templates ORDER BY frequency`);
       res.json({ tables: tables.rows[0], constraints: constraints.rows, scopes: scopes.rows.map(r => r.scope) });
   } finally {
     client.release();


### PR DESCRIPTION
## Summary
- alias quest template scope column to frequency in admin health check
- update smoke test to look at frequency instead of scope

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb560f875083288bbe4f89788be6eb