### PR TITLE
feat: add mobile-friendly export and rendering tweaks

### DIFF
--- a/apps/webapp/src/core/export.ts
+++ b/apps/webapp/src/core/export.ts
@@ -1,4 +1,46 @@
-// TODO: implement export to blob or share
-export async function exportSlide(canvas: HTMLCanvasElement): Promise<void> {
-  void canvas;
+export async function shareOrDownloadAll(blobs: Blob[]) {
+  const files = blobs.map((b, i) => new File([b], `slide_${String(i+1).padStart(2,'0')}.jpg`, { type: 'image/jpeg' }))
+
+  // 1) Лучшее: системный шэр (iOS/Android)
+  if ((navigator as any).canShare && (navigator as any).canShare({ files })) {
+    await (navigator as any).share({ files, title: 'Carousel' }).catch(()=>{})
+    return
+  }
+
+  // 2) Открыть каждый файл во вкладке (топ для iOS Telegram)
+  const isIosTg = /(iphone|ipad)/i.test(navigator.userAgent) && !!(window as any).Telegram?.WebApp
+  if (isIosTg) {
+    for (const f of files) {
+      const url = URL.createObjectURL(f)
+      window.open(url, '_blank')  // «Открыть» -> «Сохранить»
+      await delay(200)
+      URL.revokeObjectURL(url)
+    }
+    return
+  }
+
+  // 3) Стандартное скачивание якорем (Android/десктоп)
+  for (const f of files) {
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(f)
+    a.download = f.name
+    document.body.appendChild(a); a.click(); a.remove()
+    await delay(120)
+    URL.revokeObjectURL(a.href)
+  }
 }
+
+export async function downloadOne(blob: Blob, name='slide.jpg') {
+  const file = new File([blob], name, { type: 'image/jpeg' })
+
+  if ((navigator as any).canShare && (navigator as any).canShare({ files: [file] })) {
+    await (navigator as any).share({ files: [file], title: name }).catch(()=>{})
+    return
+  }
+  const url = URL.createObjectURL(file)
+  const isIosTg = /(iphone|ipad)/i.test(navigator.userAgent) && !!(window as any).Telegram?.WebApp
+  if (isIosTg) { window.open(url, '_blank'); await delay(200); URL.revokeObjectURL(url); return }
+  const a = document.createElement('a'); a.href = url; a.download = name; document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url)
+}
+
+function delay(ms:number){ return new Promise(r=>setTimeout(r,ms)) }

--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -12,61 +12,65 @@ export async function renderSlide(opts: {
   backgroundDataURL?: string
 }): Promise<Blob> {
   const { width:W, height:H, padding:PAD } = opts
-  const cvs = document.createElement('canvas')
-  cvs.width = W; cvs.height = H
+  const cvs = document.createElement('canvas'); cvs.width = W; cvs.height = H
   const ctx = cvs.getContext('2d')!
 
   // фон
-  ctx.fillStyle = '#121212'
-  ctx.fillRect(0,0,W,H)
+  ctx.fillStyle = '#121212'; ctx.fillRect(0,0,W,H)
 
+  let avgLumUnderText = 0.1
   if (opts.backgroundDataURL){
     const img = await loadImage(opts.backgroundDataURL)
-    // вписываем, cover
     const r = Math.max(W/img.width, H/img.height)
     const w = img.width*r, h = img.height*r
     const x = (W - w)/2, y = (H - h)/2
-    ctx.globalAlpha = 0.9
     ctx.drawImage(img, x,y,w,h)
-    ctx.globalAlpha = 1
-    // затемняющий оверлей
-    ctx.fillStyle = 'rgba(0,0,0,0.22)'
+
+    // оцениваем среднюю яркость под текстовой областью
+    const sx = PAD, sy = PAD, sw = W - PAD*2, sh = H - PAD*2
+    const sample = ctx.getImageData(sx,sy,sw,sh).data
+    let sum = 0
+    for (let i=0;i<sample.length;i+=4){
+      const r=sample[i], g=sample[i+1], b=sample[i+2]
+      // относительная яркость
+      sum += (0.2126*r + 0.7152*g + 0.0722*b)/255
+    }
+    avgLumUnderText = sum / (sample.length/4)
+
+    // динамический оверлей: чем светлее фон, тем темнее слой
+    const overlay = clamp(0.15 + (avgLumUnderText-0.4)*0.4, 0.15, 0.32)
+    ctx.fillStyle = `rgba(0,0,0,${overlay.toFixed(3)})`
     ctx.fillRect(0,0,W,H)
   }
 
-  // текст
+  // цвет текста по контрасту
+  const textIsLight = avgLumUnderText < 0.5
+  const textColor = textIsLight ? '#F5F5F5' : '#111111'
+  const subColor  = textIsLight ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.8)'
+
   ctx.textBaseline = 'top'
   ctx.font = `${opts.fontSize}px ${opts.fontFamily}`
   const lh = Math.round(opts.fontSize * opts.lineHeight)
   let y = PAD
 
+  ctx.fillStyle = textColor
   for (const ln of opts.lines){
     if (ln===''){ y+= Math.round(lh*0.6); continue }
-    // белый/чёрный по месту — семплим фон под строкой (просто: берём тёмный)
-    ctx.fillStyle = '#F5F5F5'
-    ctx.fillText(ln, PAD, y)
-    y += lh
+    ctx.fillText(ln, PAD, y); y += lh
   }
 
   // username
-  ctx.font = `${Math.round(opts.fontSize*0.65)}px ${opts.fontFamily}`
-  ctx.fillStyle = 'rgba(255,255,255,0.85)'
-  ctx.fillText(opts.username, PAD, H - PAD - Math.round(opts.fontSize*0.65) - 6)
+  const unSize = Math.round(opts.fontSize*0.65)
+  ctx.font = `${unSize}px ${opts.fontFamily}`
+  ctx.fillStyle = subColor
+  ctx.fillText(opts.username, PAD, H - PAD - unSize - 6)
 
   // номер страницы
   ctx.textAlign = 'right'
-  ctx.fillStyle = 'rgba(255,255,255,0.8)'
   ctx.fillText(`${opts.pageIndex}/${opts.total}`, W - PAD, H - PAD)
 
-  return await new Promise<Blob>(res => cvs.toBlob(b => res(b!), 'image/jpeg', 0.92))
+  return await new Promise<Blob>(res => cvs.toBlob(b => res(b!), 'image/jpeg', 0.92)!)
 }
 
-function loadImage(src:string){
-  return new Promise<HTMLImageElement>((resolve, reject)=>{
-    const img = new Image()
-    img.onload = ()=>resolve(img)
-    img.onerror = reject
-    img.src = src
-  })
-}
-
+function clamp(n:number, a:number, b:number){ return Math.max(a, Math.min(b, n)) }
+function loadImage(src:string){ return new Promise<HTMLImageElement>((resolve, reject)=>{ const img=new Image(); img.onload=()=>resolve(img); img.onerror=reject; img.src=src }) }

--- a/apps/webapp/src/core/text-split.ts
+++ b/apps/webapp/src/core/text-split.ts
@@ -79,9 +79,11 @@ export function splitIntoSlides(p: Params){
     size -= 2 // уменьшаем кегль и пытаемся снова
   }
 
-  // если всё ещё перебор, ограничим количеством страниц
-  if (slides.length > p.maxSlides) slides = slides.slice(0, p.maxSlides)
-
+  // если перебор
+  if (slides.length > p.maxSlides) {
+    // если пользователь выбрал "auto" (мы передаём 10), оставляем 10
+    slides = slides.slice(0, p.maxSlides)
+  }
   return slides
 }
 


### PR DESCRIPTION
## Summary
- add export helpers that share when possible and fall back to opening or downloading images
- improve slide rendering with photo background overlay and automatic text contrast
- hook up new export flow in UI with Share button and cap auto slide count

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be2f4cf88c8328afc8b1ba4b54a06f