### PR TITLE
fix: improve preview drag-and-drop handling

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -157,6 +157,8 @@ export default function App() {
 
   const handleDragStart = (idx: number) => (e: React.DragEvent) => {
     dragIndex.current = idx;
+    e.dataTransfer.setData('text/plain', String(idx));
+    e.dataTransfer.effectAllowed = 'move';
     (e.currentTarget as HTMLElement).classList.add('dragging', 'shadow-lg');
   };
   const handleDragEnd = (e: React.DragEvent) => {
@@ -173,9 +175,8 @@ export default function App() {
     const to = Number(target.dataset.index);
     dragIndex.current = null;
     if (from === to) return;
-    const reordered = reorder(slides, from, to);
-    setSlides(reordered);
-    setRawText(reordered.map(s => s.body || '').join('\n\n'));
+    setSlides(reorder(slides, from, to));
+    setPhotos(reorder(photos, from, to));
   };
 
   useEffect(() => {
@@ -376,6 +377,7 @@ export default function App() {
 .preview-card::after {
   height: calc(var(--overlay-height,0.4) * 100%);
   background: linear-gradient(0deg, rgba(var(--overlay-rgb,0,0,0),var(--overlay-opacity,0)) 0%, rgba(var(--overlay-rgb,0,0,0),0) 100%);
+  pointer-events: none;
 }
 .preview-heading {
   font-weight: 700;
@@ -411,28 +413,27 @@ export default function App() {
 
         <div className="lg:col-span-7 builder-preview">
           {slides.length ? (
-            <div className="preview-list" onDragOver={handleDragOver} onDrop={handleDrop}>
+            <div className="preview-list">
               {slides.map((s, i) => {
                 const [h, b] = settings.headingEnabled ? splitHeading(s.body || '') : ['', s.body];
                 return (
-                  <div
+                  <PreviewCard
                     key={s.id}
                     data-index={i}
                     draggable
                     onDragStart={handleDragStart(i)}
+                    onDragOver={handleDragOver}
+                    onDrop={handleDrop}
                     onDragEnd={handleDragEnd}
                     style={cardStyle}
-                  >
-                    <PreviewCard
-                      mode={mode}
-                      image={s.image}
-                      text={(settings.headingEnabled
-                          ? (<>{h && <span className="preview-heading">{h}</span>}{b ? <><br/>{b}</> : null}</>)
-                          : s.body) as any}
-                      username={username.replace(/^@/, '')}
-                      textPosition={textPosition}
-                    />
-                  </div>
+                    mode={mode}
+                    image={s.image}
+                    text={(settings.headingEnabled
+                        ? (<>{h && <span className="preview-heading">{h}</span>}{b ? <><br/>{b}</> : null}</>)
+                        : s.body) as any}
+                    username={username.replace(/^@/, '')}
+                    textPosition={textPosition}
+                  />
                 );
               })}
             </div>

--- a/apps/webapp/src/components/PreviewCard.tsx
+++ b/apps/webapp/src/components/PreviewCard.tsx
@@ -7,7 +7,7 @@ type Props = {
   text: string;
   username: string;
   textPosition?: 'bottom' | 'top';
-};
+} & React.HTMLAttributes<HTMLDivElement>;
 
 export const PreviewCard: React.FC<Props> = ({
   mode,
@@ -15,6 +15,8 @@ export const PreviewCard: React.FC<Props> = ({
   text,
   username,
   textPosition = 'bottom',
+  style,
+  ...rest
 }) => {
   const ratio = mode === 'story' ? '9 / 16' : '4 / 5';
 
@@ -24,8 +26,10 @@ export const PreviewCard: React.FC<Props> = ({
       style={{
         // основное — держит размер всегда
         '--ratio': ratio,
+        ...((style ?? {}) as React.CSSProperties),
       } as React.CSSProperties}
       data-mode={mode}
+      {...rest}
     >
       {/* Fallback для браузеров без aspect-ratio */}
       <div className="preview-card__ratio-fallback" aria-hidden />

--- a/apps/webapp/src/styles/preview-card.css
+++ b/apps/webapp/src/styles/preview-card.css
@@ -79,5 +79,11 @@
   height: 38%;
   background: linear-gradient(180deg, rgba(0,0,0,0) 0%, rgba(0,0,0,.55) 100%);
   z-index: 1;
+  pointer-events: none;
+}
+
+/* Любые оверлеи должны пропускать указатель */
+.preview-card .overlay {
+  pointer-events: none;
 }
 


### PR DESCRIPTION
## Summary
- handle drag events per preview card and ignore raw text reordering
- allow overlays to pass pointer events through
- keep slide photos ordered during drag-and-drop

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c00079988c8328b011a66df79e9a5e