### PR TITLE
Add theme toggle and hyphenation scaffolding

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { splitIntoSlides } from './core/text-split'
 import { shareOrDownloadAll, downloadOne } from './core/export'
 import { renderSlide } from './core/render'
+import { Action, PenIcon, ArrowLrIcon, TrashIcon } from './ui/Action'
 import './styles/tailwind.css'
 
 type SlideCount = 'auto' | 3 | 5 | 8 | 10
+type Theme = 'light' | 'dark' | 'photo'
 
 export default function App() {
   const [text, setText] = useState<string>('')
@@ -12,6 +14,7 @@ export default function App() {
   const [username, setUsername] = useState<string>('@username')
   const [photos, setPhotos] = useState<string[]>([]) // dataURL массив
   const [fontReady, setFontReady] = useState(false)
+  const [theme, setTheme] = useState<Theme>('light')
 
   // грузим Inter как FontFace, чтобы метрики были точные
   useEffect(() => {
@@ -23,20 +26,24 @@ export default function App() {
   }, [])
 
   // считаем слайды при каждом изменении
-  const slides = useMemo(() => {
-    if (!fontReady) return []
+  const [slides, setSlides] = useState<{lines:string[], fontSize:number, lineHeight:number, padding:number, fontFamily:string}[]>([])
+  useEffect(() => {
+    if (!fontReady) { setSlides([]); return }
     const hardMax = count === 'auto' ? 10 : count
-    return splitIntoSlides({
-      text,
-      maxSlides: hardMax,
-      fontFamily: 'Inter',
-      fontSize: 44,           // базовый кегль, будет уменьшаться при нехватке
-      minFontSize: 36,
-      lineHeight: 1.32,
-      padding: 96,
-      width: 1080,
-      height: 1350
-    })
+    ;(async()=>{
+      const res = await splitIntoSlides({
+        text,
+        maxSlides: hardMax,
+        fontFamily: 'Inter',
+        fontSize: 44,           // базовый кегль, будет уменьшаться при нехватке
+        minFontSize: 36,
+        lineHeight: 1.32,
+        padding: 96,
+        width: 1080,
+        height: 1350
+      })
+      setSlides(res)
+    })()
   }, [text, count, fontReady])
 
   const fileInput = useRef<HTMLInputElement>(null)
@@ -65,7 +72,8 @@ export default function App() {
         padding: slides[i].padding,
         width: 1080, height: 1350,
         pageIndex: i+1, total: slides.length, username,
-        backgroundDataURL: bg
+        backgroundDataURL: bg,
+        theme
       })
       blobs.push(blob)
     }
@@ -83,7 +91,8 @@ export default function App() {
       padding: slides[0].padding,
       width: 1080, height: 1350,
       pageIndex: 1, total: slides.length, username,
-      backgroundDataURL: bg
+      backgroundDataURL: bg,
+      theme
     }))
   }
 
@@ -98,11 +107,17 @@ export default function App() {
       <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6">
         {/* LEFT */}
         <div className="lg:col-span-5 space-y-4">
-          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-4">
+          <div className={`
+  rounded-2xl p-4 transition-colors
+  ${theme==='dark' ? 'bg-neutral-900/70 border border-neutral-800 text-neutral-100' : 'bg-white border border-neutral-200 text-neutral-900'}
+`}>
             <label className="block text-sm text-neutral-400 mb-2">Text</label>
             <textarea
               placeholder="Вставь текст сюда…"
-              className="w-full h-40 p-4 rounded-xl bg-neutral-950 border border-neutral-800 outline-none placeholder:text-neutral-500"
+              className={`
+    w-full h-40 p-4 rounded-xl outline-none
+    ${theme==='dark' ? 'bg-neutral-950 border border-neutral-800 text-neutral-100 placeholder:text-neutral-500' : 'bg-white border border-neutral-300 text-neutral-900 placeholder:text-neutral-400'}
+  `}
               value={text}
               onChange={e=>setText(e.target.value)}
             />
@@ -126,7 +141,10 @@ export default function App() {
 
             <div className="mt-3 flex items-center gap-3">
               <input
-                className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm w-full"
+                className={`
+    px-3 py-2 rounded-xl text-sm w-full
+    ${theme==='dark' ? 'bg-neutral-900 border border-neutral-800 text-neutral-100' : 'bg-white border border-neutral-300 text-neutral-900'}
+  `}
                 value={username}
                 onChange={e=>setUsername(e.target.value)}
                 placeholder="@username"
@@ -140,24 +158,29 @@ export default function App() {
             </div>
           </div>
 
-          {/* Toolbar (заглушки) */}
-          <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-3 flex flex-wrap gap-2 text-sm">
-            <span className="px-4 py-2 rounded-xl bg-neutral-800 border border-neutral-700">Template</span>
-            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Color</span>
-            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Layout</span>
-            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Photos</span>
-            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Info</span>
-            <span className="px-4 py-2 rounded-xl bg-neutral-900 border border-neutral-800">Export</span>
+          <div className="rounded-2xl bg-white/70 border border-neutral-200 p-3 flex flex-wrap gap-2 text-sm text-neutral-700">
+            <button className={`px-4 py-2 rounded-xl border ${theme==='light'?'bg-white border-neutral-300 shadow':'bg-white/70 border-neutral-200'}`} onClick={()=>setTheme('light')}>Template: Light</button>
+            <button className={`px-4 py-2 rounded-xl border ${theme==='dark'?'bg-neutral-900 text-white border-neutral-800':'bg-neutral-900/70 text-white/80 border-neutral-800'}`} onClick={()=>setTheme('dark')}>Dark</button>
+            <button className={`px-4 py-2 rounded-xl border ${theme==='photo'?'bg-white border-neutral-300 shadow':'bg-white/70 border-neutral-200'}`} onClick={()=>setTheme('photo')}>Photo</button>
+            <span className="ml-auto text-neutral-400">Info</span>
+            <span className="text-neutral-400">Export</span>
           </div>
         </div>
 
         {/* RIGHT preview */}
         <div className="lg:col-span-7">
-          <div className="rounded-3xl bg-neutral-900/70 border border-neutral-800 p-4 lg:p-6">
+          <div className={`
+  rounded-3xl p-4 lg:p-6 transition-colors
+  ${theme==='dark' ? 'bg-neutral-900/70 border border-neutral-800' : 'bg-white border border-neutral-200'}
+`}> 
             <div className="text-neutral-400 text-sm mb-3">Preview</div>
-            <div className="flex gap-4 overflow-x-auto pb-2">
+            <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scroll-smooth">
               {slides.map((s, i)=>(
-                <div key={i} className="shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden bg-neutral-800 relative p-4 text-[14px] leading-[1.35]">
+                <div key={i}
+      className={`
+        snap-start shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden relative p-4 text-[14px] leading-[1.35]
+        ${theme==='dark' ? 'bg-neutral-800' : 'bg-neutral-100'}
+      `}>
                   <div className="absolute inset-0">
                     {photos[i] || photos[photos.length-1] ? (
                       <>
@@ -168,14 +191,19 @@ export default function App() {
                   </div>
                   <div className="relative z-10 h-full flex flex-col justify-end">
                     {s.lines.map((ln, k)=>(
-                      <div key={k} className="text-neutral-100">{ln}</div>
+                      <div key={k} className={theme==='dark'? 'text-neutral-100':'text-neutral-900'}>{ln}</div>
                     ))}
-                    <div className="mt-2 text-neutral-300 text-xs">{username}</div>
+                    <div className={`mt-2 text-xs ${theme==='dark'?'text-neutral-300':'text-neutral-500'}`}>{username}</div>
                   </div>
-                  <div className="absolute right-3 bottom-3 text-neutral-300 text-xs">{i+1}/{slides.length}</div>
+                  <div className={`absolute right-3 bottom-3 text-xs ${theme==='dark'?'text-neutral-300':'text-neutral-500'}`}>{i+1}/{slides.length}</div>
                 </div>
               ))}
               {!slides.length && <div className="text-neutral-500">Вставь текст ↑</div>}
+            </div>
+            <div className="mt-3 flex items-center gap-10">
+              <Action icon={PenIcon} label="Edit"   onClick={()=>{}} />
+              <Action icon={ArrowLrIcon} label="Reorder" onClick={()=>{}} />
+              <Action icon={TrashIcon} label="Delete" onClick={()=>{}} />
             </div>
           </div>
         </div>

--- a/apps/webapp/src/core/hyphen.ts
+++ b/apps/webapp/src/core/hyphen.ts
@@ -1,4 +1,19 @@
-// TODO: integrate hyphenation library
-export function hyphenate(text: string): string {
-  return text;
+export type Hyphenator = (s: string) => Promise<string>
+
+let hy: Hyphenator | undefined
+export async function initHyphenRu(): Promise<Hyphenator> {
+  if (!hy) {
+    try {
+      const Hyphenopoly: any = await (new Function("return import('hyphenopoly')")())
+      const loader = Hyphenopoly.default.config({
+        require: ['ru'],
+        hyphen: '\u00AD',
+        paths: { patterndir: '/hyphen/' }
+      })
+      hy = (s: string) => loader.then((h: any) => h.hyphenate(s, 'ru'))
+    } catch {
+      hy = async (s: string) => s
+    }
+  }
+  return hy
 }

--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -1,4 +1,4 @@
-export async function renderSlide(opts: {
+export interface RenderOptions {
   lines: string[]
   width: number
   height: number
@@ -10,16 +10,21 @@ export async function renderSlide(opts: {
   total: number
   username: string
   backgroundDataURL?: string
-}): Promise<Blob> {
+  theme?: 'light' | 'dark' | 'photo'
+}
+
+export async function renderSlide(opts: RenderOptions): Promise<Blob> {
   const { width:W, height:H, padding:PAD } = opts
   const cvs = document.createElement('canvas'); cvs.width = W; cvs.height = H
   const ctx = cvs.getContext('2d')!
 
   // фон
-  ctx.fillStyle = '#121212'; ctx.fillRect(0,0,W,H)
-
-  let avgLumUnderText = 0.1
-  if (opts.backgroundDataURL){
+  let avgLumUnderText = opts.theme === 'dark' ? 0.1 : 0.9
+  if (!opts.backgroundDataURL || opts.theme !== 'photo'){
+    ctx.fillStyle = opts.theme === 'dark' ? '#121212' : '#FFFFFF'
+    ctx.fillRect(0,0,W,H)
+  }
+  if (opts.backgroundDataURL && opts.theme==='photo'){
     const img = await loadImage(opts.backgroundDataURL)
     const r = Math.max(W/img.width, H/img.height)
     const w = img.width*r, h = img.height*r

--- a/apps/webapp/src/ui/Action.tsx
+++ b/apps/webapp/src/ui/Action.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+export const Action = ({icon:Icon,label,onClick}:{icon:React.FC<React.SVGProps<SVGSVGElement>>,label:string,onClick:()=>void}) => (
+  <button onClick={onClick} className="flex items-center gap-2">
+    <span className="w-10 h-10 rounded-full border border-neutral-300 bg-white flex items-center justify-center shadow">
+      <Icon width={18} height={18} />
+    </span>
+    <span className="text-sm text-neutral-600">{label}</span>
+  </button>
+)
+
+export const PenIcon = (p:any) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...p}>
+    <path strokeWidth="2" d="M12 20h9" />
+    <path strokeWidth="2" d="M16.5 3.5l4 4L7 21H3v-4L16.5 3.5z" />
+  </svg>
+)
+
+export const ArrowLrIcon = (p:any) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...p}>
+    <path strokeWidth="2" d="M7 7l-4 4 4 4" />
+    <path strokeWidth="2" d="M17 7l4 4-4 4" />
+    <path strokeWidth="2" d="M3 11h18M3 13h18" />
+  </svg>
+)
+
+export const TrashIcon = (p:any) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" {...p}>
+    <path strokeWidth="2" d="M3 6h18" />
+    <path strokeWidth="2" d="M8 6V4h8v2" />
+    <path strokeWidth="2" d="M19 6l-1 14H6L5 6" />
+  </svg>
+)


### PR DESCRIPTION
## Summary
- implement action buttons and scrolling preview with snap support
- introduce light/dark/photo template theme switching
- scaffold Russian hyphenation using Hyphenopoly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68be34f827148328a9057e16612758e2