### PR TITLE
Compute round bank dynamically

### DIFF
--- a/src/server/routes/round.js
+++ b/src/server/routes/round.js
@@ -1,30 +1,48 @@
-import { pool } from '../db.js';
-
-export async function roundHandler(_req, res) {
-  try {
-    const client = await pool.connect();
+export default function roundRoute(app, db) {
+  app.get('/api/round', async (_req, res) => {
     try {
-      const roundRes = await client.query(
-        'SELECT id, state, ends_at AS "endsAt", bank FROM rounds ORDER BY id DESC LIMIT 1'
+      // current round
+      const r = await db.query(
+        `SELECT id, state, ends_at AS "endsAt"
+         FROM rounds
+         ORDER BY id DESC
+         LIMIT 1`
       );
-      const round = roundRes.rows[0];
-      if (!round) {
-        res.status(404).json({ ok: false });
-        return;
+      const round = r.rows[0] || null;
+
+      // last price
+      let lastPrice = null;
+      const p = await db.query(
+        `SELECT price_usd AS "lastPrice"
+         FROM price_ticks
+         ORDER BY id DESC
+         LIMIT 1`
+      );
+      if (p.rows[0]) lastPrice = Number(p.rows[0].lastPrice);
+
+      // bank: try to calculate from bets; if schema absent, keep 0
+      let bank = 0;
+      if (round) {
+        try {
+          const b = await db.query(
+            `SELECT COALESCE(SUM(amount_usd), 0)::float AS bank
+             FROM bets
+             WHERE round_id = $1`,
+            [round.id]
+          );
+          if (b.rows[0]) bank = Number(b.rows[0].bank);
+        } catch (e) {
+          // missing column/table -> ignore, bank stays 0
+          if (e.code !== '42P01' && e.code !== '42703') throw e;
+        }
       }
-      const priceRes = await client.query(
-        'SELECT price_usd AS "lastPrice" FROM price_ticks ORDER BY id DESC LIMIT 1'
-      );
-      const lastPrice = priceRes.rows[0]?.lastPrice ?? null;
-      res.json({ ...round, lastPrice });
-    } finally {
-      client.release();
+
+      if (!round)
+        return res.json({ id: null, state: null, endsAt: null, bank, lastPrice });
+      return res.json({ id: round.id, state: round.state, endsAt: round.endsAt, bank, lastPrice });
+    } catch (err) {
+      console.error('[round] error', err);
+      return res.status(500).json({ ok: false });
     }
-  } catch (e) {
-    console.error('[round] error', e);
-    res.status(500).json({ ok: false });
-  }
+  });
 }
-
-export default roundHandler;
-

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -11,7 +11,7 @@ import diag from './routes/diag.js';
 import tgDebug from './routes/tg-debug.js';
 import debugRoutes from './routes/debug.js';
 import { startPriceFeed } from './priceFeed/loop.js';
-import { roundHandler } from './routes/round.js';
+import roundRoute from './routes/round.js';
 
 const env = loadEnv('server');
 process.env.TZ = 'UTC';
@@ -41,7 +41,7 @@ app.use(diag);
 app.use(tgDebug);
 app.use(debugRoutes);
 
-app.get('/api/round', roundHandler);
+roundRoute(app, pool);
 
 app.get('/api/sse', (req, res) => {
   res.setHeader('Content-Type', 'text/event-stream');


### PR DESCRIPTION
## Summary
- Compute round bank from bets instead of relying on rounds.bank
- Register round API route via helper

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bcd2b33e7c8328bf30dcbd5fbe12bd