### PR TITLE
feat: add phased env loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
 - Start: `node src/server/server.js`
 - Required env vars:
   - `NODE_ENV=production`
-  - `PUBLIC_URL=https://btc-game-mvp.onrender.com`
   - `DATABASE_URL=postgres://...`
-  - `TG_BOT_TOKEN=xxxxxxxxx`
-  - `WEBHOOK_SECRET=any-secret`
+  - `TELEGRAM_BOT_TOKEN=xxxxxxxxx`
+  - `TG_WEBHOOK_SECRET=any-secret`
+  - `PUBLIC_URL=https://btc-game-mvp.onrender.com` (optional)
   - `ENABLE_GAME_LOOP=1`
   - `ENABLE_PRICE_FEED=1`
   - `ENABLE_BOTS=1`

--- a/scripts/db-test-migrations.js
+++ b/scripts/db-test-migrations.js
@@ -1,4 +1,5 @@
-import '../src/server/env.js';
+import { loadEnv } from '../src/server/env.js';
+loadEnv('migrate');
 import { runMigrations } from '../src/server/migrate.js';
 import { seedQuests } from './seed-quests.js';
 

--- a/scripts/seed-quests.js
+++ b/scripts/seed-quests.js
@@ -1,4 +1,5 @@
-import '../src/server/env.js';
+import { loadEnv } from '../src/server/env.js';
+loadEnv('migrate');
 import quests from './quests.definitions.json' with { type: 'json' };
 
 // Normalize scope to whitelist

--- a/src/server/bootstrap.js
+++ b/src/server/bootstrap.js
@@ -1,9 +1,8 @@
 import { runMigrations } from './migrate.js';
-import { env } from './env.js';
 
 export { runMigrations };
 
-export async function ensureBootstrap(db, envConfig = env) {
+export async function ensureBootstrap(db, envConfig) {
   const client = await db.connect();
   let current;
   try {

--- a/src/server/db.js
+++ b/src/server/db.js
@@ -1,7 +1,8 @@
 import pg from 'pg';
-import { env } from './env.js';
+
+const NODE_ENV = process.env.NODE_ENV || 'production';
 
 export const pool = new pg.Pool({
-  connectionString: env.DATABASE_URL,
-  ssl: env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+  connectionString: process.env.DATABASE_URL || '',
+  ssl: NODE_ENV === 'production' ? { rejectUnauthorized: false } : false,
 });

--- a/src/server/migrate.js
+++ b/src/server/migrate.js
@@ -1,13 +1,15 @@
-import './env.js';
+import { loadEnv } from './env.js';
 import fs from 'fs';
 import path from 'path';
 import { Pool } from 'pg';
+
+const env = loadEnv('migrate');
 
 const dir = path.join(process.cwd(), 'src', 'server', 'migrations');
 
 export async function runMigrations(pool) {
   const ownPool = !pool;
-  const db = pool || new Pool({ connectionString: process.env.DATABASE_URL });
+  const db = pool || new Pool({ connectionString: env.DATABASE_URL });
   const files = fs
     .readdirSync(dir)
     .filter(f => /^\d+_.+\.sql$/.test(f))

--- a/src/server/routes/diag.js
+++ b/src/server/routes/diag.js
@@ -1,10 +1,9 @@
 import { Router } from 'express';
 import { pool } from '../db.js';
-import { env } from '../env.js';
 
 const router = Router();
 
-router.get('/api/diag', async (_req, res) => {
+router.get('/api/diag', async (req, res) => {
   try {
     const client = await pool.connect();
     try {
@@ -19,14 +18,13 @@ router.get('/api/diag', async (_req, res) => {
         betsCurrent = betsRes.rows[0].cnt;
         bankCurrent = Number(betsRes.rows[0].bank || 0);
       }
+      const env = req.app.locals.env || {};
       res.json({
         ok: true,
         env: {
-          publicUrl: env.PUBLIC_URL,
-          enableGameLoop: env.ENABLE_GAME_LOOP,
-          enablePriceFeed: env.ENABLE_PRICE_FEED,
-          enableBots: env.ENABLE_BOTS,
-          roundLengthSec: env.ROUND_LENGTH_SEC,
+          publicUrl: req.baseUrlExt,
+          botUsername: env.BOT_USERNAME,
+          nodeEnv: env.NODE_ENV,
         },
         db: {
           roundsTotal: roundsTotalRes.rows[0].cnt,

--- a/src/server/routes/tg-debug.js
+++ b/src/server/routes/tg-debug.js
@@ -1,17 +1,17 @@
 import { Router } from 'express';
-import { env } from '../env.js';
 
 const router = Router();
 
-router.get('/tg/debug/webhook', async (_req, res) => {
-  if (!env.TG_BOT_TOKEN) {
-    return res.status(400).json({ ok: false, error: 'TG_BOT_TOKEN not set' });
+router.get('/tg/debug/webhook', async (req, res) => {
+  const env = req.app.locals.env || {};
+  if (!env.TELEGRAM_BOT_TOKEN) {
+    return res.status(400).json({ ok: false, error: 'TELEGRAM_BOT_TOKEN not set' });
   }
   try {
-    const infoUrl = `https://api.telegram.org/bot${env.TG_BOT_TOKEN}/getWebhookInfo`;
+    const infoUrl = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/getWebhookInfo`;
     const info = await fetch(infoUrl).then(r => r.json());
-    const hook = `${env.PUBLIC_URL}/tg/webhook`;
-    const setWebhook = `https://api.telegram.org/bot${env.TG_BOT_TOKEN}/setWebhook?url=${encodeURIComponent(hook)}&secret_token=${env.WEBHOOK_SECRET}`;
+    const hook = `${req.baseUrlExt}/tg/webhook`;
+    const setWebhook = `https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/setWebhook?url=${encodeURIComponent(hook)}&secret_token=${env.TG_WEBHOOK_SECRET}`;
     res.json({ ok: true, info, recommended: setWebhook });
   } catch (e) {
     res.status(500).json({ ok: false });


### PR DESCRIPTION
## Summary
- add profile-based environment loader with DB-only migrate profile
- use server profile in app with automatic base URL fallback
- avoid direct env access in diagnostic routes and Telegram debug webhook helper

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb6fce36288328bcbc4389fb6b9ade