### PR TITLE
Fix quest template migration and add service state tracking

### DIFF
--- a/src/server/bootstrap.js
+++ b/src/server/bootstrap.js
@@ -58,6 +58,12 @@ export async function ensureBootstrap(db, envConfig) {
                     VALUES('demo','global','demo',0,'Demo quest','') ON CONFLICT DO NOTHING`);
     console.log('[bootstrap] seeded quest_templates default');
   }
+  await sql(db, `
+    INSERT INTO service_state (skey, state)
+    VALUES ('bootstrap', 'ready')
+    ON CONFLICT (skey)
+    DO UPDATE SET state = EXCLUDED.state, updated_at = now();
+  `);
 
   await sql(db, `
     INSERT INTO service_status (name, ok, details)

--- a/src/server/migrate.js
+++ b/src/server/migrate.js
@@ -37,7 +37,11 @@ export async function runMigrations(pool) {
             await client.query('ROLLBACK');
           }
         } catch {}
-        console.error(`[migrate] failed ${f}`, e);
+        const msg = e?.message || e;
+        console.error(`[migrate] failed in ${f}: ${msg}`);
+        if (e?.position) {
+          console.error(`[migrate] error position ${e.position}`);
+        }
         throw e;
       } finally {
         client.release();

--- a/src/server/migrations/031_service_state.sql
+++ b/src/server/migrations/031_service_state.sql
@@ -1,0 +1,31 @@
+-- 031_service_state.sql
+BEGIN;
+
+-- Создаём таблицу, если её нет (ключ — skey)
+CREATE TABLE IF NOT EXISTS service_state (
+  skey        text PRIMARY KEY,
+  state       text NOT NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Если таблица уже есть, но нет нужных столбцов — добавляем
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='service_state' AND column_name='state'
+  ) THEN
+    ALTER TABLE service_state ADD COLUMN state text;
+    UPDATE service_state SET state = 'ready' WHERE state IS NULL;
+    ALTER TABLE service_state ALTER COLUMN state SET NOT NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='service_state' AND column_name='updated_at'
+  ) THEN
+    ALTER TABLE service_state ADD COLUMN updated_at timestamptz NOT NULL DEFAULT now();
+  END IF;
+END$$;
+
+COMMIT;

--- a/src/server/migrations/032_create_service_status.sql
+++ b/src/server/migrations/032_create_service_status.sql
@@ -1,4 +1,4 @@
--- 031_create_service_status.sql
+-- 032_create_service_status.sql
 
 CREATE TABLE IF NOT EXISTS service_status (
   name        TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- rewrite quest template migration to be idempotent and enforce qkey constraints
- add service_state migration and write bootstrap status into table
- improve migration error logging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run db:test-migrations` *(fails: Error: [env] Missing DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bc087d5ae48328ae6dd8095d3fee09