### PR TITLE
feat: add slide layout and color customization

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/apps/webapp/src/components/BottomSheet.tsx
+++ b/apps/webapp/src/components/BottomSheet.tsx
@@ -10,7 +10,7 @@ export default function BottomSheet({
       <div className="fixed inset-x-0 bottom-0 z-50 bg-neutral-900 text-white rounded-t-2xl
                       border border-neutral-800 shadow-2xl pb-[env(safe-area-inset-bottom)]">
         <div className="p-4 border-b border-neutral-800 font-medium">{title}</div>
-        <div className="p-4 space-y-3">{children}</div>
+        <div className="p-4">{children}</div>
       </div>
     </>
   );

--- a/apps/webapp/src/components/PreviewRail.tsx
+++ b/apps/webapp/src/components/PreviewRail.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useStore } from '../state/store';
+import SlidePreview from './SlidePreview';
+import type { Slide } from '../types';
+import { CanvasMode } from '../core/constants';
+
+export default function PreviewRail() {
+  const slides = useStore(s=>s.slides);
+  const defaults = useStore(s=>s.defaults);
+  const reorder = useStore(s=>s.reorderSlides);
+
+  const handleDragStart = (idx:number) => (e:React.DragEvent) => {
+    e.dataTransfer.setData('text/plain', String(idx));
+  };
+  const handleDrop = (idx:number) => (e:React.DragEvent) => {
+    const from = Number(e.dataTransfer.getData('text/plain'));
+    if (!isNaN(from)) {
+      reorder(from, idx);
+    }
+  };
+  const handleDragOver = (e:React.DragEvent) => e.preventDefault();
+
+  return (
+    <div className="flex gap-4 overflow-x-auto pb-2">
+      {slides.map((s:Slide, i:number) => {
+        const effFontSize = s.overrides?.fontSize ?? defaults.fontSize;
+        const effLH = s.overrides?.lineHeight ?? defaults.lineHeight;
+        const effPos = s.overrides?.textPosition ?? defaults.textPosition;
+        return (
+          <div key={s.id} draggable onDragStart={handleDragStart(i)} onDrop={handleDrop(i)} onDragOver={handleDragOver}>
+            <SlidePreview
+              slide={s}
+              index={i}
+              total={slides.length}
+              textPosition={effPos}
+              username="username"
+              theme={'photo'}
+              fontSize={effFontSize}
+              lineHeight={effLH}
+              color={defaults.bodyColor}
+              mode={CanvasMode.story}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/webapp/src/components/SlideEditor.tsx
+++ b/apps/webapp/src/components/SlideEditor.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect } from 'react';
+import BottomSheet from './BottomSheet';
+import { useStore } from '../state/store';
+import type { SlideId } from '../types';
+
+export default function SlideEditor({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {
+  const slide = useStore(s=> s.slides.find(x=>x.id===currentSlideId));
+  const updateSlide = useStore(s=>s.updateSlide);
+  const defaults = useStore(s=>s.defaults);
+
+  const [title, setTitle] = useState('');
+  const [match, setMatch] = useState(defaults.matchTitleToBody);
+  const [tColor, setTColor] = useState(defaults.titleColor);
+  const [fontSize, setFontSize] = useState(defaults.fontSize);
+  const [lineHeight, setLineHeight] = useState(defaults.lineHeight);
+  const [textPosition, setTextPosition] = useState<'top'|'bottom'>(defaults.textPosition);
+
+  useEffect(()=>{
+    if(open && slide){
+      setTitle(slide.title ?? '');
+      setMatch(slide.overrides?.matchTitleToBody ?? defaults.matchTitleToBody);
+      setTColor(slide.overrides?.titleColor ?? defaults.titleColor);
+      setFontSize(slide.overrides?.fontSize ?? defaults.fontSize);
+      setLineHeight(slide.overrides?.lineHeight ?? defaults.lineHeight);
+      setTextPosition(slide.overrides?.textPosition ?? defaults.textPosition);
+    }
+  },[open, currentSlideId]);
+
+  const apply=()=>{
+    if(!slide) return;
+    updateSlide(slide.id, {
+      title,
+      overrides:{
+        matchTitleToBody: match,
+        titleColor: tColor,
+        fontSize,
+        lineHeight,
+        textPosition,
+      }
+    });
+    onClose();
+  };
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Edit slide">
+      <Label>Title</Label>
+      <input value={title} onChange={e=>setTitle(e.target.value)} className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-800" placeholder="Введите заголовок" />
+
+      <div className="mt-3 flex items-center gap-2">
+        <input type="checkbox" checked={match} onChange={e=>setMatch(e.target.checked)} />
+        <span className="text-sm text-neutral-300">Заголовок как текст</span>
+      </div>
+
+      {!match && (
+        <>
+          <Label>Title color</Label>
+          <div className="flex gap-2">
+            {['#FFFFFF','#F5F5F5','#111111','#7C4DFF','#2563EB','#10B981','#F59E0B','#EF4444'].map(c=>(
+              <button key={c} onClick={()=>setTColor(c)} className="w-8 h-8 rounded-full border border-white/20" style={{background:c}} />
+            ))}
+          </div>
+        </>
+      )}
+
+      <Label>Text size: {Math.round(fontSize)}px</Label>
+      <input type="range" min={36} max={64} step={1} value={fontSize} onChange={e=>setFontSize(+e.target.value)} />
+
+      <Label>Line height: {lineHeight.toFixed(2)}</Label>
+      <input type="range" min={1.10} max={1.60} step={0.02} value={lineHeight} onChange={e=>setLineHeight(+e.target.value)} />
+
+      <Label>Text position</Label>
+      <div className="flex gap-2">
+        <button className={btn(textPosition==='bottom')} onClick={()=>setTextPosition('bottom')}>Bottom</button>
+        <button className={btn(textPosition==='top')} onClick={()=>setTextPosition('top')}>Top</button>
+      </div>
+
+      <div className="mt-4 flex justify-end gap-2">
+        <button className="px-4 py-2 rounded-lg bg-neutral-800 text-neutral-100" onClick={onClose}>Cancel</button>
+        <button className="px-4 py-2 rounded-lg bg-neutral-100 text-neutral-900" onClick={apply}>Apply</button>
+      </div>
+    </BottomSheet>
+  );
+}
+
+const Label = ({children}:{children:React.ReactNode}) => (
+  <div className="text-sm text-neutral-400 mt-3 mb-1">{children}</div>
+);
+const btn = (active:boolean) => `px-3 py-1.5 rounded-lg border ${active?'bg-neutral-800 border-neutral-700':'bg-neutral-900 border-neutral-800'}`;

--- a/apps/webapp/src/components/SlidePreview.tsx
+++ b/apps/webapp/src/components/SlidePreview.tsx
@@ -31,7 +31,14 @@ export function SlidePreview({ slide, index, total, textPosition, username, them
       width: preset.w,
       height: preset.h,
       theme,
-      layout: { textPosition, textSize: fontSize, lineHeight, color },
+      defaults: {
+        fontSize,
+        lineHeight,
+        textPosition,
+        bodyColor: color,
+        titleColor: color,
+        matchTitleToBody: true,
+      },
       username: username.replace(/^@/, ''),
       page: { index: index + 1, total, showArrow: index + 1 < total },
     });

--- a/apps/webapp/src/components/sheets/ColorSheet.tsx
+++ b/apps/webapp/src/components/sheets/ColorSheet.tsx
@@ -1,0 +1,52 @@
+import React, { useState, useEffect } from 'react';
+import BottomSheet from '../BottomSheet';
+import { useStore } from '../../state/store';
+import type { SlideId } from '../../types';
+
+export default function ColorSheet({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {
+  const slide = useStore(s=> s.slides.find(x=>x.id===currentSlideId));
+  const updateSlide = useStore(s=>s.updateSlide);
+  const defaults = useStore(s=>s.defaults);
+  const [title, setTitle] = useState(slide?.title ?? "");
+  const [match, setMatch] = useState(slide?.overrides?.matchTitleToBody ?? defaults.matchTitleToBody);
+  const [tColor, setTColor] = useState(slide?.overrides?.titleColor ?? defaults.titleColor);
+
+  useEffect(()=>{ if(open && slide){ setTitle(slide.title ?? ""); setMatch(slide.overrides?.matchTitleToBody ?? defaults.matchTitleToBody); setTColor(slide.overrides?.titleColor ?? defaults.titleColor); }},[open, currentSlideId]);
+
+  const apply=()=>{
+    if (!slide) return;
+    updateSlide(slide.id, {
+      title,
+      overrides: { matchTitleToBody: match, titleColor: tColor }
+    });
+    onClose();
+  };
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Title & Color">
+      <Label>Title</Label>
+      <input value={title} onChange={e=>setTitle(e.target.value)} className="w-full px-3 py-2 rounded-lg bg-neutral-900 border border-neutral-800" placeholder="Введите заголовок" />
+
+      <div className="mt-3 flex items-center gap-2">
+        <input type="checkbox" checked={match} onChange={e=>setMatch(e.target.checked)} />
+        <span className="text-sm text-neutral-300">Заголовок как текст</span>
+      </div>
+
+      {!match && (
+        <>
+          <Label>Title color</Label>
+          <div className="flex gap-2">
+            {['#FFFFFF','#F5F5F5','#111111','#7C4DFF','#2563EB','#10B981','#F59E0B','#EF4444'].map(c=>(
+              <button key={c} onClick={()=>setTColor(c)} className="w-8 h-8 rounded-full border border-white/20" style={{background:c}} />
+            ))}
+          </div>
+        </>
+      )}
+
+      <div className="mt-4 flex justify-end">
+        <button className="px-4 py-2 rounded-lg bg-neutral-100 text-neutral-900" onClick={apply}>Apply</button>
+      </div>
+    </BottomSheet>
+  )
+}
+const Label=({children}:{children:React.ReactNode})=>(<div className="text-sm text-neutral-400 mt-3 mb-1">{children}</div>);

--- a/apps/webapp/src/components/sheets/LayoutSheet.tsx
+++ b/apps/webapp/src/components/sheets/LayoutSheet.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useEffect } from 'react';
+import BottomSheet from '../BottomSheet';
+import { useStore } from '../../state/store';
+import type { SlideId } from '../../types';
+
+export default function LayoutSheet({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {
+  const defaults = useStore(s => s.defaults);
+  const updateDefaults = useStore(s => s.updateDefaults);
+  const updateSlide = useStore(s => s.updateSlide);
+
+  const [scope, setScope] = useState<'slide'|'all'>('slide');
+  const [fontSize, setFontSize] = useState<number>(defaults.fontSize);
+  const [lineHeight, setLineHeight] = useState<number>(defaults.lineHeight);
+  const [textPosition, setTextPosition] = useState<'top'|'bottom'>(defaults.textPosition);
+
+  useEffect(() => {
+    if (!open) return;
+    if (scope === 'slide' && currentSlideId) {
+      const slide = useStore.getState().slides.find(s => s.id === currentSlideId);
+      if (slide?.overrides) {
+        setFontSize(slide.overrides.fontSize ?? defaults.fontSize);
+        setLineHeight(slide.overrides.lineHeight ?? defaults.lineHeight);
+        setTextPosition(slide.overrides.textPosition ?? defaults.textPosition);
+      } else {
+        setFontSize(defaults.fontSize);
+        setLineHeight(defaults.lineHeight);
+        setTextPosition(defaults.textPosition);
+      }
+    } else {
+      setFontSize(defaults.fontSize);
+      setLineHeight(defaults.lineHeight);
+      setTextPosition(defaults.textPosition);
+    }
+  }, [open, scope, currentSlideId, defaults]);
+
+  const apply = () => {
+    if (scope === 'all') {
+      updateDefaults({ fontSize, lineHeight, textPosition });
+    } else if (currentSlideId) {
+      updateSlide(currentSlideId, { overrides: { fontSize, lineHeight, textPosition } });
+    }
+    onClose();
+  };
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Layout">
+      {/* scope */}
+      <div className="flex gap-2 mb-3">
+        <button className={btn(scope==='slide')} onClick={()=>setScope('slide')}>This slide</button>
+        <button className={btn(scope==='all')} onClick={()=>setScope('all')}>All slides</button>
+      </div>
+
+      {/* sliders */}
+      <Label>Text size: {Math.round(fontSize)}px</Label>
+      <input type="range" min={36} max={64} step={1} value={fontSize} onChange={e=>setFontSize(+e.target.value)} />
+
+      <Label>Line height: {lineHeight.toFixed(2)}</Label>
+      <input type="range" min={1.10} max={1.60} step={0.02} value={lineHeight} onChange={e=>setLineHeight(+e.target.value)} />
+
+      <Label>Text position</Label>
+      <div className="flex gap-2">
+        <button className={btn(textPosition==='bottom')} onClick={()=>setTextPosition('bottom')}>Bottom</button>
+        <button className={btn(textPosition==='top')} onClick={()=>setTextPosition('top')}>Top</button>
+      </div>
+
+      <div className="mt-4 flex justify-end">
+        <button className="px-4 py-2 rounded-lg bg-neutral-100 text-neutral-900" onClick={apply}>Apply</button>
+      </div>
+    </BottomSheet>
+  );
+}
+
+const Label = ({children}:{children:React.ReactNode}) => (
+  <div className="text-sm text-neutral-400 mt-3 mb-1">{children}</div>
+);
+const btn = (active:boolean) => `px-3 py-1.5 rounded-lg border ${active?'bg-neutral-800 border-neutral-700':'bg-neutral-900 border-neutral-800'}`;

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -1,0 +1,38 @@
+import { create } from 'zustand';
+import type { Slide, Defaults, SlideId } from '../types';
+
+export type StoreState = {
+  slides: Slide[];
+  defaults: Defaults;
+  updateDefaults: (partial: Partial<Defaults>) => void;
+  updateSlide: (id: SlideId, partial: Partial<Slide> | { overrides: Partial<Slide['overrides']> }) => void;
+  reorderSlides: (fromIndex: number, toIndex: number) => void;
+};
+
+export const useStore = create<StoreState>((set) => ({
+  slides: [],
+  defaults: {
+    fontSize: 44,
+    lineHeight: 1.28,
+    textPosition: 'bottom',
+    bodyColor: '#FFFFFF',
+    titleColor: '#FFFFFF',
+    matchTitleToBody: true,
+  },
+  updateDefaults: (partial) => set((state) => ({ defaults: { ...state.defaults, ...partial } })),
+  updateSlide: (id, partial) => set((state) => ({
+    slides: state.slides.map((s) => {
+      if (s.id !== id) return s;
+      if ('overrides' in partial) {
+        return { ...s, overrides: { ...s.overrides, ...(partial as any).overrides } };
+      }
+      return { ...s, ...partial };
+    }),
+  })),
+  reorderSlides: (fromIndex, toIndex) => set((state) => {
+    const slides = [...state.slides];
+    const [moved] = slides.splice(fromIndex, 1);
+    slides.splice(toIndex, 0, moved);
+    return { slides };
+  }),
+}));

--- a/apps/webapp/src/types.ts
+++ b/apps/webapp/src/types.ts
@@ -1,6 +1,29 @@
+export type SlideId = string;
+
 export type Slide = {
-  body?: string;     // текст только этого слайда
-  image?: string;    // dataURL/URL выбранной фотки
+  id: SlideId;
+  body: string;                 // текст этого слайда
+  title?: string;               // заголовок (опционально)
+  image?: string;               // dataURL/URL выбранной фотки
+  imageId?: string | null;
+
+  // визуальные пер-слайд настройки (если не задано — берём из defaults)
+  overrides?: {
+    fontSize?: number;          // px при canvas width=1080
+    lineHeight?: number;        // 1.1..1.6
+    textPosition?: 'top'|'bottom';
+    titleColor?: string;        // css color
+    matchTitleToBody?: boolean; // если true — titleColor игнорим и берём body color
+  };
+};
+
+export type Defaults = {
+  fontSize: number;             // общий дефолт, напр. 44
+  lineHeight: number;           // напр. 1.28
+  textPosition: 'top'|'bottom';
+  bodyColor: string;            // цвет основного текста
+  titleColor: string;           // дефолтный цвет заголовка
+  matchTitleToBody: boolean;    // если true — заголовок = bodyColor
 };
 
 export type PhotoMeta = {
@@ -9,12 +32,5 @@ export type PhotoMeta = {
 };
 
 export type Theme = 'photo' | 'light' | 'dark';
-
-export type LayoutOptions = {
-  textPosition: 'bottom' | 'top';
-  textSize: number;
-  lineHeight: number;
-  color: string;
-};
 
 export type { CanvasMode } from './core/constants';


### PR DESCRIPTION
## Summary
- extend slide model with titles and per-slide overrides
- add Zustand store with update and reorder actions
- implement layout & color sheets, slide editor, and draggable preview rail
- render slides with effective typography and title coloring

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bf2aba55fc8328b0a2db78bf73758c