### PR TITLE
feat: add basic Telegraf bot for WebApp

### DIFF
--- a/bot/bot.js
+++ b/bot/bot.js
@@ -1,0 +1,14 @@
+const { Telegraf, Markup } = require('telegraf');
+
+const bot = new Telegraf(process.env.TELEGRAM_BOT_TOKEN);
+const WEBAPP_URL = process.env.WEBAPP_URL;
+
+bot.start((ctx) => {
+  return ctx.reply(
+    'Собери карусель из текста и фото:',
+    Markup.inlineKeyboard([Markup.button.webApp('Открыть конструктор', WEBAPP_URL)])
+  );
+});
+
+bot.launch();
+console.log('Bot started');


### PR DESCRIPTION
## Summary
- add simple Telegraf bot that opens WebApp via inline button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be1c0f54c083289b48fb061bf3b250