### PR TITLE
Align slide content to bottom and debounce exports

### DIFF
--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -12,6 +12,7 @@ export async function renderSlide(opts: {
   backgroundDataURL?: string
   title?: string
   subtitle?: string
+  align?: 'top' | 'bottom'
 }): Promise<Blob> {
   const { width:W, height:H, padding:PAD } = opts
   const cvs = document.createElement('canvas'); cvs.width = W; cvs.height = H
@@ -51,60 +52,91 @@ export async function renderSlide(opts: {
   const subColor  = textIsLight ? 'rgba(255,255,255,0.85)' : 'rgba(0,0,0,0.8)'
 
   const lh = Math.round(opts.fontSize * opts.lineHeight)
-  let y = opts.padding
+  const gap = Math.round(lh * 0.6)
 
-  // === HERO title pill =====================================================
+  // --- pre-calc heights for title/subtitle/body ---
+  ctx.font = `${opts.fontSize}px ${opts.fontFamily}`
+  let blockH = opts.lines.reduce((h, ln) => h + (ln === '' ? gap : lh), 0)
+
+  let titleLines: string[] = []
+  let titleSize = Math.round(opts.fontSize * 1.0)
+  let titleLH = Math.round(titleSize * 1.15)
+  const pillPadX = 22, pillPadY = 12
+  let pillW = 0, pillH = 0
   if (opts.title) {
-    const pillPadX = 22, pillPadY = 12
-    const titleSize = Math.round(opts.fontSize * 1.0)
-    const titleLH = Math.round(titleSize * 1.15)
     ctx.font = `${titleSize}px ${opts.fontFamily}`
-    ctx.textBaseline = 'top'
-    const lines = wrap(ctx, opts.title, (opts.width - opts.padding*2) - pillPadX*2)
+    titleLines = wrap(ctx, opts.title, (opts.width - opts.padding*2) - pillPadX*2)
+    pillW = Math.max(...titleLines.map(ln => ctx.measureText(ln).width), 0) + pillPadX*2
+    pillH = titleLines.length * titleLH + pillPadY*2
+    blockH += pillH + Math.round(titleLH*0.6)
+  }
 
-    const pillH = lines.length * titleLH + pillPadY*2
-    // плашка
-    roundRect(ctx, opts.padding, y, opts.width - opts.padding*2, pillH, 14)
+  let subLines: string[] = []
+  const subSize = Math.round(opts.fontSize * 0.82)
+  const subLH = Math.round(subSize * 1.28)
+  if (opts.subtitle) {
+    ctx.font = `${subSize}px ${opts.fontFamily}`
+    subLines = wrap(ctx, opts.subtitle, opts.width - opts.padding*2)
+    blockH += subLines.length * subLH + Math.round(subLH*0.4)
+  }
+
+  const usernameSize = Math.round(opts.fontSize * 0.65)
+  const bottomMetaH = usernameSize + 6
+
+  let y = opts.padding
+  if ((opts.align ?? 'bottom') === 'bottom') {
+    y = opts.height - opts.padding - bottomMetaH - blockH
+    if (y < opts.padding) y = opts.padding
+  }
+
+  ctx.textBaseline = 'top'
+
+  // --- HERO title pill ---
+  if (opts.title) {
+    ctx.font = `${titleSize}px ${opts.fontFamily}`
+    roundRect(ctx, opts.padding, y, pillW, pillH, 14)
     ctx.fillStyle = '#5B4BFF'; ctx.globalAlpha = 0.95; ctx.fill(); ctx.globalAlpha = 1
-
-    // текст в плашке
     ctx.fillStyle = '#FFFFFF'
     let ty = y + pillPadY
-    for (const ln of lines){ ctx.fillText(ln, opts.padding + pillPadX, ty); ty += titleLH }
-
+    for (const ln of titleLines){ ctx.fillText(ln, opts.padding + pillPadX, ty); ty += titleLH }
     y += pillH + Math.round(titleLH*0.6)
   }
 
-  // === Subtitle ============================================================
+  // --- Subtitle ---
   if (opts.subtitle) {
-    const subSize = Math.round(opts.fontSize * 0.82)
-    const subLH = Math.round(subSize * 1.28)
     ctx.font = `${subSize}px ${opts.fontFamily}`
     ctx.fillStyle = subColor
-    for (const ln of wrap(ctx, opts.subtitle, opts.width - opts.padding*2)){
-      ctx.fillText(ln, opts.padding, y); y += subLH
-    }
+    for (const ln of subLines){ ctx.fillText(ln, opts.padding, y); y += subLH }
     y += Math.round(subLH*0.4)
   }
 
-  // === Body (обычные строки) ==============================================
-  ctx.textBaseline = 'top'
+  // --- Body ---
   ctx.font = `${opts.fontSize}px ${opts.fontFamily}`
   ctx.fillStyle = textColor
   for (const ln of opts.lines){
-    if (ln===''){ y+= Math.round(lh*0.6); continue }
-    ctx.fillText(ln, opts.padding, y); y += lh
+    const step = ln === '' ? gap : lh
+    if (ln) ctx.fillText(ln, opts.padding, y)
+    y += step
   }
 
-  // username
-  const unSize = Math.round(opts.fontSize*0.65)
-  ctx.font = `${unSize}px ${opts.fontFamily}`
-  ctx.fillStyle = subColor
-  ctx.fillText(opts.username, PAD, H - PAD - unSize - 6)
+  // mini-username at top-left
+  ctx.font = `${Math.round(opts.fontSize*0.55)}px ${opts.fontFamily}`
+  ctx.fillStyle = 'rgba(255,255,255,0.85)'
+  ctx.textAlign = 'left'
+  ctx.fillText('@' + opts.username.replace(/^@/,''), opts.padding, opts.padding)
 
-  // номер страницы
+  // big username bottom-left
+  ctx.font = `${usernameSize}px ${opts.fontFamily}`
+  ctx.fillStyle = subColor
+  ctx.fillText('@' + opts.username.replace(/^@/,''), PAD, H - PAD - usernameSize - 6)
+
+  // page index
   ctx.textAlign = 'right'
   ctx.fillText(`${opts.pageIndex}/${opts.total}`, W - PAD, H - PAD)
+
+  // arrow near pager
+  ctx.textAlign = 'left'
+  ctx.fillText('→', W - PAD - 18, H - PAD - usernameSize - 6)
 
   return await new Promise<Blob>(res => cvs.toBlob(b => res(b!), 'image/jpeg', 0.92)!)
 }


### PR DESCRIPTION
## Summary
- Add optional `align` parameter to slide renderer to bottom-align text, include mini username and arrow
- Anchor preview content at bottom and pass `align: 'bottom'` to renders
- Debounce `Save all` to prevent duplicate exports and disable button during processing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68be3897cc0883288d22dddbc52665f7