### PR TITLE
fix price feed rest timeout with AbortController

### DIFF
--- a/src/server/priceFeed/providers/binance.js
+++ b/src/server/priceFeed/providers/binance.js
@@ -22,9 +22,15 @@ export function parseWs(raw){
 }
 
 export async function fetchRest(){
-  const r = await fetch(restUrl, { timeout:5000 }).then(r=>r.json());
-  const p = Number(r.price);
-  return Number.isFinite(p) ? p : null;
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 5000);
+  try {
+    const r = await fetch(restUrl, { signal: ctl.signal }).then(r=>r.json());
+    const p = Number(r.price);
+    return Number.isFinite(p) ? p : null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function connect(onPrice, onStatus){

--- a/src/server/priceFeed/providers/bitstamp.js
+++ b/src/server/priceFeed/providers/bitstamp.js
@@ -25,9 +25,15 @@ export function parseWs(raw){
 }
 
 export async function fetchRest(){
-  const r = await fetch(restUrl, { timeout:5000 }).then(r=>r.json());
-  const p = Number(r.last);
-  return Number.isFinite(p) ? p : null;
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 5000);
+  try {
+    const r = await fetch(restUrl, { signal: ctl.signal }).then(r=>r.json());
+    const p = Number(r.last);
+    return Number.isFinite(p) ? p : null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function connect(onPrice, onStatus){

--- a/src/server/priceFeed/providers/coinbase.js
+++ b/src/server/priceFeed/providers/coinbase.js
@@ -25,9 +25,15 @@ export function parseWs(raw){
 }
 
 export async function fetchRest(){
-  const r = await fetch(restUrl, { timeout:5000 }).then(r=>r.json());
-  const p = Number(r.price);
-  return Number.isFinite(p) ? p : null;
+  const ctl = new AbortController();
+  const timer = setTimeout(() => ctl.abort(), 5000);
+  try {
+    const r = await fetch(restUrl, { signal: ctl.signal }).then(r=>r.json());
+    const p = Number(r.price);
+    return Number.isFinite(p) ? p : null;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export function connect(onPrice, onStatus){


### PR DESCRIPTION
## Summary
- avoid unsupported `timeout` option when fetching price data
- ensure REST price polling aborts after 5s for Binance, Coinbase, and Bitstamp providers

## Testing
- `node src/server/priceFeed/providers.test.js`
- `node src/server/priceFeed/failover.test.js`
- `node src/server/farmUtils.test.js`
- `node src/server/shopMath.test.js`
- `node src/server/verifyInitData.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb615b308c8328b38cc2f19d0929b6