### PR TITLE
Fix vertical scroll and bottom bar gestures

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -4,7 +4,14 @@ import { CANVAS_PRESETS } from "./core/constants";
 import BottomSheet from "./components/BottomSheet";
 import ImagesModal from "./components/ImagesModal";
 import PreviewCard from "./components/PreviewCard";
-import BottomBar from "./components/BottomBar";
+import {
+  IconTemplate,
+  IconLayout,
+  IconFonts,
+  IconPhotos,
+  IconInfo,
+  IconExport,
+} from "./ui/icons";
 import "./styles/tailwind.css";
 import "./styles/builder-preview.css";
 import "./styles/preview-list.css";
@@ -31,6 +38,7 @@ export default function App() {
   const [activeIndex, setActiveIndex] = useState(0);
   const prevTextPos = useRef<'top'|'bottom'>('bottom');
   const promptedRef = useRef<Record<string, boolean>>({});
+  const touchRef = useRef<{ x: number; y: number } | null>(null);
 
   const genId = () => Math.random().toString(36).slice(2);
 
@@ -62,6 +70,13 @@ export default function App() {
   useEffect(() => {
     localStorage.setItem('carouselSettings', JSON.stringify(settings));
   }, [settings]);
+
+  useEffect(() => {
+    const hasModal =
+      openTemplate || openLayout || openFonts || openImages || openInfo;
+    document.body.classList.toggle('overflow-hidden', hasModal);
+    return () => document.body.classList.remove('overflow-hidden');
+  }, [openTemplate, openLayout, openFonts, openImages, openInfo]);
 
   const PRESETS = {
     minimal: { textSize: 0.46, lineHeight: 1.4, textPosition: 'bottom', template: 'photo', overlayEnabled: false, headingEnabled: false, quoteMode: false },
@@ -219,6 +234,23 @@ export default function App() {
     });
   };
 
+  const onSlideTouchStart = (e: React.TouchEvent) => {
+    const t = e.touches[0];
+    touchRef.current = { x: t.clientX, y: t.clientY };
+  };
+  const onSlideTouchMove = (e: React.TouchEvent) => {
+    if (!touchRef.current) return;
+    const t = e.touches[0];
+    const dx = t.clientX - touchRef.current.x;
+    const dy = t.clientY - touchRef.current.y;
+    if (Math.abs(dx) > Math.abs(dy) + 6) {
+      e.preventDefault();
+    }
+  };
+  const onSlideTouchEnd = () => {
+    touchRef.current = null;
+  };
+
 
   useEffect(() => {
     if (localStorage.getItem(SEED_KEY)) return;
@@ -329,7 +361,11 @@ export default function App() {
   color: var(--heading-color,#6E56CF);
 }
     `}</style>
-    <div className="min-h-full pt-[calc(12px+env(safe-area-inset-top))] px-4 sm:px-6 bg-neutral-950 text-neutral-100">
+    <div
+      id="scrollRoot"
+      className="relative min-h-full pt-[calc(12px+env(safe-area-inset-top))] px-4 sm:px-6 bg-neutral-950 text-neutral-100 overflow-y-auto overscroll-y-contain"
+      style={{ WebkitOverflowScrolling: 'touch', touchAction: 'pan-y' }}
+    >
       <div className="pb-[88px] pb-[calc(88px+env(safe-area-inset-bottom))]">
         <div className="max-w-6xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-6">
           <div className="lg:col-span-5 space-y-4">
@@ -370,7 +406,7 @@ export default function App() {
                     onMoveUp={() => onReorder(i, i - 1)}
                     onMoveDown={() => onReorder(i, i + 1)}
                     onDelete={() => deleteSlide(i)}
-                    style={cardStyle}
+                    style={{ ...cardStyle, touchAction: 'pan-y' }}
                     mode={mode}
                     image={img}
                     text={(settings.headingEnabled && !settings.quoteMode
@@ -379,6 +415,9 @@ export default function App() {
                     username={username.replace(/^@/, '')}
                     textPosition={settings.quoteMode ? 'center' : settings.textPosition}
                     onClick={() => setActiveIndex(i)}
+                    onTouchStartCapture={onSlideTouchStart}
+                    onTouchMoveCapture={onSlideTouchMove}
+                    onTouchEndCapture={onSlideTouchEnd}
                   />
                 );
               })}
@@ -552,16 +591,81 @@ export default function App() {
         </div>
       )}
 
-      <BottomBar
-        onTemplate={()=>setOpenTemplate(true)}
-        onLayout={()=>setOpenLayout(true)}
-        onFonts={()=>setOpenFonts(true)}
-        onPhotos={()=>setOpenImages(true)}
-        onInfo={()=>setOpenInfo(true)}
-        onExport={handleExport}
-        disabledExport={!slides.length || exporting}
-        active={openTemplate?"template":openLayout?"layout":openFonts?"fonts":openImages?"photos":openInfo?"info":undefined}
-      />
+      {(() => {
+        const active =
+          openTemplate
+            ? 'template'
+            : openLayout
+            ? 'layout'
+            : openFonts
+            ? 'fonts'
+            : openImages
+            ? 'photos'
+            : openInfo
+            ? 'info'
+            : undefined;
+        const btn =
+          'w-full h-11 flex items-center justify-center gap-2 rounded-lg text-xs cursor-pointer select-none transition-transform';
+        const rest =
+          'hover:opacity-90 active:opacity-90 hover:-translate-y-px active:-translate-y-px active:scale-[0.96]';
+        return (
+          <div className="fixed inset-x-0 bottom-0 z-40 pb-[env(safe-area-inset-bottom)] pointer-events-none">
+            <div className="mx-auto max-w-6xl pointer-events-auto">
+              <div className="m-3 rounded-2xl border border-neutral-800 bg-neutral-900/85 backdrop-blur px-3 py-2 grid grid-cols-6 gap-1">
+                <button
+                  onClick={() => setOpenTemplate(true)}
+                  aria-label="Template"
+                  className={`${btn} ${rest} ${active==='template'?'text-[var(--fg)]':'text-[var(--fg-muted)]'}`}
+                >
+                  <IconTemplate size={22} />
+                  <span>Template</span>
+                </button>
+                <button
+                  onClick={() => setOpenLayout(true)}
+                  aria-label="Layout"
+                  className={`${btn} ${rest} ${active==='layout'?'text-[var(--fg)]':'text-[var(--fg-muted)]'}`}
+                >
+                  <IconLayout size={22} />
+                  <span>Layout</span>
+                </button>
+                <button
+                  onClick={() => setOpenFonts(true)}
+                  aria-label="Fonts"
+                  className={`${btn} ${rest} ${active==='fonts'?'text-[var(--fg)]':'text-[var(--fg-muted)]'}`}
+                >
+                  <IconFonts size={22} />
+                  <span>Fonts</span>
+                </button>
+                <button
+                  onClick={() => setOpenImages(true)}
+                  aria-label="Photos"
+                  className={`${btn} ${rest} ${active==='photos'?'text-[var(--fg)]':'text-[var(--fg-muted)]'}`}
+                >
+                  <IconPhotos size={22} />
+                  <span>Photos</span>
+                </button>
+                <button
+                  onClick={() => setOpenInfo(true)}
+                  aria-label="Info"
+                  className={`${btn} ${rest} ${active==='info'?'text-[var(--fg)]':'text-[var(--fg-muted)]'}`}
+                >
+                  <IconInfo size={22} />
+                  <span>Info</span>
+                </button>
+                <button
+                  onClick={handleExport}
+                  disabled={!slides.length || exporting}
+                  aria-label="Export"
+                  className={`${btn} ${!slides.length || exporting ? 'opacity-40' : rest} text-[var(--fg-muted)]`}
+                >
+                  <IconExport size={22} />
+                  <span>Export</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
     </div>
     </>
   );


### PR DESCRIPTION
## Summary
- make main content scrollable with inertial touch scroll and body overflow lock for modals
- handle swipe gestures per slide without blocking vertical scroll
- inline bottom bar with pointer-events fixes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c0bea652f483288a4fa5082e9e6be0