### PR TITLE
chore: fix workflow and vite base path

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 20
       - name: Install dependencies
         working-directory: apps/webapp
-        run: npm ci
+        run: npm install
       - name: Build
         working-directory: apps/webapp
         run: npm run build

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/btc-game-mvp/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- use `npm install` in Pages deployment workflow
- set Vite base path to `/btc-game-mvp/`

## Testing
- `npm install --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68be132770348328bd28b93c6b72375c