### PR TITLE
Remove drag-and-drop from preview and enable swipe actions

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -138,13 +138,26 @@ export default function App() {
 
   const genId = () => Math.random().toString(36).slice(2);
 
-  const onReorder = (from: number, to: number) => {
-    setSlides(prev => {
-      const next = prev.slice();
-      const [moved] = next.splice(from, 1);
-      next.splice(to, 0, moved);
-      return next;
+  const onMoveUp = (i: number) => {
+    if (i === 0) return;
+    setSlides(s => {
+      const a = s.slice();
+      [a[i - 1], a[i]] = [a[i], a[i - 1]];
+      return a;
     });
+  };
+
+  const onMoveDown = (i: number) => {
+    setSlides(s => {
+      if (i >= s.length - 1) return s;
+      const a = s.slice();
+      [a[i], a[i + 1]] = [a[i + 1], a[i]];
+      return a;
+    });
+  };
+
+  const onDelete = (i: number) => {
+    setSlides(s => s.filter((_, idx) => idx !== i));
   };
 
   useEffect(() => {
@@ -357,14 +370,16 @@ export default function App() {
 
         <div className="lg:col-span-7 builder-preview">
           {slides.length ? (
-            <div className="preview-list dnd-area" onDragOver={(e)=>e.preventDefault()}>
+            <div className="preview-list">
               {slides.map((s, i) => {
                 const [h, b] = settings.headingEnabled ? splitHeading(s.body || '') : ['', s.body];
                 return (
                   <PreviewCard
                     key={s.id}
                     index={i}
-                    onReorder={onReorder}
+                    onMoveUp={onMoveUp}
+                    onMoveDown={onMoveDown}
+                    onDelete={onDelete}
                     style={cardStyle}
                     mode={mode}
                     image={s.image}

--- a/apps/webapp/src/components/PreviewCard.tsx
+++ b/apps/webapp/src/components/PreviewCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import '../styles/preview-card.css';
 
 type Props = {
@@ -8,7 +8,9 @@ type Props = {
   username: string;
   textPosition?: 'bottom' | 'top';
   index?: number;
-  onReorder?: (from: number, to: number) => void;
+  onMoveUp?: (index: number) => void;
+  onMoveDown?: (index: number) => void;
+  onDelete?: (index: number) => void;
 } & React.HTMLAttributes<HTMLDivElement>;
 
 export const PreviewCard: React.FC<Props> = ({
@@ -18,54 +20,95 @@ export const PreviewCard: React.FC<Props> = ({
   username,
   textPosition = 'bottom',
   index,
-  onReorder,
+  onMoveUp,
+  onMoveDown,
+  onDelete,
   style,
   ...rest
 }) => {
   const ratio = mode === 'story' ? '9 / 16' : '4 / 5';
+  const ACTION_WIDTH = 144; // ширина панели действий
+  const startX = useRef<number | null>(null);
+  const [offset, setOffset] = useState(0);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    startX.current = e.touches[0].clientX - offset;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (startX.current == null) return;
+    const dx = e.touches[0].clientX - startX.current;
+    setOffset(Math.min(0, Math.max(dx, -ACTION_WIDTH)));
+  };
+
+  const handleTouchEnd = () => {
+    setOffset(prev => (prev < -ACTION_WIDTH / 2 ? -ACTION_WIDTH : 0));
+    startX.current = null;
+  };
+
+  const handleAction = (fn?: (i: number) => void) => {
+    if (typeof index !== 'number' || !fn) return;
+    fn(index);
+    setOffset(0);
+  };
 
   return (
-    <div
-      className="preview-card"
-      style={{
-        // основное — держит размер всегда
-        '--ratio': ratio,
-        ...((style ?? {}) as React.CSSProperties),
-      } as React.CSSProperties}
-      data-mode={mode}
-      draggable={typeof index === 'number'}
-      onDragStart={typeof index === 'number' ? (e => {
-        e.dataTransfer.setData('text/plain', String(index));
-      }) : undefined}
-      onDragOver={typeof index === 'number' ? (e => e.preventDefault()) : undefined}
-      onDrop={typeof index === 'number' && onReorder ? (e => {
-        e.preventDefault();
-        const from = Number(e.dataTransfer.getData('text/plain'));
-        const to = index!;
-        if (!Number.isNaN(from) && from !== to) onReorder(from, to);
-      }) : undefined}
-      {...rest}
-    >
-      {/* Fallback для браузеров без aspect-ratio */}
-      <div className="preview-card__ratio-fallback" aria-hidden />
-
-      {/* Фото */}
-      {image && (
-        <img className="preview-card__img" src={image} alt="" />
-      )}
-
-      {/* Текст */}
-      <div
-        className={`preview-card__text preview-card__text--${textPosition}`}
-      >
-        {text}
+    <div className="relative overflow-hidden">
+      <div className="absolute inset-y-0 right-0 flex">
+        <button
+          onClick={() => handleAction(onMoveUp)}
+          className="w-12 bg-neutral-800 text-neutral-100"
+        >
+          ↑
+        </button>
+        <button
+          onClick={() => handleAction(onMoveDown)}
+          className="w-12 bg-neutral-800 text-neutral-100"
+        >
+          ↓
+        </button>
+        <button
+          onClick={() => handleAction(onDelete)}
+          className="w-12 bg-red-700 text-neutral-100"
+        >
+          ✕
+        </button>
       </div>
+      <div
+        className="preview-card"
+        style={{
+          // основное — держит размер всегда
+          '--ratio': ratio,
+          transform: `translateX(${offset}px)`,
+          ...((style ?? {}) as React.CSSProperties),
+        } as React.CSSProperties}
+        data-mode={mode}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        {...rest}
+      >
+        {/* Fallback для браузеров без aspect-ratio */}
+        <div className="preview-card__ratio-fallback" aria-hidden />
 
-      {/* Ник (всегда левый нижний) */}
-      <div className="preview-card__username">@{username}</div>
+        {/* Фото */}
+        {image && (
+          <img className="preview-card__img" src={image} alt="" />
+        )}
 
-      {/* Пэйджер (опционально) */}
-      {/* <div className="preview-card__pager">1/5 →</div> */}
+        {/* Текст */}
+        <div
+          className={`preview-card__text preview-card__text--${textPosition}`}
+        >
+          {text}
+        </div>
+
+        {/* Ник (всегда левый нижний) */}
+        <div className="preview-card__username">@{username}</div>
+
+        {/* Пэйджер (опционально) */}
+        {/* <div className="preview-card__pager">1/5 →</div> */}
+      </div>
     </div>
   );
 };

--- a/apps/webapp/src/styles/tailwind.css
+++ b/apps/webapp/src/styles/tailwind.css
@@ -11,7 +11,6 @@ html, body, #root { height: 100%; }
 * { -webkit-tap-highlight-color: transparent; }
 body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
 [data-floating-label="export"] { display: none !important; }
-.dnd-area { touch-action: none; }
 @layer components {
   .slideCard {
     width: min(88vw, 320px);


### PR DESCRIPTION
## Summary
- drop all drag & drop handlers from preview cards and container
- add swipeable action panel with move up/down/delete controls
- manage slide order solely through new move callbacks and clean CSS

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0b796717883289745fbc58da87057