### PR TITLE
Fix rendering parity, safe-areas, bigger preview; ник фикс; авто-сплит; чёрный первый слайд

### DIFF
--- a/apps/webapp/src/core/autoSplit.ts
+++ b/apps/webapp/src/core/autoSplit.ts
@@ -1,0 +1,62 @@
+export type BaseParams = {
+  fontSize: number;
+  lineHeight: number;
+  width: number;
+  height: number;
+  padding: number;
+};
+
+export function splitToSlides(input: string, renderParams: BaseParams): string[] {
+  const parts = input.split(/\n\s*Слайд\s+\d+[^\n]*\n/i).filter(Boolean);
+  if (parts.length > 1) return parts.map(s => s.trim());
+
+  // авто: режем по вместимости
+  const paragraphs = input.split(/\n{2,}/).map(s=>s.trim());
+  const slides: string[] = [];
+  let cur = "";
+  for (const p of paragraphs){
+    const candidate = cur ? cur+"\n\n"+p : p;
+    if (fits(candidate, renderParams)) {
+      cur = candidate;
+    } else {
+      if (cur) slides.push(cur);
+      cur = p;
+    }
+  }
+  if (cur) slides.push(cur);
+  return slides;
+}
+
+function fits(text: string, renderParams: BaseParams): boolean {
+  const cnv = document.createElement('canvas');
+  cnv.width = renderParams.width; cnv.height = renderParams.height;
+  const ctx = cnv.getContext('2d')!;
+  const pad = renderParams.padding;
+  const nameFs = 36; // base 1080
+  const bottomSafe = Math.ceil(nameFs*1.6) + pad;
+  const bodyFs = renderParams.fontSize;
+  const lh = renderParams.lineHeight;
+  ctx.font = `${bodyFs}px Inter, system-ui, -apple-system`;
+  const maxWidth = renderParams.width - pad*2;
+  const lines = layoutParagraph(ctx, text, maxWidth);
+  const lineH = Math.round(bodyFs*lh);
+  const blockHeight = lines.length * lineH;
+  return blockHeight <= renderParams.height - pad - bottomSafe;
+}
+
+function layoutParagraph(ctx: CanvasRenderingContext2D, text: string, maxW: number){
+  const words = text.replace(/\r/g,"").split(/\s+/);
+  const lines:string[] = [];
+  let cur = "";
+  for (const w of words){
+    const test = cur ? cur + " " + w : w;
+    if (ctx.measureText(test).width <= maxW) {
+      cur = test;
+    } else {
+      if (cur) lines.push(cur);
+      cur = w;
+    }
+  }
+  if (cur) lines.push(cur);
+  return lines;
+}

--- a/apps/webapp/src/core/exportImages.ts
+++ b/apps/webapp/src/core/exportImages.ts
@@ -1,0 +1,23 @@
+import { renderSlide, SlideRenderModel } from "./render";
+
+function ensureImageLoaded(img: HTMLImageElement): Promise<void> {
+  if (img.complete) return Promise.resolve();
+  return new Promise((res, rej) => {
+    img.onload = () => res();
+    img.onerror = () => rej();
+  });
+}
+
+export async function exportAll(slides: SlideRenderModel[]){
+  const cnv = document.createElement("canvas");
+  cnv.width = 1080; cnv.height = 1350;
+  const ctx = cnv.getContext("2d")!;
+  const blobs: Blob[] = [];
+  for (const s of slides){
+    await ensureImageLoaded(s.img);
+    renderSlide(ctx, { ...s, w:cnv.width, h:cnv.height });
+    const blob = await new Promise<Blob>(res=> cnv.toBlob(b=>res(b!), "image/jpeg", 0.95));
+    blobs.push(blob);
+  }
+  return blobs; // дальше уже сохраняем
+}


### PR DESCRIPTION
## Summary
- refactor canvas renderer to reserve safe area and overlay username
- add export helpers and slide auto-splitting based on layout
- simplify export pipeline to render slides consistently

## Testing
- `npm run build`

## QA checklist
- [ ] Ник не двигается при длинном тексте (верх/низ).
- [ ] Первый слайд не чёрный в шаблоне photo.
- [ ] Превью = экспорт (визуально совпадает).
- [ ] Авто-сплит: ввод без «Слайд N» разбивается на 2–10 слайдов корректно.
- [ ] BottomBar не перекрывает карточки; шиты всплывают над ним.
- [ ] Нет дублей при сохранении.


------
https://chatgpt.com/codex/tasks/task_e_68bece1527948328b4890e5d22a4b98c