### PR TITLE
feat(webapp): add minimal slide rendering

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,87 +1,171 @@
-import React from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { splitIntoSlides } from './core/text-split'
+import { renderSlide } from './core/render'
+import './styles/tailwind.css'
 
-const Tab = ({ children, active=false }: {children: React.ReactNode, active?: boolean}) => (
-  <button className={`px-4 py-2 rounded-xl border text-sm
-    ${active ? 'bg-neutral-800 border-neutral-700' : 'bg-neutral-900 border-neutral-800 hover:bg-neutral-800'}`}>
-    {children}
-  </button>
-)
+type SlideCount = 'auto' | 3 | 5 | 8 | 10
 
 export default function App() {
+  const [text, setText] = useState<string>('')
+  const [count, setCount] = useState<SlideCount>('auto')
+  const [username, setUsername] = useState<string>('@username')
+  const [photos, setPhotos] = useState<string[]>([]) // dataURL массив
+  const [fontReady, setFontReady] = useState(false)
+
+  // грузим Inter как FontFace, чтобы метрики были точные
+  useEffect(() => {
+    const f = new FontFace('Inter', 'url(https://fonts.gstatic.com/s/inter/v13/UcCO3Fwr0gYb.woff2)')
+    f.load().then(ff => {
+      (document as any).fonts.add(ff)
+      setFontReady(true)
+    }).catch(()=>setFontReady(true))
+  }, [])
+
+  // считаем слайды при каждом изменении
+  const slides = useMemo(() => {
+    if (!fontReady) return []
+    const hardMax = count === 'auto' ? 10 : count
+    return splitIntoSlides({
+      text,
+      maxSlides: hardMax,
+      fontFamily: 'Inter',
+      fontSize: 44,           // базовый кегль, будет уменьшаться при нехватке
+      minFontSize: 36,
+      lineHeight: 1.32,
+      padding: 96,
+      width: 1080,
+      height: 1350
+    })
+  }, [text, count, fontReady])
+
+  const fileInput = useRef<HTMLInputElement>(null)
+  const onPickPhotos = () => fileInput.current?.click()
+  const onFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? [])
+    const arr: string[] = []
+    for (const f of files.slice(0,10)) {
+      const buf = await f.arrayBuffer()
+      const blob = new Blob([buf], { type: f.type })
+      arr.push(await blobToDataURL(blob))
+    }
+    setPhotos(arr)
+    e.target.value = ''
+  }
+
+  const onSaveAll = async () => {
+    // рендерим/скачиваем последовательно
+    for (let i=0; i<slides.length; i++) {
+      const bg = photos[i] || photos[photos.length-1] || '' // повторяем последнее, если фоток меньше
+      const blob = await renderSlide({
+        lines: slides[i].lines,
+        fontFamily: slides[i].fontFamily,
+        fontSize: slides[i].fontSize,
+        lineHeight: slides[i].lineHeight,
+        padding: slides[i].padding,
+        width: 1080,
+        height: 1350,
+        pageIndex: i+1,
+        total: slides.length,
+        username,
+        backgroundDataURL: bg
+      })
+      const a = document.createElement('a')
+      a.href = URL.createObjectURL(blob)
+      a.download = `slide_${String(i+1).padStart(2,'0')}.jpg`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(a.href)
+      await delay(120) // чтобы iOS не «слиплась»
+    }
+  }
+
   return (
-    <div className="min-h-full pt-[calc(12px+var(--sat))] pb-[calc(12px+var(--sab))] px-4 sm:px-6">
-      {/* Topbar */}
+    <div className="min-h-full pt-[calc(12px+env(safe-area-inset-top))] pb-[calc(12px+env(safe-area-inset-bottom))] px-4 sm:px-6 bg-neutral-950 text-neutral-100">
       <div className="max-w-6xl mx-auto flex items-center gap-3 mb-4">
         <button className="px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-800 text-sm">Back</button>
         <div className="text-neutral-300 text-sm">Get Images</div>
         <div className="ml-auto text-neutral-500 text-xs">09:41</div>
       </div>
 
-      {/* Workspace */}
       <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6">
-        {/* LEFT: controls */}
+        {/* LEFT */}
         <div className="lg:col-span-5 space-y-4">
-          {/* Card */}
-          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-4 shadow-[0_0_30px_rgba(0,0,0,0.35)]">
+          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-4">
             <label className="block text-sm text-neutral-400 mb-2">Text</label>
-            <textarea placeholder="Вставь текст сюда…" className="
-                w-full h-36 resize-none px-4 py-3 rounded-xl
-                bg-neutral-950 border border-neutral-800 outline-none
-                placeholder:text-neutral-500 focus:border-neutral-600" />
+            <textarea
+              placeholder="Вставь текст сюда…"
+              className="w-full h-40 p-4 rounded-xl bg-neutral-950 border border-neutral-800 outline-none placeholder:text-neutral-500"
+              value={text}
+              onChange={e=>setText(e.target.value)}
+            />
             <div className="mt-3 flex items-center gap-3">
-              <label className="inline-flex items-center">
-                <input type="file" accept="image/*" multiple className="hidden" id="pickphotos" />
-                <span className="px-4 py-2 rounded-xl bg-neutral-100 text-neutral-900 font-medium text-sm cursor-pointer select-none"
-                  onClick={() => document.getElementById('pickphotos')?.click()}
-                >
-                  Добавить фото
-                </span>
-              </label>
-              <select className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm">
-                <option>Авто</option>
-                <option>3 слайда</option>
-                <option>5 слайдов</option>
-                <option>8 слайдов</option>
+              <input ref={fileInput} type="file" accept="image/*" multiple className="hidden" onChange={onFiles}/>
+              <button className="px-4 py-2 rounded-xl bg-neutral-100 text-neutral-900 font-medium text-sm" onClick={onPickPhotos}>
+                Добавить фото
+              </button>
+              <select
+                className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
+                value={String(count)}
+                onChange={e => setCount(e.target.value === 'auto' ? 'auto' : Number(e.target.value) as SlideCount)}
+              >
+                <option value="auto">Авто</option>
+                <option value="3">3</option>
+                <option value="5">5</option>
+                <option value="8">8</option>
+                <option value="10">10</option>
               </select>
+            </div>
+
+            <div className="mt-3 flex items-center gap-3">
+              <input
+                className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm w-full"
+                value={username}
+                onChange={e=>setUsername(e.target.value)}
+                placeholder="@username"
+              />
+              <button className="px-4 py-2 rounded-xl bg-neutral-800 border border-neutral-700 text-sm" onClick={onSaveAll} disabled={!slides.length}>
+                Save all
+              </button>
             </div>
           </div>
 
-          {/* Bottom toolbar (tabs) */}
-          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-3 flex flex-wrap gap-2">
-            <Tab active>Template</Tab>
-            <Tab>Color</Tab>
-            <Tab>Layout</Tab>
-            <Tab>Photos</Tab>
-            <Tab>Info</Tab>
-            <Tab>Export</Tab>
+          {/* Toolbar (заглушки) */}
+          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-3 flex flex-wrap gap-2 text-sm">
+            <span className="px-4 py-2 rounded-xl bg-neutral-800 border border-neutral-700">Template</span>
+            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Color</span>
+            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Layout</span>
+            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Photos</span>
+            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Info</span>
+            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Export</span>
           </div>
         </div>
 
-        {/* RIGHT: preview carousel */}
+        {/* RIGHT preview */}
         <div className="lg:col-span-7">
-          <div className="rounded-3xl bg-neutral-900/70 border border-neutral-800 p-4 lg:p-6
-                          shadow-[0_0_60px_rgba(0,0,0,0.35)]">
+          <div className="rounded-3xl bg-neutral-900/70 border border-neutral-800 p-4 lg:p-6">
             <div className="text-neutral-400 text-sm mb-3">Preview</div>
             <div className="flex gap-4 overflow-x-auto pb-2">
-              {/* Один слайд-превью — визуально как карточка 4:5 */}
-              <div className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden bg-neutral-800 relative">
-                <img src="" alt="" className="absolute inset-0 w-full h-full object-cover opacity-60" />
-                <div className="absolute inset-0 bg-black/25" />
-                <div className="absolute left-4 right-4 bottom-4 text-[15px] leading-[1.35]">
-                  <div className="inline-block bg-[#5B4BFF] text-white px-2.5 py-1.5 rounded-lg font-semibold mb-2">
-                    Выгорание убивает контент-план. Что делать?
+              {slides.map((s, i)=>(
+                <div key={i} className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden bg-neutral-800 relative p-4 text-[14px] leading-[1.35]">
+                  <div className="absolute inset-0">
+                    {photos[i] || photos[photos.length-1] ? (
+                      <>
+                        <img src={photos[i] || photos[photos.length-1]} className="w-full h-full object-cover opacity-70" />
+                        <div className="absolute inset-0 bg-black/25" />
+                      </>
+                    ) : null}
                   </div>
-                  <div className="text-neutral-100/90">
-                    Система против мотивации. Показываю рабочий подход
+                  <div className="relative z-10 h-full flex flex-col justify-end">
+                    {s.lines.map((ln, k)=>(
+                      <div key={k} className="text-neutral-100">{ln}</div>
+                    ))}
+                    <div className="mt-2 text-neutral-300 text-xs">{username}</div>
                   </div>
-                  <div className="mt-3 text-neutral-300 text-xs">@username</div>
+                  <div className="absolute right-3 bottom-3 text-neutral-300 text-xs">{i+1}/{slides.length}</div>
                 </div>
-                <div className="absolute right-4 bottom-4 text-neutral-300 text-xs">1/8</div>
-              </div>
-
-              {/* Пустые-превью для эффекта карусели */}
-              <div className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl bg-neutral-850/40 border border-neutral-800" />
-              <div className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl bg-neutral-850/40 border border-neutral-800" />
+              ))}
+              {!slides.length && <div className="text-neutral-500">Вставь текст ↑</div>}
             </div>
           </div>
         </div>
@@ -89,4 +173,7 @@ export default function App() {
     </div>
   )
 }
+
+function delay(ms:number){ return new Promise(r=>setTimeout(r,ms)) }
+async function blobToDataURL(b: Blob){ return new Promise<string>(res=>{ const r=new FileReader(); r.onload=()=>res(String(r.result)); r.readAsDataURL(b) })}
 

--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -1,5 +1,72 @@
-// TODO: canvas rendering logic
-export async function renderSlide(): Promise<HTMLCanvasElement> {
-  const canvas = document.createElement('canvas');
-  return canvas;
+export async function renderSlide(opts: {
+  lines: string[]
+  width: number
+  height: number
+  padding: number
+  fontFamily: string
+  fontSize: number
+  lineHeight: number
+  pageIndex: number
+  total: number
+  username: string
+  backgroundDataURL?: string
+}): Promise<Blob> {
+  const { width:W, height:H, padding:PAD } = opts
+  const cvs = document.createElement('canvas')
+  cvs.width = W; cvs.height = H
+  const ctx = cvs.getContext('2d')!
+
+  // фон
+  ctx.fillStyle = '#121212'
+  ctx.fillRect(0,0,W,H)
+
+  if (opts.backgroundDataURL){
+    const img = await loadImage(opts.backgroundDataURL)
+    // вписываем, cover
+    const r = Math.max(W/img.width, H/img.height)
+    const w = img.width*r, h = img.height*r
+    const x = (W - w)/2, y = (H - h)/2
+    ctx.globalAlpha = 0.9
+    ctx.drawImage(img, x,y,w,h)
+    ctx.globalAlpha = 1
+    // затемняющий оверлей
+    ctx.fillStyle = 'rgba(0,0,0,0.22)'
+    ctx.fillRect(0,0,W,H)
+  }
+
+  // текст
+  ctx.textBaseline = 'top'
+  ctx.font = `${opts.fontSize}px ${opts.fontFamily}`
+  const lh = Math.round(opts.fontSize * opts.lineHeight)
+  let y = PAD
+
+  for (const ln of opts.lines){
+    if (ln===''){ y+= Math.round(lh*0.6); continue }
+    // белый/чёрный по месту — семплим фон под строкой (просто: берём тёмный)
+    ctx.fillStyle = '#F5F5F5'
+    ctx.fillText(ln, PAD, y)
+    y += lh
+  }
+
+  // username
+  ctx.font = `${Math.round(opts.fontSize*0.65)}px ${opts.fontFamily}`
+  ctx.fillStyle = 'rgba(255,255,255,0.85)'
+  ctx.fillText(opts.username, PAD, H - PAD - Math.round(opts.fontSize*0.65) - 6)
+
+  // номер страницы
+  ctx.textAlign = 'right'
+  ctx.fillStyle = 'rgba(255,255,255,0.8)'
+  ctx.fillText(`${opts.pageIndex}/${opts.total}`, W - PAD, H - PAD)
+
+  return await new Promise<Blob>(res => cvs.toBlob(b => res(b!), 'image/jpeg', 0.92))
 }
+
+function loadImage(src:string){
+  return new Promise<HTMLImageElement>((resolve, reject)=>{
+    const img = new Image()
+    img.onload = ()=>resolve(img)
+    img.onerror = reject
+    img.src = src
+  })
+}
+

--- a/apps/webapp/src/core/text-split.ts
+++ b/apps/webapp/src/core/text-split.ts
@@ -1,4 +1,105 @@
-// TODO: implement text splitting algorithm
-export function splitText(input: string, slides: number): string[] {
-  return [input];
+type Params = {
+  text: string
+  maxSlides: number
+  fontFamily: string
+  fontSize: number
+  minFontSize: number
+  lineHeight: number
+  padding: number
+  width: number
+  height: number
 }
+
+export function splitIntoSlides(p: Params){
+  const W = p.width, H = p.height, PAD = p.padding
+  const maxWidth = W - PAD*2
+  const maxHeight = H - PAD*2
+
+  // чистим текст, разбиваем абзацы (пустая строка = новый абзац)
+  const paragraphs = p.text
+    .replace(/\r/g,'')
+    .split(/\n{2,}|\-\-\-+/g) // поддержка разделителя ---
+    .map(s=>s.trim())
+    .filter(Boolean)
+
+  let size = p.fontSize
+  let slides: {lines:string[], fontSize:number, lineHeight:number, padding:number, fontFamily:string}[] = []
+
+  while (size >= p.minFontSize) {
+    const ctx = getMeasureCtx(`${size}px ${p.fontFamily}`)
+    const lineH = Math.round(size * p.lineHeight)
+    const lines: string[] = []
+
+    // wrap по словам
+    for (const para of paragraphs) {
+      const words = para.split(/\s+/)
+      let line = ''
+      for (const w of words) {
+        const test = (line ? line + ' ' : '') + w
+        if (ctx.measureText(test).width <= maxWidth) {
+          line = test
+        } else {
+          if (line) lines.push(line)
+          // слово может быть длиннее ширины — режем грубо
+          if (ctx.measureText(w).width > maxWidth){
+            let part = ''
+            for (const ch of w){
+              const t = part + ch
+              if (ctx.measureText(t).width <= maxWidth) part = t
+              else { lines.push(part); part = ch }
+            }
+            line = part
+          } else {
+            line = w
+          }
+        }
+      }
+      if (line) lines.push(line)
+      lines.push('') // небольшой абзацный интервал (пустая строка)
+    }
+    if (lines.at(-1)==='') lines.pop()
+
+    // укладываем в страницы по высоте
+    slides = []
+    let acc:string[] = []
+    let y = 0
+    for (const ln of lines){
+      const h = ln==='' ? Math.round(lineH*0.6) : lineH
+      if (y + h > maxHeight){
+        slides.push(makeSlide(acc, size, p))
+        acc = []
+        y = 0
+      }
+      acc.push(ln)
+      y += h
+    }
+    if (acc.length) slides.push(makeSlide(acc, size, p))
+
+    if (slides.length <= p.maxSlides) break
+    size -= 2 // уменьшаем кегль и пытаемся снова
+  }
+
+  // если всё ещё перебор, ограничим количеством страниц
+  if (slides.length > p.maxSlides) slides = slides.slice(0, p.maxSlides)
+
+  return slides
+}
+
+function makeSlide(lines:string[], fontSize:number, p:Params){
+  return {
+    lines,
+    fontSize,
+    lineHeight: p.lineHeight,
+    padding: p.padding,
+    fontFamily: p.fontFamily
+  }
+}
+
+let _canvas: HTMLCanvasElement | null = null
+function getMeasureCtx(font: string){
+  if (!_canvas){ _canvas = document.createElement('canvas') }
+  const ctx = _canvas.getContext('2d')!
+  ctx.font = font
+  return ctx
+}
+


### PR DESCRIPTION
## Summary
- implement text splitting based on font metrics and max slide count
- add canvas renderer for slides with optional photo background
- integrate slide generation, preview, and export UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be2d3a975083288cbc62463ff89bc8