### PR TITLE
feat: add overlay and heading options

### DIFF
--- a/apps/webapp/src/styles/builder-preview.css
+++ b/apps/webapp/src/styles/builder-preview.css
@@ -1,3 +1,20 @@
 .builder-preview {
   padding: 0 12px 100px;
 }
+
+.segmented {
+  display: flex;
+  gap: 4px;
+  background: rgba(255,255,255,0.06);
+  padding: 4px;
+  border-radius: 16px;
+}
+.segmented__item {
+  flex: 1;
+  padding: 12px 0;
+  border-radius: 12px;
+  text-align: center;
+}
+.segmented__item--active {
+  background: rgba(255,255,255,0.12);
+}


### PR DESCRIPTION
## Summary
- add segmented template picker with story mode toggle
- support overlay gradient and heading color for preview and canvas
- expose overlay and heading settings in layout panel

## Testing
- `npm --prefix apps/webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68bf72f400008328805512b98f305162