### PR TITLE
Fix service_status bootstrap and migration

### DIFF
--- a/src/server/migrations/033_sync_service_status.sql
+++ b/src/server/migrations/033_sync_service_status.sql
@@ -1,0 +1,49 @@
+-- 033_sync_service_status.sql
+
+-- 1) Создадим таблицу, если её нет
+CREATE TABLE IF NOT EXISTS service_status (
+  name       TEXT PRIMARY KEY,
+  state      TEXT NOT NULL DEFAULT 'booting',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 2) Если колонка state отсутствует, но есть legacy-колонка status — переименуем
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name='service_status' AND column_name='state'
+  ) THEN
+    IF EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_name='service_status' AND column_name='status'
+    ) THEN
+      EXECUTE 'ALTER TABLE service_status RENAME COLUMN status TO state';
+    ELSE
+      EXECUTE 'ALTER TABLE service_status ADD COLUMN state TEXT';
+    END IF;
+  END IF;
+END$$;
+
+-- 3) Обязательные атрибуты и ограничения
+ALTER TABLE service_status
+  ALTER COLUMN state SET NOT NULL;
+
+ALTER TABLE service_status
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+ALTER TABLE service_status
+  DROP CONSTRAINT IF EXISTS service_status_state_chk;
+
+ALTER TABLE service_status
+  ADD CONSTRAINT service_status_state_chk
+  CHECK (state IN ('booting','ready','error')) NOT VALID;
+
+ALTER TABLE service_status
+  VALIDATE CONSTRAINT service_status_state_chk;
+
+-- 4) Базовая запись о сервисе
+INSERT INTO service_status (name, state)
+VALUES ('srv','booting')
+ON CONFLICT (name)
+DO UPDATE SET state = EXCLUDED.state, updated_at = now();

--- a/src/server/migrations/040_squash_schema.sql
+++ b/src/server/migrations/040_squash_schema.sql
@@ -152,3 +152,16 @@ BEGIN
     ALTER TABLE quest_templates DROP COLUMN qkey;
   END IF;
 END $$;
+
+-- service_status table for clean deploy
+CREATE TABLE IF NOT EXISTS service_status (
+  name       TEXT PRIMARY KEY,
+  state      TEXT NOT NULL DEFAULT 'booting',
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT service_status_state_chk
+    CHECK (state IN ('booting','ready','error'))
+);
+
+INSERT INTO service_status (name, state)
+VALUES ('srv','booting')
+ON CONFLICT (name) DO NOTHING;

--- a/src/server/routes/health.js
+++ b/src/server/routes/health.js
@@ -5,8 +5,8 @@ const router = Router();
 
 router.get('/health', async (_req, res) => {
   try {
-    const { rows: [row] = [] } = await pool.query("SELECT ok FROM service_status WHERE name='server'");
-    const ok = row?.ok ?? false;
+    const { rows: [row] = [] } = await pool.query("SELECT state FROM service_status WHERE name='srv'");
+    const ok = row?.state === 'ready';
     if (ok) res.json({ ok: true });
     else res.status(503).json({ ok: false });
   } catch (e) {

--- a/src/server/routes/status.js
+++ b/src/server/routes/status.js
@@ -16,8 +16,8 @@ router.get('/api/status', async (_req, res) => {
       }
       const priceRes = await client.query('SELECT price FROM price_ticks ORDER BY id DESC LIMIT 1');
       const lastPrice = priceRes.rows[0]?.price || null;
-      const svcRes = await client.query("SELECT ok, details FROM service_status WHERE name='server'");
-      const svcRow = svcRes.rows[0] || {};
+      const svcRes = await client.query("SELECT state FROM service_status WHERE name='srv'");
+      const svcRow = svcRes.rows[0] || { state: 'booting' };
       const qtRes = await client.query('SELECT active, COUNT(*)::int AS cnt FROM quest_templates GROUP BY active');
       const quests = { enabled: 0, disabled: 0 };
       for (const r of qtRes.rows) {
@@ -29,7 +29,7 @@ router.get('/api/status', async (_req, res) => {
         client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR descr IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
       ]);
       const result = {
-        service: { ok: svcRow.ok ?? true, details: svcRow.details || {} },
+        service: { state: svcRow.state },
         round: round ? { id: round.id, state: round.state, endsAt: round.ends_at } : null,
         bank,
         lastPrice,


### PR DESCRIPTION
## Summary
- ensure service_status table has `state` column with constraint and seed record via new sync migration
- include service_status definition and seed in squashed schema
- bootstrap server to normalize service_status and update health/status routes to read `state`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run db:test-migrations` *(fails: [env] Missing DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c49acc48328a04730f1009aaa5b