### PR TITLE
fix: ensure preview containers keep aspect ratio

### DIFF
--- a/apps/webapp/src/components/SlidePreview.tsx
+++ b/apps/webapp/src/components/SlidePreview.tsx
@@ -53,13 +53,9 @@ export function SlidePreview({ slide, index, total, textPosition, username, them
 
   const preset = CANVAS_PRESETS[mode];
   return (
-    <canvas
-      ref={ref}
-      width={preset.w}
-      height={preset.h}
-      style={{ aspectRatio: `${preset.w} / ${preset.h}` }}
-      className="slideCard"
-    />
+    <div className={`slideCard preview-container ${mode}`}>
+      <canvas ref={ref} width={preset.w} height={preset.h} />
+    </div>
   );
 }
 

--- a/apps/webapp/src/styles/tailwind.css
+++ b/apps/webapp/src/styles/tailwind.css
@@ -17,4 +17,42 @@ body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-seri
     overflow: hidden;
     background: #111;
   }
+
+  .preview-container {
+    position: relative;
+    width: 100%;
+    background: #000;
+    overflow: hidden;
+  }
+  .preview-container.carousel { aspect-ratio: 4 / 5; }
+  .preview-container.story { aspect-ratio: 9 / 16; }
+  @supports not (aspect-ratio: 1 / 1) {
+    .preview-container.carousel { padding-bottom: 125%; }
+    .preview-container.story { padding-bottom: 177.77%; }
+  }
+  .preview-container img,
+  .preview-container canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .preview-text {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: 40px;
+    color: white;
+    font-size: 16px;
+    line-height: 1.4;
+    z-index: 2;
+  }
+  .preview-username {
+    position: absolute;
+    left: 8px;
+    bottom: 8px;
+    font-size: 14px;
+    opacity: 0.8;
+  }
 }


### PR DESCRIPTION
## Summary
- implement preview container with aspect-ratio and fallback
- wrap slide preview canvas in responsive container

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf39137dc083288d2d27252cf439d5