### PR TITLE
feat: add bottom sheets and image modal

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,26 +1,39 @@
-import React, { useEffect, useMemo, useRef, useState } from "react"
-import { splitIntoSlides } from "./core/text-split"
-import { renderSlide } from "./core/render"
-import { shareOrDownloadAll } from "./core/export"
-import { makeStory } from "./core/story"
-import "./styles/tailwind.css"
+import React, { useEffect, useMemo, useState } from "react";
+import { splitIntoSlides } from "./core/text-split";
+import { renderSlide } from "./core/render";
+import { shareOrDownloadAll } from "./core/export";
+import { makeStory } from "./core/story";
+import BottomBar from "./components/BottomBar";
+import BottomSheet from "./components/BottomSheet";
+import ImagesModal from "./components/ImagesModal";
+import "./styles/tailwind.css";
 
-type SlideCount = "auto" | 1|2|3|4|5|6|7|8|9|10
-type Theme = "light" | "dark" | "photo"
+type SlideCount = "auto" | 1|2|3|4|5|6|7|8|9|10;
+type Theme = "light" | "dark" | "photo";
+type Img = {id:string; url:string};
 
 export default function App() {
-  const [text, setText] = useState("")
-  const [count, setCount] = useState<SlideCount>("auto")
-  const [username, setUsername] = useState("@username")
-  const [photos, setPhotos] = useState<string[]>([])
-  const [fontReady, setFontReady] = useState(false)
-  const [theme, setTheme] = useState<Theme>("photo")
-  const [isExporting, setIsExporting] = useState(false)
+  const [text, setText] = useState("");
+  const [count, setCount] = useState<SlideCount>("auto");
+  const [username, setUsername] = useState("@username");
+  const [fontReady, setFontReady] = useState(false);
+  const [theme, setTheme] = useState<Theme>("photo");
+  const [accent, setAccent] = useState("#5B4BFF");
+  const [fontSize, setFontSize] = useState(42);
+  const [lineHeight, setLineHeight] = useState(1.32);
+  const [isExporting, setIsExporting] = useState(false);
+  const [images, setImages] = useState<Img[]>([]);
+  const [previews, setPreviews] = useState<string[]>([]);
+  const [openTemplate, setOpenTemplate] = useState(false);
+  const [openColor, setOpenColor] = useState(false);
+  const [openLayout, setOpenLayout] = useState(false);
+  const [openImages, setOpenImages] = useState(false);
+  const [openInfo, setOpenInfo] = useState(false);
 
   useEffect(() => {
-    const f = new FontFace("Inter", "url(https://fonts.gstatic.com/s/inter/v13/UcCO3Fwr0gYb.woff2)")
-    f.load().then(ff => { (document as any).fonts.add(ff); setFontReady(true) }).catch(()=>setFontReady(true))
-  }, [])
+    const f = new FontFace("Inter", "url(https://fonts.gstatic.com/s/inter/v13/UcCO3Fwr0gYb.woff2)");
+    f.load().then(ff => { (document as any).fonts.add(ff); setFontReady(true); }).catch(()=>setFontReady(true));
+  }, []);
 
   useEffect(() => {
     if (localStorage.getItem("carousel__seeded")) return;
@@ -41,66 +54,72 @@ export default function App() {
     localStorage.setItem("carousel__seeded", "1");
   }, []);
 
-  const fileInput = useRef<HTMLInputElement>(null)
-  const onPickPhotos = () => fileInput.current?.click()
-  const onFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = Array.from(e.target.files ?? [])
-    const arr: string[] = []
-    for (const f of files.slice(0,10)) {
-      const buf = await f.arrayBuffer()
-      const blob = new Blob([buf], {type: f.type})
-      arr.push(await blobToDataURL(blob))
-    }
-    setPhotos(arr); e.target.value = ""
-  }
-
   const slides = useMemo(() => {
-    if (!fontReady) return []
-    const maxN = count === "auto" ? 10 : (count as number)
-    const story = makeStory(text, maxN)
+    if (!fontReady) return [];
+    const maxN = count === "auto" ? 10 : (count as number);
+    const story = makeStory(text, maxN);
     const packed = story.map(block => {
-      const bodyText = (block.body ?? []).join(" ")
+      const bodyText = (block.body ?? []).join(" ");
       const s = splitIntoSlides({
         text: bodyText, maxSlides: 1, fontFamily: "Inter",
-        fontSize: 42, minFontSize: 34, lineHeight: 1.32,
+        fontSize, minFontSize: Math.max(12, fontSize-8), lineHeight,
         padding: 96, width:1080, height:1350
-      })[0] ?? { lines:[], fontFamily:"Inter", fontSize:42, lineHeight:1.32, padding:96 }
-      return { ...s, title: block.title, subtitle: block.subtitle }
-    })
-    return packed.slice(0, maxN)
-  }, [text, count, fontReady])
+      })[0] ?? { lines:[], fontFamily:"Inter", fontSize, lineHeight, padding:96 };
+      return { ...s, title: block.title, subtitle: block.subtitle };
+    });
+    return packed.slice(0, maxN);
+  }, [text, count, fontReady, fontSize, lineHeight]);
 
-  const onSaveAll = async () => {
-    if (isExporting) return
-    setIsExporting(true)
-    try {
-      const blobs: Blob[] = []
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
+      const urls: string[] = [];
       for (let i=0; i<slides.length; i++){
-        const bg = photos[i] || photos[photos.length-1] || ""
+        const bg = images[i]?.url || images[images.length-1]?.url || "";
         const blob = await renderSlide({
           lines: slides[i].lines,
           title: slides[i].title, subtitle: slides[i].subtitle,
           fontFamily: slides[i].fontFamily, fontSize: slides[i].fontSize,
           lineHeight: slides[i].lineHeight, padding: slides[i].padding,
           width:1080, height:1350, pageIndex:i+1, total:slides.length,
-          username, backgroundDataURL: bg, theme
-        })
-        blobs.push(blob)
+          username, backgroundDataURL: bg, theme, accent,
+          showTopUsername:false,
+        });
+        urls.push(URL.createObjectURL(blob));
       }
-      await shareOrDownloadAll(blobs)
+      if (!cancel) setPreviews(urls);
+    })();
+    return () => {
+      cancel = true;
+      setPreviews(prev => { prev.forEach(u=>URL.revokeObjectURL(u)); return []; });
+    };
+  }, [slides, images, username, theme, accent]);
+
+  const onSaveAll = async () => {
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      const blobs: Blob[] = [];
+      for (let i=0; i<slides.length; i++){
+        const bg = images[i]?.url || images[images.length-1]?.url || "";
+        const blob = await renderSlide({
+          lines: slides[i].lines,
+          title: slides[i].title, subtitle: slides[i].subtitle,
+          fontFamily: slides[i].fontFamily, fontSize: slides[i].fontSize,
+          lineHeight: slides[i].lineHeight, padding: slides[i].padding,
+          width:1080, height:1350, pageIndex:i+1, total:slides.length,
+          username, backgroundDataURL: bg, theme, accent, showTopUsername:true,
+        });
+        blobs.push(blob);
+      }
+      await shareOrDownloadAll(blobs);
     } finally {
-      setTimeout(()=>setIsExporting(false), 600)
+      setTimeout(()=>setIsExporting(false), 600);
     }
-  }
+  };
 
   return (
     <div className="min-h-full pt-[calc(12px+env(safe-area-inset-top))] pb-[calc(12px+env(safe-area-inset-bottom))] px-4 sm:px-6 bg-neutral-950 text-neutral-100">
-      <div className="max-w-6xl mx-auto flex items-center gap-3 mb-4">
-        <button className="px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-800 text-sm">Back</button>
-        <div className="text-neutral-300 text-sm">Get Images</div>
-        <div className="ml-auto text-neutral-500 text-xs">09:41</div>
-      </div>
-
       <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6">
         <div className="lg:col-span-5 space-y-4">
           <div className="rounded-2xl bg-neutral-900/70 border border-neutral-800 p-4">
@@ -111,11 +130,6 @@ export default function App() {
               value={text} onChange={e=>setText(e.target.value)}
             />
             <div className="mt-3 flex items-center gap-3">
-              <input ref={fileInput} type="file" accept="image/*" multiple className="hidden" onChange={onFiles}/>
-              <button className="px-4 py-2 rounded-xl bg-neutral-100 text-neutral-900 font-medium text-sm" onClick={onPickPhotos}>
-                Добавить фото
-              </button>
-
               <select
                 className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm"
                 value={String(count)}
@@ -124,9 +138,6 @@ export default function App() {
                 <option value="auto">Авто</option>
                 {[...Array(10)].map((_,i)=><option key={i+1} value={i+1}>{i+1}</option>)}
               </select>
-            </div>
-
-            <div className="mt-3 flex items-center gap-3">
               <input
                 className="px-3 py-2 rounded-xl bg-neutral-900 border border-neutral-800 text-sm w-full"
                 value={username} onChange={e=>setUsername(e.target.value)} placeholder="@username"
@@ -135,12 +146,6 @@ export default function App() {
                 className={`px-4 py-2 rounded-xl ${isExporting?'opacity-50 pointer-events-none':''} bg-neutral-800 border border-neutral-700 text-sm`}
                 onClick={onSaveAll} disabled={!slides.length || isExporting}
               >{isExporting ? "Saving…" : "Save all"}</button>
-
-              <button
-                className="px-4 py-2 rounded-xl bg-neutral-800 border border-neutral-700 text-sm"
-                onClick={()=>setTheme(t=> t==="photo"?"dark": t==="dark"?"light":"photo")}
-                title="Template: photo → dark → light"
-              >Template: {theme}</button>
             </div>
           </div>
         </div>
@@ -148,67 +153,64 @@ export default function App() {
         <div className="lg:col-span-7">
           <div className="rounded-3xl bg-neutral-900/70 border border-neutral-800 p-4 lg:p-6">
             <div className="text-neutral-400 text-sm mb-3">Preview</div>
-
             <div className="flex gap-4 overflow-x-auto pb-2 snap-x snap-mandatory scroll-smooth">
-              {slides.map((s,i)=>(
-                <div key={i} className="snap-start shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden bg-neutral-800 relative p-4 text-[14px] leading-[1.35]">
-                  <div className="absolute inset-0">
-                    {photos[i] || photos[photos.length-1] ? (
-                      <>
-                        <img src={photos[i] || photos[photos.length-1]} className="w-full h-full object-cover opacity-70" />
-                        <div className="absolute inset-0 bg-black/25" />
-                      </>
-                    ) : null}
-                  </div>
-
-                  <div className="absolute top-3 left-3 text-white/85 text-xs z-10">@{username.replace(/^@/,'')}</div>
-
-                  <div className="relative z-10 h-full flex flex-col justify-end">
-                    {s.title && <div className="inline-block bg-[#5B4BFF] text-white px-3 py-2 rounded-lg font-semibold mb-2 self-start">{s.title}</div>}
-                    {s.subtitle && <div className="text-neutral-100/90 mb-2">{s.subtitle}</div>}
-                    {s.lines.map((ln,k)=><div key={k} className="text-neutral-100">{ln}</div>)}
-                    <div className="absolute right-3 bottom-3 text-neutral-300 text-xs">{i+1}/{slides.length} →</div>
-                  </div>
+              {previews.map((url,i)=>(
+                <div key={i} className="snap-start shrink-0 w-[260px] aspect-[4/5] rounded-3xl overflow-hidden bg-neutral-800 relative">
+                  <img src={url} className="w-full h-full object-cover" />
+                  <div className="absolute top-3 left-3 text-white/85 text-xs z-10">@{username.replace(/^@/, "")}</div>
                 </div>
               ))}
-              {!slides.length && <div className="text-neutral-500">Вставь текст ↑</div>}
+              {!previews.length && <div className="text-neutral-500">Вставь текст ↑</div>}
             </div>
           </div>
         </div>
       </div>
 
-      {/* Bottom nav */}
-      <div className="fixed left-0 right-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)]">
-        <div className="mx-auto max-w-6xl">
-          <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-6 gap-1">
-            <NavBtn icon="⧉" label="Template" onClick={()=>setTheme(t=> t==="photo"?"dark": t==="dark"?"light":"photo")} />
-            <NavBtn icon="🎨" label="Color" onClick={()=>{/* TODO */}} />
-            <NavBtn icon="⬒" label="Layout" onClick={()=>{/* TODO */}} />
-            <NavBtn icon="📷" label="Photos" onClick={onPickPhotos} />
-            <NavBtn icon="ℹ️" label="Info" onClick={()=>{/* TODO */}} />
-            <NavBtn icon="⬇️" label="Export" onClick={onSaveAll} disabled={!slides.length || isExporting}/>
-          </div>
+      <BottomBar
+        onTemplate={()=>setOpenTemplate(true)}
+        onColor={()=>setOpenColor(true)}
+        onLayout={()=>setOpenLayout(true)}
+        onPhotos={()=>setOpenImages(true)}
+        onInfo={()=>setOpenInfo(true)}
+        onExport={onSaveAll}
+        disabledExport={!slides.length || isExporting}
+      />
+
+      <BottomSheet open={openTemplate} onClose={()=>setOpenTemplate(false)} title="Template">
+        <div className="grid grid-cols-3 gap-3">
+          <button className="rounded-xl border border-neutral-700 p-3 hover:bg-neutral-800" onClick={()=>{ setTheme("photo"); setOpenTemplate(false); }}>Photo</button>
+          <button className="rounded-xl border border-neutral-700 p-3 hover:bg-neutral-800" onClick={()=>{ setTheme("light"); setOpenTemplate(false); }}>Light</button>
+          <button className="rounded-xl border border-neutral-700 p-3 hover:bg-neutral-800" onClick={()=>{ setTheme("dark"); setOpenTemplate(false); }}>Dark</button>
         </div>
-      </div>
+      </BottomSheet>
+
+      <BottomSheet open={openColor} onClose={()=>setOpenColor(false)} title="Color">
+        <div className="flex gap-3">
+          {["#7C4DFF","#2563EB","#10B981","#F59E0B","#EF4444"].map(c=>(
+            <button key={c} onClick={()=>{ setAccent(c); setOpenColor(false); }}
+                    className="w-8 h-8 rounded-full border-2 border-white/20" style={{background:c}}/>
+          ))}
+        </div>
+      </BottomSheet>
+
+      <BottomSheet open={openLayout} onClose={()=>setOpenLayout(false)} title="Layout">
+        <div className="space-y-2">
+          <label className="flex items-center justify-between">
+            <span>Text size</span>
+            <input type="range" min={34} max={60} value={fontSize} onChange={e=>setFontSize(Number(e.target.value))}/>
+          </label>
+          <label className="flex items-center justify-between">
+            <span>Line height</span>
+            <input type="range" min={1.1} max={1.6} step={0.05} value={lineHeight} onChange={e=>setLineHeight(Number(e.target.value))}/>
+          </label>
+        </div>
+      </BottomSheet>
+
+      <ImagesModal open={openImages} onClose={()=>setOpenImages(false)} images={images} setImages={setImages} />
+
+      <BottomSheet open={openInfo} onClose={()=>setOpenInfo(false)} title="Info">
+        <div>Coming soon…</div>
+      </BottomSheet>
     </div>
-  )
-}
-
-async function blobToDataURL(b: Blob){
-  return new Promise<string>(res=>{ const r=new FileReader(); r.onload=()=>res(String(r.result)); r.readAsDataURL(b) })
-}
-
-function NavBtn({icon,label,onClick,disabled}:{icon:string;label:string;onClick?:()=>void;disabled?:boolean}) {
-  return (
-    <button
-      disabled={disabled}
-      onClick={onClick}
-      className={`flex flex-col items-center justify-center h-14 rounded-xl text-sm ${
-        disabled ? "opacity-40" : "hover:bg-neutral-800/60 active:scale-[0.98] transition"
-      }`}
-    >
-      <div className="text-lg leading-none">{icon}</div>
-      <div className="text-neutral-200 mt-1">{label}</div>
-    </button>
-  )
+  );
 }

--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import TemplateIcon from "../icons/TemplateIcon";
+import PaletteIcon from "../icons/PaletteIcon";
+import LayoutIcon from "../icons/LayoutIcon";
+import CameraIcon from "../icons/CameraIcon";
+import InfoIcon from "../icons/InfoIcon";
+import DownloadIcon from "../icons/DownloadIcon";
+
+export default function BottomBar({
+  onTemplate, onColor, onLayout, onPhotos, onInfo, onExport, disabledExport
+}:{
+  onTemplate: ()=>void;
+  onColor: ()=>void;
+  onLayout: ()=>void;
+  onPhotos: ()=>void;
+  onInfo: ()=>void;
+  onExport: ()=>void;
+  disabledExport?: boolean;
+}) {
+  const Item = ({icon,label,onClick,disabled}:{icon:React.ReactNode,label:string,onClick?:()=>void,disabled?:boolean}) => (
+    <button onClick={onClick} disabled={disabled}
+      className={`flex flex-col items-center justify-center h-14 rounded-xl text-xs
+        ${disabled ? "opacity-40" : "hover:bg-neutral-800/60 active:scale-[0.98] transition"}`}>
+      <div className="h-6 w-6 text-neutral-100">{icon}</div>
+      <div className="text-neutral-200 mt-1">{label}</div>
+    </button>
+  );
+
+  return (
+    <div className="fixed left-0 right-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)]">
+      <div className="mx-auto max-w-6xl">
+        <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-6 gap-1">
+          <Item icon={<TemplateIcon className="w-6 h-6"/>} label="Template" onClick={onTemplate}/>
+          <Item icon={<PaletteIcon className="w-6 h-6"/>}  label="Color"    onClick={onColor}/>
+          <Item icon={<LayoutIcon className="w-6 h-6"/>}   label="Layout"   onClick={onLayout}/>
+          <Item icon={<CameraIcon className="w-6 h-6"/>}   label="Photos"   onClick={onPhotos}/>
+          <Item icon={<InfoIcon className="w-6 h-6"/>}     label="Info"     onClick={onInfo}/>
+          <Item icon={<DownloadIcon className="w-6 h-6"/>} label="Export"   onClick={onExport} disabled={disabledExport}/>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/BottomSheet.tsx
+++ b/apps/webapp/src/components/BottomSheet.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+export default function BottomSheet({
+  open, onClose, title, children
+}:{open:boolean; onClose:()=>void; title:string; children:React.ReactNode}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose}/>
+      <div className="absolute left-0 right-0 bottom-0 bg-neutral-900 text-white rounded-t-2xl
+                      border border-neutral-800 shadow-2xl">
+        <div className="p-4 border-b border-neutral-800 font-medium">{title}</div>
+        <div className="p-4 space-y-3">{children}</div>
+        <div className="h-3" />
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/ImagesModal.tsx
+++ b/apps/webapp/src/components/ImagesModal.tsx
@@ -1,0 +1,76 @@
+import React, {useState, useRef} from "react";
+
+type Img = { id:string; url:string };
+
+export default function ImagesModal({
+  open, onClose, images, setImages
+}:{
+  open:boolean; onClose:()=>void;
+  images: Img[]; setImages:(imgs:Img[])=>void;
+}) {
+  const fileRef = useRef<HTMLInputElement>(null);
+  const [dragIdx, setDragIdx] = useState<number|null>(null);
+
+  if (!open) return null;
+
+  const onFiles = (files: FileList | null) => {
+    if (!files || !files.length) return;
+    const arr: Promise<Img>[] = Array.from(files).map(
+      f => new Promise(resolve=>{
+        const r = new FileReader();
+        r.onload = ()=> resolve({ id: crypto.randomUUID(), url: String(r.result) });
+        r.readAsDataURL(f);
+      })
+    );
+    Promise.all(arr).then(newImgs => setImages([...images, ...newImgs]));
+  };
+
+  const remove = (id:string) => setImages(images.filter(i=>i.id!==id));
+
+  const onDragStart = (idx:number)=> setDragIdx(idx);
+  const onDragOver  = (e:React.DragEvent, idx:number)=> {
+    e.preventDefault();
+    if (dragIdx===null || dragIdx===idx) return;
+    const copy = [...images];
+    const [m] = copy.splice(dragIdx,1);
+    copy.splice(idx,0,m);
+    setImages(copy);
+    setDragIdx(idx);
+  };
+  const onDragEnd = ()=> setDragIdx(null);
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div className="absolute inset-0 bg-black/40" onClick={onClose}/>
+      <div className="absolute left-0 right-0 bottom-0 top-16 bg-neutral-950 text-white rounded-t-2xl
+                      border border-neutral-800 shadow-2xl p-4 overflow-y-auto">
+        <div className="flex items-center justify-between mb-3">
+          <div className="font-medium">Photos</div>
+          <div className="flex gap-2">
+            <button className="px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700"
+                    onClick={()=>fileRef.current?.click()}>Add</button>
+            <button className="px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700"
+                    onClick={onClose}>Done</button>
+          </div>
+        </div>
+
+        <input ref={fileRef} type="file" accept="image/*" multiple className="hidden"
+               onChange={e=>onFiles(e.target.files)} />
+
+        <div className="grid grid-cols-3 gap-3">
+          {images.map((img,idx)=>(
+            <div key={img.id} draggable
+                 onDragStart={()=>onDragStart(idx)}
+                 onDragOver={(e)=>onDragOver(e, idx)}
+                 onDragEnd={onDragEnd}
+                 className="relative rounded-lg overflow-hidden border border-neutral-700">
+              <img src={img.url} className="w-full h-28 object-cover" />
+              <button onClick={()=>remove(img.id)}
+                      className="absolute top-1 right-1 text-xs bg-black/60 rounded px-2 py-0.5">×</button>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -13,6 +13,8 @@ export async function renderSlide(opts: {
   title?: string
   subtitle?: string
   theme?: "light" | "dark" | "photo"
+  accent?: string
+  showTopUsername?: boolean
 }): Promise<Blob> {
   const { width: W, height: H, padding: PAD } = opts
   const cvs = document.createElement("canvas")
@@ -65,9 +67,11 @@ export async function renderSlide(opts: {
   // mini-username сверху слева
   ctx.textAlign = "left"
   ctx.textBaseline = "top"
-  ctx.font = `${Math.round(opts.fontSize*0.55)}px ${opts.fontFamily}`
-  ctx.fillStyle = subColor
-  ctx.fillText("@"+opts.username.replace(/^@/,''), PAD, PAD)
+  if (opts.showTopUsername !== false) {
+    ctx.font = `${Math.round(opts.fontSize*0.55)}px ${opts.fontFamily}`
+    ctx.fillStyle = subColor
+    ctx.fillText("@"+opts.username.replace(/^@/,''), PAD, PAD)
+  }
 
   // HERO title (фиолетовая плашка)
   let yCursor = PAD
@@ -79,7 +83,7 @@ export async function renderSlide(opts: {
     const lines = wrap(ctx, opts.title, W - PAD*2 - pillPadX*2)
     const pillH = lines.length*titleLH + pillPadY*2
     roundRect(ctx, PAD, yCursor, W-PAD*2, pillH, 14)
-    ctx.fillStyle = "#5B4BFF"; ctx.globalAlpha = 0.95; ctx.fill(); ctx.globalAlpha = 1
+    ctx.fillStyle = opts.accent || "#5B4BFF"; ctx.globalAlpha = 0.95; ctx.fill(); ctx.globalAlpha = 1
     ctx.fillStyle = "#FFFFFF"
     let ty = yCursor + pillPadY
     for (const ln of lines){ ctx.fillText(ln, PAD+pillPadX, ty); ty+=titleLH }

--- a/apps/webapp/src/icons/CameraIcon.tsx
+++ b/apps/webapp/src/icons/CameraIcon.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+export default function CameraIcon(props:{className?:string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"
+         className={props.className}>
+      <path d="M4 7h3l2-3h6l2 3h3a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V9a2 2 0 0 1 2-2z"/>
+      <circle cx="12" cy="13" r="3"/>
+    </svg>
+  );
+}

--- a/apps/webapp/src/icons/DownloadIcon.tsx
+++ b/apps/webapp/src/icons/DownloadIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+export default function DownloadIcon(props:{className?:string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"
+         className={props.className}>
+      <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+      <polyline points="7 10 12 15 17 10"/>
+      <line x1="12" y1="15" x2="12" y2="3"/>
+    </svg>
+  );
+}

--- a/apps/webapp/src/icons/InfoIcon.tsx
+++ b/apps/webapp/src/icons/InfoIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+export default function InfoIcon(props:{className?:string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"
+         className={props.className}>
+      <circle cx="12" cy="12" r="10"/>
+      <line x1="12" y1="16" x2="12" y2="12"/>
+      <line x1="12" y1="8" x2="12.01" y2="8"/>
+    </svg>
+  );
+}

--- a/apps/webapp/src/icons/LayoutIcon.tsx
+++ b/apps/webapp/src/icons/LayoutIcon.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+export default function LayoutIcon(props:{className?:string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"
+         className={props.className}>
+      <rect x="3" y="3" width="18" height="18" rx="2"/>
+      <line x1="3" y1="9" x2="21" y2="9"/>
+      <line x1="9" y1="21" x2="9" y2="9"/>
+    </svg>
+  );
+}

--- a/apps/webapp/src/icons/PaletteIcon.tsx
+++ b/apps/webapp/src/icons/PaletteIcon.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+export default function PaletteIcon(props:{className?:string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"
+         className={props.className}>
+      <path d="M12 3a9 9 0 0 0 0 18c1.9 0 3-1.1 3-2.5S13.5 16 12 16a4 4 0 0 1-4-4"/>
+      <circle cx="7.5" cy="10.5" r="1"/>
+      <circle cx="10.5" cy="7.5" r="1"/>
+      <circle cx="14" cy="9" r="1"/>
+      <circle cx="16" cy="12" r="1"/>
+    </svg>
+  );
+}

--- a/apps/webapp/src/icons/TemplateIcon.tsx
+++ b/apps/webapp/src/icons/TemplateIcon.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+export default function TemplateIcon(props:{className?:string}) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"
+         className={props.className}>
+      <rect x="3" y="3" width="7" height="7" rx="1"/>
+      <rect x="14" y="3" width="7" height="7" rx="1"/>
+      <rect x="14" y="14" width="7" height="7" rx="1"/>
+      <rect x="3" y="14" width="7" height="7" rx="1"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add optional username render flag and accent color to slide renderer
- replace footer with SVG icon bottom bar and new sheets for template, color and layout
- introduce image picker modal with drag-and-drop reordering

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beba8e11c08328822577f6bdc9d85c