### PR TITLE
Fix missing service state during bootstrap

### DIFF
--- a/src/server/bootstrap.js
+++ b/src/server/bootstrap.js
@@ -2,17 +2,35 @@ import { runMigrations } from './migrate.js';
 
 export { runMigrations };
 
+async function sql(db, text, params) {
+  try {
+    return await db.query(text, params);
+  } catch (err) {
+    console.error('[bootstrap.sql] failed', { text, params, error: err });
+    throw err;
+  }
+}
+
 export async function ensureBootstrap(db, envConfig) {
   const client = await db.connect();
   let current;
   try {
-    await client.query('BEGIN');
-    const { rows: roundRows } = await client.query('SELECT id, state, ends_at FROM rounds ORDER BY id DESC LIMIT 1 FOR UPDATE');
-    const nowRes = await client.query('SELECT now() AS now');
+    await sql(client, 'BEGIN');
+
+    await sql(client, `CREATE TABLE IF NOT EXISTS service_state (
+      id boolean PRIMARY KEY DEFAULT TRUE,
+      state text NOT NULL DEFAULT 'idle',
+      updated_at timestamptz NOT NULL DEFAULT now()
+    )`);
+    await sql(client, `INSERT INTO service_state(id) VALUES (TRUE) ON CONFLICT (id) DO NOTHING`);
+
+    const { rows: roundRows } = await sql(client, 'SELECT id, state, ends_at FROM rounds ORDER BY id DESC LIMIT 1 FOR UPDATE');
+    const nowRes = await sql(client, 'SELECT now() AS now');
     const now = nowRes.rows[0].now;
     current = roundRows[0];
     if (!current) {
-      const ins = await client.query(
+      const ins = await sql(
+        client,
         `INSERT INTO rounds(state, starts_at, ends_at)
          VALUES('OPEN', $1, $1 + ($2 || ' seconds')::interval) RETURNING id, state, ends_at`,
         [now, envConfig.ROUND_LENGTH_SEC]
@@ -20,9 +38,10 @@ export async function ensureBootstrap(db, envConfig) {
       current = ins.rows[0];
       console.log(`[bootstrap] created initial round id=${current.id}`);
     } else if (current.state === 'OPEN' && current.ends_at < now) {
-      await client.query('UPDATE rounds SET state=\'CLOSED\' WHERE id=$1', [current.id]);
+      await sql(client, 'UPDATE rounds SET state=\'CLOSED\' WHERE id=$1', [current.id]);
       console.log(`[bootstrap] recovered stuck round id=${current.id} -> CLOSED`);
-      const ins = await client.query(
+      const ins = await sql(
+        client,
         `INSERT INTO rounds(state, starts_at, ends_at)
          VALUES('OPEN', $1, $1 + ($2 || ' seconds')::interval) RETURNING id, state, ends_at`,
         [now, envConfig.ROUND_LENGTH_SEC]
@@ -30,18 +49,18 @@ export async function ensureBootstrap(db, envConfig) {
       current = ins.rows[0];
       console.log(`[bootstrap] created initial round id=${current.id}`);
     }
-    await client.query('COMMIT');
+    await sql(client, 'COMMIT');
   } catch (e) {
-    await client.query('ROLLBACK');
+    await sql(client, 'ROLLBACK');
     throw e;
   } finally {
     client.release();
   }
 
   // Seed quest_templates if empty
-  const { rows: qtCount } = await db.query('SELECT COUNT(*)::int AS cnt FROM quest_templates');
+  const { rows: qtCount } = await sql(db, 'SELECT COUNT(*)::int AS cnt FROM quest_templates');
   if (qtCount[0].cnt === 0) {
-    await db.query(`INSERT INTO quest_templates(code, scope, metric, goal, title, description)
+    await sql(db, `INSERT INTO quest_templates(code, scope, metric, goal, title, description)
                     VALUES('demo','global','demo',0,'Demo quest','') ON CONFLICT DO NOTHING`);
     console.log('[bootstrap] seeded quest_templates default');
   }

--- a/src/server/migrations/026_create_service_state.sql
+++ b/src/server/migrations/026_create_service_state.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS service_state (
+  id boolean PRIMARY KEY DEFAULT TRUE,
+  state text NOT NULL DEFAULT 'idle',
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+INSERT INTO service_state(id) VALUES (TRUE) ON CONFLICT (id) DO NOTHING;

--- a/src/server/routes/status.js
+++ b/src/server/routes/status.js
@@ -16,7 +16,10 @@ router.get('/api/status', async (_req, res) => {
       }
       const priceRes = await client.query('SELECT price FROM price_ticks ORDER BY id DESC LIMIT 1');
       const lastPrice = priceRes.rows[0]?.price || null;
+      const svcRes = await client.query('SELECT state FROM service_state WHERE id=TRUE');
+      const svcState = svcRes.rows[0]?.state || 'idle';
       const result = {
+        service: { state: svcState },
         round: round ? { id: round.id, state: round.state, endsAt: round.ends_at } : null,
         bank,
         lastPrice,


### PR DESCRIPTION
## Summary
- add `service_state` migration to track server lifecycle
- log SQL errors and create/seed `service_state` in bootstrap
- expose current service state in `/api/status`

## Testing
- `node --test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb77f2a6a083288c0f3a33eb85c1b2