### PR TITLE
feat(webapp): react skeleton and root mount

### DIFF
--- a/apps/webapp/index.html
+++ b/apps/webapp/index.html
@@ -1,12 +1,13 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Carousel</title>
+    <title>Carousel MVP</title>
   </head>
-  <body>
+  <body class="bg-neutral-50">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <!-- ВАЖНО: относительный путь, чтобы работать в /btc-game-mvp/ -->
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+export default function App() {
+  return (
+    <div className="min-h-screen p-6 flex items-start justify-center">
+      <div className="w-full max-w-4xl space-y-4">
+        <h1 className="text-2xl font-semibold">Carousel MVP</h1>
+
+        {/* Первый экран: вставить текст + выбрать фото (пока заглушки) */}
+        <textarea
+          placeholder="Вставь текст сюда…"
+          className="w-full h-40 p-4 border rounded-lg"
+        />
+
+        <div className="flex gap-3">
+          <button className="px-4 py-2 rounded-lg border">Добавить фото</button>
+          <select className="px-3 py-2 rounded-lg border">
+            <option>Авто</option>
+            <option>3 слайда</option>
+            <option>5 слайдов</option>
+            <option>8 слайдов</option>
+          </select>
+        </div>
+
+        <div className="flex gap-2 text-sm opacity-70">
+          <span>Template</span>
+          <span>Color</span>
+          <span>Layout</span>
+          <span>Photos</span>
+          <span>Info</span>
+          <span>Export</span>
+        </div>
+
+        <div className="aspect-[4/5] w-72 border rounded-xl flex items-center justify-center">
+          Превью слайда
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/webapp/src/app.tsx
+++ b/apps/webapp/src/app.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function App() {
-  return <div className="p-4">Carousel MVP</div>;
-}

--- a/apps/webapp/src/main.tsx
+++ b/apps/webapp/src/main.tsx
@@ -1,10 +1,6 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './app';
-import './styles/tailwind.css';
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './styles/tailwind.css'
 
-ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
-);
+createRoot(document.getElementById('root')!).render(<App />)


### PR DESCRIPTION
## Summary
- add basic React skeleton to render Carousel MVP controls
- mount React App to root with createRoot and Tailwind styling

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be193bbf30832889aa40976bc528ee