### PR TITLE
feat: add preview card and list components

### DIFF
--- a/apps/webapp/src/components/PreviewCard.tsx
+++ b/apps/webapp/src/components/PreviewCard.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import '../styles/preview-card.css';
+
+type Props = {
+  mode: 'carousel' | 'story'; // 4:5 | 9:16
+  image?: string;
+  text: string;
+  username: string;
+  textPosition?: 'bottom' | 'top';
+};
+
+export const PreviewCard: React.FC<Props> = ({
+  mode,
+  image,
+  text,
+  username,
+  textPosition = 'bottom',
+}) => {
+  const ratio = mode === 'story' ? '9 / 16' : '4 / 5';
+
+  return (
+    <div
+      className="preview-card"
+      style={{
+        // основное — держит размер всегда
+        '--ratio': ratio,
+      } as React.CSSProperties}
+      data-mode={mode}
+    >
+      {/* Fallback для браузеров без aspect-ratio */}
+      <div className="preview-card__ratio-fallback" aria-hidden />
+
+      {/* Фото */}
+      {image && (
+        <img className="preview-card__img" src={image} alt="" />
+      )}
+
+      {/* Текст */}
+      <div
+        className={`preview-card__text preview-card__text--${textPosition}`}
+      >
+        {text}
+      </div>
+
+      {/* Ник (всегда левый нижний) */}
+      <div className="preview-card__username">@{username}</div>
+
+      {/* Пэйджер (опционально) */}
+      {/* <div className="preview-card__pager">1/5 →</div> */}
+    </div>
+  );
+};
+
+export default PreviewCard;
+

--- a/apps/webapp/src/components/PreviewList.tsx
+++ b/apps/webapp/src/components/PreviewList.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import '../styles/preview-list.css';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export const PreviewList: React.FC<Props> = ({ children }) => {
+  return <div className="preview-list">{children}</div>;
+};
+
+export default PreviewList;
+

--- a/apps/webapp/src/styles/preview-card.css
+++ b/apps/webapp/src/styles/preview-card.css
@@ -1,0 +1,83 @@
+.preview-card {
+  position: relative;
+  width: 100%;
+  max-width: 420px;         /* чтобы красиво встала в колонку */
+  margin: 0 auto;
+  background: #000;         /* placeholder, чтобы не было "прыжка" */
+  border-radius: 22px;
+  overflow: hidden;
+
+  /* фиксируем высоту: современный способ */
+  aspect-ratio: var(--ratio, 4 / 5);
+
+  /* важно: карточку нельзя сжимать родителем */
+  flex: 0 0 auto;
+}
+
+/* Fallback, если aspect-ratio не поддерживается */
+.preview-card__ratio-fallback {
+  height: 0;
+  padding-bottom: calc(100% * (var(--ratio, 4 / 5)));
+}
+
+/* Фото занимает всё поле и не влияет на размеры */
+.preview-card__img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* Общие параметры текста */
+.preview-card__text {
+  position: absolute;
+  left: 16px;
+  right: 16px;
+  color: #fff;
+  font-size: 16px;          /* регулируешь ползунком в layout */
+  line-height: 1.35;
+  text-wrap: balance;       /* приятные переносы */
+  z-index: 2;
+  /* лёгкий нижний градиент, чтобы читаемость была всегда */
+  padding-top: 16px;
+  padding-bottom: 48px;
+}
+
+/* позиция текста */
+.preview-card__text--bottom { bottom: 24px; }
+.preview-card__text--top    { top: 24px; }
+
+/* Ник – всегда внизу слева */
+.preview-card__username {
+  position: absolute;
+  left: 16px;
+  bottom: 12px;
+  color: #fff;
+  opacity: 0.9;
+  font-size: 14px;
+  z-index: 2;
+  pointer-events: none;
+}
+
+/* (если нужен) пэйджер вправо вниз */
+.preview-card__pager {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  color: #fff;
+  font-size: 14px;
+  opacity: 0.9;
+  z-index: 2;
+}
+
+/* Тёмный снизу градиент под текст (как ты просил) */
+.preview-card::after {
+  content: '';
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 38%;
+  background: linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,.55) 100%);
+  z-index: 1;
+}
+

--- a/apps/webapp/src/styles/preview-list.css
+++ b/apps/webapp/src/styles/preview-list.css
@@ -1,0 +1,12 @@
+.preview-list {
+  display: grid;
+  gap: 16px;
+  /* если у тебя горизонтальная лента – сделай flex + overflow-x */
+  /* overflow-y: auto;  // для вертикального скролла */
+  /* max-height: calc(100vh - 260px); // если нужно ограничить высоту секцией над списком */
+}
+
+.preview-list > * {
+  flex-shrink: 0; /* на всякий случай для flex-варианта */
+}
+


### PR DESCRIPTION
## Summary
- add `PreviewCard` component with aspect-ratio styling and absolute positioning for image, text and username
- add `PreviewList` container ensuring previews keep their size

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf3f44a1f483288f17b90373aabc66