### PR TITLE
feat: add Telegram WebApp layout with Tailwind base styles

### DIFF
--- a/apps/webapp/index.html
+++ b/apps/webapp/index.html
@@ -1,13 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="ru">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>Carousel MVP</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script src="https://telegram.org/js/telegram-web-app.js"></script>
   </head>
-  <body class="bg-neutral-50">
+  <body class="bg-neutral-950 text-neutral-100">
     <div id="root"></div>
-    <!-- ВАЖНО: относительный путь, чтобы работать в /btc-game-mvp/ -->
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/webapp/postcss.config.js
+++ b/apps/webapp/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,40 +1,92 @@
 import React from 'react'
 
+const Tab = ({ children, active=false }: {children: React.ReactNode, active?: boolean}) => (
+  <button className={`px-4 py-2 rounded-xl border text-sm
+    ${active ? 'bg-neutral-800 border-neutral-700' : 'bg-neutral-900 border-neutral-800 hover:bg-neutral-800'}`}>
+    {children}
+  </button>
+)
+
 export default function App() {
   return (
-    <div className="min-h-screen p-6 flex items-start justify-center">
-      <div className="w-full max-w-4xl space-y-4">
-        <h1 className="text-2xl font-semibold">Carousel MVP</h1>
+    <div className="min-h-full pt-[calc(12px+var(--sat))] pb-[calc(12px+var(--sab))] px-4 sm:px-6">
+      {/* Topbar */}
+      <div className="max-w-6xl mx-auto flex items-center gap-3 mb-4">
+        <button className="px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-800 text-sm">Back</button>
+        <div className="text-neutral-300 text-sm">Get Images</div>
+        <div className="ml-auto text-neutral-500 text-xs">09:41</div>
+      </div>
 
-        {/* Первый экран: вставить текст + выбрать фото (пока заглушки) */}
-        <textarea
-          placeholder="Вставь текст сюда…"
-          className="w-full h-40 p-4 border rounded-lg"
-        />
+      {/* Workspace */}
+      <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6">
+        {/* LEFT: controls */}
+        <div className="lg:col-span-5 space-y-4">
+          {/* Card */}
+          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-4 shadow-[0_0_30px_rgba(0,0,0,0.35)]">
+            <label className="block text-sm text-neutral-400 mb-2">Text</label>
+            <textarea placeholder="Вставь текст сюда…" className="
+                w-full h-36 resize-none px-4 py-3 rounded-xl
+                bg-neutral-950 border border-neutral-800 outline-none
+                placeholder:text-neutral-500 focus:border-neutral-600" />
+            <div className="mt-3 flex items-center gap-3">
+              <label className="inline-flex items-center">
+                <input type="file" accept="image/*" multiple className="hidden" id="pickphotos" />
+                <span className="px-4 py-2 rounded-xl bg-neutral-100 text-neutral-900 font-medium text-sm cursor-pointer select-none"
+                  onClick={() => document.getElementById('pickphotos')?.click()}
+                >
+                  Добавить фото
+                </span>
+              </label>
+              <select className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm">
+                <option>Авто</option>
+                <option>3 слайда</option>
+                <option>5 слайдов</option>
+                <option>8 слайдов</option>
+              </select>
+            </div>
+          </div>
 
-        <div className="flex gap-3">
-          <button className="px-4 py-2 rounded-lg border">Добавить фото</button>
-          <select className="px-3 py-2 rounded-lg border">
-            <option>Авто</option>
-            <option>3 слайда</option>
-            <option>5 слайдов</option>
-            <option>8 слайдов</option>
-          </select>
+          {/* Bottom toolbar (tabs) */}
+          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-3 flex flex-wrap gap-2">
+            <Tab active>Template</Tab>
+            <Tab>Color</Tab>
+            <Tab>Layout</Tab>
+            <Tab>Photos</Tab>
+            <Tab>Info</Tab>
+            <Tab>Export</Tab>
+          </div>
         </div>
 
-        <div className="flex gap-2 text-sm opacity-70">
-          <span>Template</span>
-          <span>Color</span>
-          <span>Layout</span>
-          <span>Photos</span>
-          <span>Info</span>
-          <span>Export</span>
-        </div>
+        {/* RIGHT: preview carousel */}
+        <div className="lg:col-span-7">
+          <div className="rounded-3xl bg-neutral-900/70 border border-neutral-800 p-4 lg:p-6
+                          shadow-[0_0_60px_rgba(0,0,0,0.35)]">
+            <div className="text-neutral-400 text-sm mb-3">Preview</div>
+            <div className="flex gap-4 overflow-x-auto pb-2">
+              {/* Один слайд-превью — визуально как карточка 4:5 */}
+              <div className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden bg-neutral-800 relative">
+                <img src="" alt="" className="absolute inset-0 w-full h-full object-cover opacity-60" />
+                <div className="absolute inset-0 bg-black/25" />
+                <div className="absolute left-4 right-4 bottom-4 text-[15px] leading-[1.35]">
+                  <div className="inline-block bg-[#5B4BFF] text-white px-2.5 py-1.5 rounded-lg font-semibold mb-2">
+                    Выгорание убивает контент-план. Что делать?
+                  </div>
+                  <div className="text-neutral-100/90">
+                    Система против мотивации. Показываю рабочий подход
+                  </div>
+                  <div className="mt-3 text-neutral-300 text-xs">@username</div>
+                </div>
+                <div className="absolute right-4 bottom-4 text-neutral-300 text-xs">1/8</div>
+              </div>
 
-        <div className="aspect-[4/5] w-72 border rounded-xl flex items-center justify-center">
-          Превью слайда
+              {/* Пустые-превью для эффекта карусели */}
+              <div className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl bg-neutral-850/40 border border-neutral-800" />
+              <div className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl bg-neutral-850/40 border border-neutral-800" />
+            </div>
+          </div>
         </div>
       </div>
     </div>
   )
 }
+

--- a/apps/webapp/src/main.tsx
+++ b/apps/webapp/src/main.tsx
@@ -1,6 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 import './styles/tailwind.css'
 
-createRoot(document.getElementById('root')!).render(<App />)
+function Boot() {
+  useEffect(() => {
+    // Telegram WebApp: раскрыть, подхватить тему
+    const tg = (window as any).Telegram?.WebApp
+    if (tg) {
+      tg.expand()
+      tg.setHeaderColor('secondary_bg_color')
+      tg.setBackgroundColor('secondary_bg_color')
+    }
+    // iOS safe-area
+    document.documentElement.style.setProperty('--sat', 'env(safe-area-inset-top)')
+    document.documentElement.style.setProperty('--sab', 'env(safe-area-inset-bottom)')
+  }, [])
+  return <App />
+}
+
+createRoot(document.getElementById('root')!).render(<Boot />)

--- a/apps/webapp/src/styles/tailwind.css
+++ b/apps/webapp/src/styles/tailwind.css
@@ -1,3 +1,12 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+:root{
+  --sat: 0px; /* safe-area top */
+  --sab: 0px; /* safe-area bottom */
+}
+html, body, #root { height: 100%; }
+
+* { -webkit-tap-highlight-color: transparent; }
+body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }

--- a/apps/webapp/tailwind.config.js
+++ b/apps/webapp/tailwind.config.js
@@ -1,7 +1,17 @@
-module.exports = {
+/** @type {import('tailwindcss').Config} */
+export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        neutral: {
+          850: '#1C1C1E',
+        },
+      },
+      borderRadius: {
+        '3xl': '1.5rem',
+      },
+    },
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
## Summary
- set up Telegram WebApp HTML with Inter font and dark theme
- add Boot script for Telegram theme expansion and safe-area
- implement Tailwind base styles, layout skeleton, and PostCSS config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be283a72ac8328ae2b36d2be4822e5