### PR TITLE
feat: add svg icon set and swipe actions

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -4,11 +4,7 @@ import { CANVAS_PRESETS } from "./core/constants";
 import BottomSheet from "./components/BottomSheet";
 import ImagesModal from "./components/ImagesModal";
 import PreviewCard from "./components/PreviewCard";
-import TemplateIcon from "./icons/TemplateIcon";
-import LayoutIcon from "./icons/LayoutIcon";
-import CameraIcon from "./icons/CameraIcon";
-import InfoIcon from "./icons/InfoIcon";
-import DownloadIcon from "./icons/DownloadIcon";
+import BottomBar from "./components/BottomBar";
 import "./styles/tailwind.css";
 import "./styles/builder-preview.css";
 import "./styles/preview-list.css";
@@ -16,54 +12,6 @@ import { getWelcomeText, SEED_KEY } from "./core/seed";
 import type { Slide, Theme, CanvasMode, PhotoMeta } from "./types";
 
 type SlideCount = "auto" | 1|2|3|4|5|6|7|8|9|10;
-
-
-const FontIcon = ({className}:{className?:string}) => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className={className}>
-    <path d="M4 20h16"/>
-    <path d="M9 20l3-9 3 9"/>
-    <path d="M8 16h8"/>
-  </svg>
-);
-
-const Button = (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
-  <button {...props} />
-);
-
-function BottomBar({
-  onTemplate, onLayout, onFonts, onPhotos, onInfo, onExport, disabledExport, active
-}:{
-  onTemplate: ()=>void;
-  onLayout: ()=>void;
-  onFonts: ()=>void;
-  onPhotos: ()=>void;
-  onInfo: ()=>void;
-  onExport: ()=>void;
-  disabledExport?: boolean;
-  active?: 'template'|'layout'|'fonts'|'photos'|'info';
-}) {
-  const Item = ({icon,label,onClick,disabled,active}:{icon:React.ReactNode,label:string,onClick?:()=>void,disabled?:boolean,active?:boolean}) => (
-    <button onClick={onClick} disabled={disabled}
-      className={`flex flex-col items-center justify-center h-14 rounded-xl text-xs ${disabled?"opacity-40":""} ${active?"bg-neutral-800/60":"hover:bg-neutral-800/60"} active:scale-[0.98] transition`}>
-      <div className="h-6 w-6 text-neutral-100">{icon}</div>
-      <div className="text-neutral-200 mt-1">{label}</div>
-    </button>
-  );
-  return (
-    <div className="fixed left-0 right-0 bottom-0 z-40 pb-[env(safe-area-inset-bottom)]">
-      <div className="mx-auto max-w-6xl">
-        <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-6 gap-1">
-          <Item icon={<TemplateIcon className="w-6 h-6"/>} label="Template" onClick={onTemplate} active={active==='template'}/>
-          <Item icon={<LayoutIcon className="w-6 h-6"/>}   label="Layout"   onClick={onLayout} active={active==='layout'}/>
-          <Item icon={<FontIcon className="w-6 h-6"/>}     label="Fonts"    onClick={onFonts} active={active==='fonts'}/>
-          <Item icon={<CameraIcon className="w-6 h-6"/>}   label="Photos"   onClick={onPhotos} active={active==='photos'}/>
-          <Item icon={<InfoIcon className="w-6 h-6"/>}     label="Info"     onClick={onInfo} active={active==='info'}/>
-          <Item icon={<DownloadIcon className="w-6 h-6"/>} label="Export"   onClick={onExport} disabled={disabledExport}/>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 export default function App() {
   const [rawText, setRawText] = useState("");
@@ -141,10 +89,17 @@ export default function App() {
   const onReorder = (from: number, to: number) => {
     setSlides(prev => {
       const next = prev.slice();
+      if (to < 0 || to >= next.length) return next;
       const [moved] = next.splice(from, 1);
       next.splice(to, 0, moved);
       return next;
     });
+  };
+
+  const deleteSlide = (idx: number) => {
+    if (confirm('Delete slide?')) {
+      setSlides(prev => prev.filter((_, i) => i !== idx));
+    }
   };
 
   useEffect(() => {
@@ -365,6 +320,9 @@ export default function App() {
                     key={s.id}
                     index={i}
                     onReorder={onReorder}
+                    onMoveUp={() => onReorder(i, i - 1)}
+                    onMoveDown={() => onReorder(i, i + 1)}
+                    onDelete={() => deleteSlide(i)}
                     style={cardStyle}
                     mode={mode}
                     image={s.image}

--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,46 +1,43 @@
 import React from "react";
-import TemplateIcon from "../icons/TemplateIcon";
-import PaletteIcon from "../icons/PaletteIcon";
-import LayoutIcon from "../icons/LayoutIcon";
-import FrameIcon from "../icons/FrameIcon";
-import CameraIcon from "../icons/CameraIcon";
-import InfoIcon from "../icons/InfoIcon";
-import DownloadIcon from "../icons/DownloadIcon";
-import type { CanvasMode } from '../types';
+import {
+  IconTemplate,
+  IconLayout,
+  IconFonts,
+  IconPhotos,
+  IconInfo,
+  IconExport,
+} from "../ui/icons";
 
 export default function BottomBar({
-  onTemplate, onColor, onLayout, onMode, onPhotos, onInfo, onExport, disabledExport, active, mode
+  onTemplate, onLayout, onFonts, onPhotos, onInfo, onExport, disabledExport, active,
 }:{
   onTemplate: ()=>void;
-  onColor: ()=>void;
   onLayout: ()=>void;
-  onMode: ()=>void;
+  onFonts: ()=>void;
   onPhotos: ()=>void;
   onInfo: ()=>void;
   onExport: ()=>void;
   disabledExport?: boolean;
-  active?: 'template'|'color'|'layout'|'photos'|'info';
-  mode: CanvasMode;
+  active?: 'template'|'layout'|'fonts'|'photos'|'info';
 }) {
   const Item = ({icon,label,onClick,disabled,active}:{icon:React.ReactNode,label:string,onClick?:()=>void,disabled?:boolean,active?:boolean}) => (
-    <button onClick={onClick} disabled={disabled}
-      className={`flex flex-col items-center justify-center h-14 rounded-xl text-xs ${disabled?"opacity-40":""} ${active?"bg-neutral-800/60":"hover:bg-neutral-800/60"} active:scale-[0.98] transition`}>
-      <div className="h-6 w-6 text-neutral-100">{icon}</div>
-      <div className="text-neutral-200 mt-1">{label}</div>
+    <button onClick={onClick} disabled={disabled} aria-label={label}
+      className={`w-full h-11 flex items-center justify-center gap-2 rounded-lg text-xs cursor-pointer select-none transition-transform ${disabled?"opacity-40":"hover:opacity-90 active:opacity-90 hover:-translate-y-px active:-translate-y-px active:scale-[0.96]"} ${active?"text-[var(--fg)]":"text-[var(--fg-muted)]"}`}>
+      {icon}
+      <span>{label}</span>
     </button>
   );
 
   return (
       <div className="fixed left-0 right-0 bottom-0 z-40 pb-[env(safe-area-inset-bottom)]">
       <div className="mx-auto max-w-6xl">
-        <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-7 gap-1">
-          <Item icon={<TemplateIcon className="w-6 h-6"/>} label="Template" onClick={onTemplate} active={active==='template'}/>
-          <Item icon={<PaletteIcon className="w-6 h-6"/>}  label="Color"    onClick={onColor} active={active==='color'}/>
-          <Item icon={<LayoutIcon className="w-6 h-6"/>}   label="Layout"   onClick={onLayout} active={active==='layout'}/>
-          <Item icon={<FrameIcon className="w-6 h-6"/>}    label={mode==='story'?'Story':'Carousel'} onClick={onMode}/>
-          <Item icon={<CameraIcon className="w-6 h-6"/>}   label="Photos"   onClick={onPhotos} active={active==='photos'}/>
-          <Item icon={<InfoIcon className="w-6 h-6"/>}     label="Info"     onClick={onInfo} active={active==='info'}/>
-          <Item icon={<DownloadIcon className="w-6 h-6"/>} label="Export"   onClick={onExport} disabled={disabledExport}/>
+        <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-6 gap-1">
+          <Item icon={<IconTemplate size={22} />} label="Template" onClick={onTemplate} active={active==='template'}/>
+          <Item icon={<IconLayout size={22} />}  label="Layout"   onClick={onLayout} active={active==='layout'}/>
+          <Item icon={<IconFonts size={22} />}   label="Fonts"    onClick={onFonts} active={active==='fonts'}/>
+          <Item icon={<IconPhotos size={22} />}  label="Photos"   onClick={onPhotos} active={active==='photos'}/>
+          <Item icon={<IconInfo size={22} />}    label="Info"     onClick={onInfo} active={active==='info'}/>
+          <Item icon={<IconExport size={22} />}  label="Export"   onClick={onExport} disabled={disabledExport}/>
         </div>
       </div>
     </div>

--- a/apps/webapp/src/styles/preview-card.css
+++ b/apps/webapp/src/styles/preview-card.css
@@ -87,3 +87,24 @@
   pointer-events: none;
 }
 
+.preview-card__actions {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  background: rgba(0,0,0,0.4);
+  backdrop-filter: blur(4px);
+  box-shadow: 0 0 10px rgba(0,0,0,0.5);
+  transform: translateX(100%);
+  transition: transform .2s ease;
+}
+.preview-card__actions--show {
+  transform: translateX(0);
+}
+

--- a/apps/webapp/src/ui/icons.tsx
+++ b/apps/webapp/src/ui/icons.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+
+type IconProps = React.SVGProps<SVGSVGElement> & { size?: number };
+
+const Base: React.FC<IconProps & { children: React.ReactNode }> = ({
+  size = 24, children, ...p
+}) => (
+  <svg
+    width={size} height={size} viewBox="0 0 24 24"
+    fill="none" stroke="currentColor" strokeWidth={2}
+    strokeLinecap="round" strokeLinejoin="round" {...p}
+  >
+    {children}
+  </svg>
+);
+
+// Toolbar
+export const IconTemplate = (p:IconProps) => (
+  <Base {...p}>
+    <rect x="3" y="3" width="7" height="7" rx="2"/>
+    <rect x="14" y="3" width="7" height="7" rx="2"/>
+    <rect x="3" y="14" width="7" height="7" rx="2"/>
+    <rect x="14" y="14" width="7" height="7" rx="2"/>
+  </Base>
+);
+
+export const IconLayout  = (p:IconProps) => (
+  <Base {...p}>
+    <rect x="3" y="4" width="18" height="16" rx="3"/>
+    <path d="M3 12h18"/>
+  </Base>
+);
+
+export const IconFonts   = (p:IconProps) => (
+  <Base {...p}>
+    <path d="M4 18h6M7 18L12 6h2l5 12"/>
+    <path d="M10 14h6"/>
+  </Base>
+);
+
+export const IconPhotos  = (p:IconProps) => (
+  <Base {...p}>
+    <rect x="3" y="5" width="18" height="14" rx="3"/>
+    <path d="M9 9h.01"/>
+    <path d="M3 15l4-4 3 3 4-4 5 5"/>
+  </Base>
+);
+
+export const IconInfo    = (p:IconProps) => (
+  <Base {...p}>
+    <circle cx="12" cy="12" r="9"/>
+    <path d="M12 8h.01"/>
+    <path d="M11 12h2v5h-2z"/>
+  </Base>
+);
+
+export const IconExport  = (p:IconProps) => (
+  <Base {...p}>
+    <path d="M12 3v10"/>
+    <path d="M8 7l4-4 4 4"/>
+    <path d="M5 21h14a2 2 0 0 0 2-2v-4"/>
+    <path d="M19 15l-3 3-3-3"/>
+  </Base>
+);
+
+// Swipe actions
+export const IconTrash   = (p:IconProps) => (
+  <Base {...p}>
+    <path d="M3 6h18"/>
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/>
+    <rect x="6" y="6" width="12" height="14" rx="2"/>
+    <path d="M10 11v6M14 11v6"/>
+  </Base>
+);
+
+export const IconMoveUp  = (p:IconProps) => (
+  <Base {...p}><path d="M12 19V5"/><path d="M7 10l5-5 5 5"/></Base>
+);
+export const IconMoveDown= (p:IconProps) => (
+  <Base {...p}><path d="M12 5v14"/><path d="M17 14l-5 5-5-5"/></Base>
+);
+export const IconGrip    = (p:IconProps) => (
+  <Base {...p}>
+    <circle cx="9" cy="7" r="1"/><circle cx="15" cy="7" r="1"/>
+    <circle cx="9" cy="12" r="1"/><circle cx="15" cy="12" r="1"/>
+    <circle cx="9" cy="17" r="1"/><circle cx="15" cy="17" r="1"/>
+  </Base>
+);
+
+// Mode toggle
+export const IconStory   = (p:IconProps) => (
+  <Base {...p}><rect x="4" y="3" width="16" height="18" rx="4"/><path d="M8 7h8M8 12h8M8 17h5"/></Base>
+);
+export const IconCarousel= (p:IconProps) => (
+  <Base {...p}>
+    <rect x="2" y="6" width="6" height="12" rx="2"/>
+    <rect x="9" y="3" width="6" height="18" rx="2"/>
+    <rect x="16" y="6" width="6" height="12" rx="2"/>
+  </Base>
+);
+
+// Overlay indicator (optional)
+export const IconOverlay = (p:IconProps) => (
+  <Base {...p}><rect x="3" y="5" width="18" height="14" rx="3"/><path d="M3 15h18" opacity=".6"/><path d="M3 17h18" opacity=".3"/></Base>
+);
+
+export default {
+  IconTemplate,
+  IconLayout,
+  IconFonts,
+  IconPhotos,
+  IconInfo,
+  IconExport,
+  IconTrash,
+  IconMoveUp,
+  IconMoveDown,
+  IconGrip,
+  IconStory,
+  IconCarousel,
+  IconOverlay,
+};


### PR DESCRIPTION
## Summary
- add shared React SVG icon components
- restyle bottom toolbar with new icons
- introduce swipe action rail for slides with move and delete controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0b735ded08328bebb8cdf1b0850eb