### PR TITLE
Add debug endpoints and price schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@
     - `ENABLE_GAME_LOOP=1` (off by default)
     - `ENABLE_PRICE_FEED=1` (off by default)
     - `ENABLE_BOTS=1` (off by default)
+    - `ADMIN_SECRET` — secret key for debug routes
+
+### Debug endpoints
+
+Set the `ADMIN_SECRET` environment variable to use debug routes.
+
+```
+export ADMIN_SECRET=your_secret
+```
+
+Example requests:
+
+```
+curl -H "X-Admin-Secret: $ADMIN_SECRET" -X POST https://.../api/debug/price -d '{"price":60000}' -H "Content-Type: application/json"
+curl -H "X-Admin-Secret: $ADMIN_SECRET" -X POST https://.../api/debug/round/start
+```
 
 ### Background Worker/Web Service (bot)
 - Root Directory: `bot`

--- a/src/server/env.js
+++ b/src/server/env.js
@@ -23,6 +23,7 @@ export function loadEnv(profile = 'server') {
     TELEGRAM_BOT_TOKEN: process.env.TELEGRAM_BOT_TOKEN || '',
     BOT_USERNAME: process.env.BOT_USERNAME || process.env.TG_BOT_USERNAME || '',
     TG_WEBHOOK_SECRET: process.env.TG_WEBHOOK_SECRET || '',
+    ADMIN_SECRET: process.env.ADMIN_SECRET || '',
     PUBLIC_URL,
     PORT: number(process.env.PORT, 10000),
     ROUND_LENGTH_SEC: number(process.env.ROUND_LENGTH_SEC, 60),

--- a/src/server/migrations/041_price_ticks_schema.sql
+++ b/src/server/migrations/041_price_ticks_schema.sql
@@ -1,0 +1,13 @@
+-- 041_price_ticks_schema.sql
+
+ALTER TABLE price_ticks
+  ALTER COLUMN id TYPE BIGINT,
+  ALTER COLUMN id SET NOT NULL,
+  ALTER COLUMN price DROP IDENTITY IF EXISTS,
+  ALTER COLUMN price TYPE NUMERIC,
+  ALTER COLUMN price SET NOT NULL,
+  ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'manual',
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS price_ticks_created_at_idx
+  ON price_ticks (created_at DESC);

--- a/src/server/routes/debug.js
+++ b/src/server/routes/debug.js
@@ -1,0 +1,55 @@
+import { Router } from 'express';
+import { pool } from '../db.js';
+
+const router = Router();
+
+router.use('/api/debug', (req, res, next) => {
+  const env = req.app.locals.env || {};
+  const secret = req.get('X-Admin-Secret') || '';
+  if (!env.ADMIN_SECRET || secret !== env.ADMIN_SECRET) {
+    return res.status(401).json({ ok: false });
+  }
+  next();
+});
+
+router.post('/api/debug/price', async (req, res) => {
+  const price = Number(req.body?.price);
+  if (!Number.isFinite(price)) {
+    return res.status(400).json({ ok: false, error: 'invalid price' });
+  }
+  try {
+    await pool.query(
+      'INSERT INTO price_ticks (price) OVERRIDING SYSTEM VALUE VALUES ($1)',
+      [price]
+    );
+    res.json({ ok: true });
+  } catch (e) {
+    console.error('[debug/price] error', e);
+    res.status(500).json({ ok: false });
+  }
+});
+
+router.post('/api/debug/round/start', async (_req, res) => {
+  try {
+    const { rows: priceRows } = await pool.query(
+      'SELECT price FROM price_ticks ORDER BY created_at DESC LIMIT 1'
+    );
+    const lastPrice = priceRows[0]?.price;
+    if (lastPrice == null) {
+      return res.status(400).json({ ok: false, error: 'no price' });
+    }
+    const { rows } = await pool.query(
+      `INSERT INTO rounds(state, starts_at, ends_at, start_price)
+       VALUES('OPEN', now(), now() + interval '60 seconds', $1)
+       RETURNING id, state, ends_at`,
+      [lastPrice]
+    );
+    const round = rows[0];
+    res.json({ ok: true, round });
+  } catch (e) {
+    console.error('[debug/round/start] error', e);
+    res.status(500).json({ ok: false });
+  }
+});
+
+export default router;

--- a/src/server/routes/diag.js
+++ b/src/server/routes/diag.js
@@ -3,47 +3,20 @@ import { pool } from '../db.js';
 
 const router = Router();
 
-router.get('/api/diag', async (req, res) => {
+router.get('/api/diag', async (_req, res) => {
   try {
     const client = await pool.connect();
     try {
-      const roundsTotalRes = await client.query('SELECT COUNT(*)::int AS cnt FROM rounds');
-      const currentRoundRes = await client.query("SELECT id, state, ends_at FROM rounds WHERE state='OPEN' ORDER BY id DESC LIMIT 1");
-      const currentRound = currentRoundRes.rows[0] || null;
-      const priceTicksRes = await client.query("SELECT COUNT(*)::int AS cnt FROM price_ticks WHERE created_at > now() - interval '5 minutes'");
-      let betsCurrent = 0;
-      let bankCurrent = 0;
-      if (currentRound) {
-        const betsRes = await client.query('SELECT COUNT(*)::int AS cnt, COALESCE(SUM(bet),0) AS bank FROM arena_user_round WHERE round_id=$1', [currentRound.id]);
-        betsCurrent = betsRes.rows[0].cnt;
-        bankCurrent = Number(betsRes.rows[0].bank || 0);
-      }
-      const env = req.app.locals.env || {};
-      const integrityRes = await Promise.all([
-        client.query("SELECT COUNT(*)::int AS bad_frequency FROM quest_templates WHERE frequency NOT IN ('once','daily','weekly')"),
-        client.query("SELECT COUNT(*)::int AS bad_reward_type FROM quest_templates WHERE reward_type NOT IN ('USD','VOP','XP')"),
-        client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR description IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
-      ]);
-      res.json({
-        ok: true,
-        env: {
-          publicUrl: req.baseUrlExt,
-          botUsername: env.BOT_USERNAME,
-          nodeEnv: env.NODE_ENV,
-        },
-        db: {
-          roundsTotal: roundsTotalRes.rows[0].cnt,
-          currentRound: currentRound ? { id: currentRound.id, state: currentRound.state, endsAt: currentRound.ends_at } : null,
-          priceTicks5m: priceTicksRes.rows[0].cnt,
-          betsCurrent,
-          bankCurrent,
-        },
-        integrity: {
-          badFrequency: integrityRes[0].rows[0].bad_frequency,
-          badRewardType: integrityRes[1].rows[0].bad_reward_type,
-          hasNulls: integrityRes[2].rows[0].has_nulls,
-        }
-      });
+      const priceTicksRes = await client.query(
+        "SELECT COUNT(*)::int AS cnt FROM price_ticks WHERE created_at > now() - interval '5 minutes'"
+      );
+      const priceTicks5m = priceTicksRes.rows[0].cnt;
+      const svcRes = await client.query(
+        "SELECT state FROM service_status WHERE name='srv'"
+      );
+      const svcState = svcRes.rows[0]?.state || 'booting';
+      const ok = priceTicks5m > 0 && ['ready', 'booting'].includes(svcState);
+      res.json({ priceTicks5m, ok });
     } finally {
       client.release();
     }

--- a/src/server/routes/status.js
+++ b/src/server/routes/status.js
@@ -7,41 +7,18 @@ router.get('/api/status', async (_req, res) => {
   try {
     const client = await pool.connect();
     try {
-      const roundRes = await client.query("SELECT id, state, ends_at FROM rounds WHERE state='OPEN' ORDER BY id DESC LIMIT 1");
-      const round = roundRes.rows[0] || null;
-      let bank = 0;
-      if (round) {
-        const bankRes = await client.query('SELECT COALESCE(SUM(bet),0) AS bank FROM arena_user_round WHERE round_id=$1', [round.id]);
-        bank = Number(bankRes.rows[0].bank || 0);
-      }
-      const priceRes = await client.query('SELECT price FROM price_ticks ORDER BY id DESC LIMIT 1');
-      const lastPrice = priceRes.rows[0]?.price || null;
-      const svcRes = await client.query("SELECT state FROM service_status WHERE name='srv'");
-      const svcRow = svcRes.rows[0] || { state: 'booting' };
-      const qtRes = await client.query('SELECT active, COUNT(*)::int AS cnt FROM quest_templates GROUP BY active');
-      const quests = { enabled: 0, disabled: 0 };
-      for (const r of qtRes.rows) {
-        if (r.active) quests.enabled = r.cnt; else quests.disabled = r.cnt;
-      }
-      const integrityRes = await Promise.all([
-        client.query("SELECT COUNT(*)::int AS bad_frequency FROM quest_templates WHERE frequency NOT IN ('once','daily','weekly')"),
-        client.query("SELECT COUNT(*)::int AS bad_reward_type FROM quest_templates WHERE reward_type NOT IN ('USD','VOP','XP')"),
-        client.query("SELECT COUNT(*)::int AS has_nulls FROM quest_templates WHERE code IS NULL OR scope IS NULL OR metric IS NULL OR goal IS NULL OR title IS NULL OR description IS NULL OR frequency IS NULL OR active IS NULL OR reward_type IS NULL OR reward_value IS NULL"),
-      ]);
-      const result = {
-        service: { state: svcRow.state },
-        round: round ? { id: round.id, state: round.state, endsAt: round.ends_at } : null,
-        bank,
-        lastPrice,
-        quests,
-        integrity: {
-          badFrequency: integrityRes[0].rows[0].bad_frequency,
-          badRewardType: integrityRes[1].rows[0].bad_reward_type,
-          hasNulls: integrityRes[2].rows[0].has_nulls,
-        },
-      };
-      console.log('[status] ok');
-      res.json(result);
+      const priceRes = await client.query(
+        'SELECT price FROM price_ticks ORDER BY created_at DESC LIMIT 1'
+      );
+      const lastPrice = priceRes.rows[0]?.price ?? 60000;
+      const roundRes = await client.query(
+        'SELECT id, state, ends_at FROM rounds ORDER BY id DESC LIMIT 1'
+      );
+      const r = roundRes.rows[0] || null;
+      const round = r
+        ? { id: r.id, state: r.state, endsAt: r.ends_at }
+        : null;
+      res.json({ lastPrice, round });
     } finally {
       client.release();
     }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -9,6 +9,7 @@ import health from './routes/health.js';
 import status from './routes/status.js';
 import diag from './routes/diag.js';
 import tgDebug from './routes/tg-debug.js';
+import debugRoutes from './routes/debug.js';
 
 const env = loadEnv('server');
 process.env.TZ = 'UTC';
@@ -36,6 +37,7 @@ app.use(health);
 app.use(status);
 app.use(diag);
 app.use(tgDebug);
+app.use(debugRoutes);
 
 app.get('/api/sse', (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');


### PR DESCRIPTION
## Summary
- add migration to normalize `price_ticks`
- introduce admin-protected debug routes for price ticks and rounds
- simplify status and diag endpoints
- document `ADMIN_SECRET` and debug curl examples

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bcc334dd608328950897b8bf997b04