### PR TITLE
fix: use description column

### DIFF
--- a/scripts/seed-quests.js
+++ b/scripts/seed-quests.js
@@ -66,14 +66,14 @@ export async function seedQuests(pool) {
       const code = q.code;
       await client.query(
         `INSERT INTO quest_templates
-         (code, scope, metric, goal, title, descr, frequency, active, reward_type, reward_value, cooldown_hours)
+         (code, scope, metric, goal, title, description, frequency, active, reward_type, reward_value, cooldown_hours)
          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
          ON CONFLICT (code) DO UPDATE SET
            scope = EXCLUDED.scope,
            metric = EXCLUDED.metric,
            goal = EXCLUDED.goal,
            title = EXCLUDED.title,
-           descr = EXCLUDED.descr,
+           description = EXCLUDED.description,
            frequency = EXCLUDED.frequency,
            active = EXCLUDED.active,
            reward_type = EXCLUDED.reward_type,

--- a/src/server/bootstrap.js
+++ b/src/server/bootstrap.js
@@ -52,7 +52,7 @@ export async function ensureBootstrap(db, envConfig) {
   // Seed quest_templates if empty
   const { rows: qtCount } = await sql(db, 'SELECT COUNT(*)::int AS cnt FROM quest_templates');
   if (qtCount[0].cnt === 0) {
-    await sql(db, `INSERT INTO quest_templates(code, scope, metric, goal, title, descr)
+    await sql(db, `INSERT INTO quest_templates(code, scope, metric, goal, title, description)
                     VALUES('demo','global','demo',0,'Demo quest','') ON CONFLICT DO NOTHING`);
     console.log('[bootstrap] seeded quest_templates default');
   }

--- a/src/server/routes/diag.js
+++ b/src/server/routes/diag.js
@@ -22,7 +22,7 @@ router.get('/api/diag', async (req, res) => {
       const integrityRes = await Promise.all([
         client.query("SELECT COUNT(*)::int AS bad_frequency FROM quest_templates WHERE frequency NOT IN ('once','daily','weekly')"),
         client.query("SELECT COUNT(*)::int AS bad_reward_type FROM quest_templates WHERE reward_type NOT IN ('USD','VOP','XP')"),
-        client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR descr IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
+        client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR description IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
       ]);
       res.json({
         ok: true,

--- a/src/server/routes/status.js
+++ b/src/server/routes/status.js
@@ -26,7 +26,7 @@ router.get('/api/status', async (_req, res) => {
       const integrityRes = await Promise.all([
         client.query("SELECT COUNT(*)::int AS bad_frequency FROM quest_templates WHERE frequency NOT IN ('once','daily','weekly')"),
         client.query("SELECT COUNT(*)::int AS bad_reward_type FROM quest_templates WHERE reward_type NOT IN ('USD','VOP','XP')"),
-        client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR descr IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
+        client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR description IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
       ]);
       const result = {
         service: { state: svcRow.state },

--- a/src/server/scripts/smoke-quests.mjs
+++ b/src/server/scripts/smoke-quests.mjs
@@ -17,9 +17,9 @@ async function main() {
         throw new Error('duplicate code: ' + JSON.stringify(dupRes.rows));
       }
 
-      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE descr IS NULL OR frequency IS NULL`);
+      const nullRes = await client.query(`SELECT COUNT(*)::int AS cnt FROM quest_templates WHERE description IS NULL OR frequency IS NULL`);
       if (nullRes.rows[0]?.cnt > 0) {
-        throw new Error('NULL descr/frequency rows: ' + nullRes.rows[0].cnt);
+        throw new Error('NULL description/frequency rows: ' + nullRes.rows[0].cnt);
       }
 
     console.log('[smoke] ok');


### PR DESCRIPTION
## Summary
- query quest_templates.description instead of obsolete descr in status and diag routes
- update seeder and utility scripts for quest_templates.description column

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcae6d87148328bb0cfe3db428c53f