### PR TITLE
Handle text splitting and multi-image slides

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -27,7 +27,7 @@ export default function BottomBar({
   );
 
   return (
-    <div className="fixed left-0 right-0 bottom-0 z-50 pb-[env(safe-area-inset-bottom)]">
+      <div className="fixed left-0 right-0 bottom-0 z-40 pb-[env(safe-area-inset-bottom)]">
       <div className="mx-auto max-w-6xl">
         <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-6 gap-1">
           <Item icon={<TemplateIcon className="w-6 h-6"/>} label="Template" onClick={onTemplate} active={active==='template'}/>

--- a/apps/webapp/src/components/BottomSheet.tsx
+++ b/apps/webapp/src/components/BottomSheet.tsx
@@ -5,13 +5,13 @@ export default function BottomSheet({
 }:{open:boolean; onClose:()=>void; title:string; children:React.ReactNode}) {
   if (!open) return null;
   return (
-    <div className="fixed inset-0 z-50">
-      <div className="absolute inset-0 bg-black/40" onClick={onClose}/>
-      <div className="absolute left-0 right-0 bottom-0 bg-neutral-900 text-white rounded-t-2xl
+    <>
+      <div className="fixed inset-0 bg-black/40 backdrop-blur-sm z-40" onClick={onClose}/>
+      <div className="fixed inset-x-0 bottom-0 z-50 bg-neutral-900 text-white rounded-t-2xl
                       border border-neutral-800 shadow-2xl pb-[env(safe-area-inset-bottom)]">
         <div className="p-4 border-b border-neutral-800 font-medium">{title}</div>
         <div className="p-4 space-y-3">{children}</div>
       </div>
-    </div>
+    </>
   );
 }

--- a/apps/webapp/src/components/ImagesModal.tsx
+++ b/apps/webapp/src/components/ImagesModal.tsx
@@ -1,72 +1,58 @@
-import React, {useState, useRef} from "react";
-
-type Img = { id:string; url:string };
+import React, { useRef, useState } from "react";
 
 export default function ImagesModal({
-  open, onClose, images, setImages
+  open,
+  onClose,
+  onConfirm,
 }:{
-  open:boolean; onClose:()=>void;
-  images: Img[]; setImages:(imgs:Img[])=>void;
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (urls: string[]) => void;
 }) {
+  const [images, setImages] = useState<string[]>([]);
   const fileRef = useRef<HTMLInputElement>(null);
-  const [dragIdx, setDragIdx] = useState<number|null>(null);
 
   if (!open) return null;
 
   const onFiles = (files: FileList | null) => {
     if (!files || !files.length) return;
-    const arr: Promise<Img>[] = Array.from(files).map(
-      f => new Promise(resolve=>{
+    const arr: Promise<string>[] = Array.from(files).map(
+      f => new Promise(resolve => {
         const r = new FileReader();
-        r.onload = ()=> resolve({ id: crypto.randomUUID(), url: String(r.result) });
+        r.onload = () => resolve(String(r.result));
         r.readAsDataURL(f);
       })
     );
-    Promise.all(arr).then(newImgs => setImages([...images, ...newImgs]));
+    Promise.all(arr).then(urls => setImages(prev => [...prev, ...urls]));
   };
 
-  const remove = (id:string) => setImages(images.filter(i=>i.id!==id));
+  const remove = (idx: number) => setImages(images.filter((_, i) => i !== idx));
 
-  const onDragStart = (idx:number)=> setDragIdx(idx);
-  const onDragOver  = (e:React.DragEvent, idx:number)=> {
-    e.preventDefault();
-    if (dragIdx===null || dragIdx===idx) return;
-    const copy = [...images];
-    const [m] = copy.splice(dragIdx,1);
-    copy.splice(idx,0,m);
-    setImages(copy);
-    setDragIdx(idx);
+  const confirm = () => {
+    onConfirm(images);
+    onClose();
+    setImages([]);
   };
-  const onDragEnd = ()=> setDragIdx(null);
 
   return (
     <div className="fixed inset-0 z-50">
       <div className="absolute inset-0 bg-black/40" onClick={onClose}/>
-      <div className="absolute left-0 right-0 bottom-0 top-16 bg-neutral-950 text-white rounded-t-2xl
-                      border border-neutral-800 shadow-2xl p-4 overflow-y-auto pb-[calc(16px+env(safe-area-inset-bottom))]">
+      <div className="absolute left-0 right-0 bottom-0 top-16 bg-neutral-950 text-white rounded-t-2xl border border-neutral-800 shadow-2xl p-4 overflow-y-auto pb-[calc(16px+env(safe-area-inset-bottom))]">
         <div className="flex items-center justify-between mb-3">
           <div className="font-medium">Photos</div>
           <div className="flex gap-2">
-            <button className="px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700"
-                    onClick={()=>fileRef.current?.click()}>Add</button>
-            <button className="px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700"
-                    onClick={onClose}>Done</button>
+            <button className="px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700" onClick={()=>fileRef.current?.click()}>Add</button>
+            <button className="px-3 py-1.5 rounded-lg bg-neutral-800 border border-neutral-700" onClick={confirm}>Done</button>
           </div>
         </div>
 
-        <input ref={fileRef} type="file" accept="image/*" multiple className="hidden"
-               onChange={e=>onFiles(e.target.files)} />
+        <input ref={fileRef} type="file" accept="image/*" multiple className="hidden" onChange={e=>onFiles(e.target.files)} />
 
         <div className="grid grid-cols-3 gap-3">
-          {images.map((img,idx)=>(
-            <div key={img.id} draggable
-                 onDragStart={()=>onDragStart(idx)}
-                 onDragOver={(e)=>onDragOver(e, idx)}
-                 onDragEnd={onDragEnd}
-                 className="relative rounded-lg overflow-hidden border border-neutral-700">
-              <img src={img.url} className="w-full h-28 object-cover" />
-              <button onClick={()=>remove(img.id)}
-                      className="absolute top-1 right-1 text-xs bg-black/60 rounded px-2 py-0.5">×</button>
+          {images.map((url,idx)=>(
+            <div key={idx} className="relative rounded-lg overflow-hidden border border-neutral-700">
+              <img src={url} className="w-full h-28 object-cover" />
+              <button onClick={()=>remove(idx)} className="absolute top-1 right-1 text-xs bg-black/60 rounded px-2 py-0.5">×</button>
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- store raw text and slides, auto-splitting input into slide bodies
- allow attaching multiple photos and show slide text overlay in previews
- fix bottom bar/ sheet layering and single username rendering

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bec326ccb48328964f15521e9832a2