### PR TITLE
Implement slide export and toolbar layout

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.5.2"
+    "zustand": "^4.5.2",
+    "file-saver": "^2.0.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,0 +1,38 @@
+import { saveAs } from 'file-saver';
+import { renderSlideToCanvas, Slide, OverlayOpts } from '../lib/canvasRender';
+
+interface ExportSettings {
+  mode: 'story' | 'carousel';
+  overlay: OverlayOpts;
+  text: {
+    font: string;
+    size: number;
+    lineHeight: number;
+    align: CanvasTextAlign;
+    color: string;
+    titleColor: string;
+    titleEnabled: boolean;
+    content?: string;
+  };
+  username: string;
+  quality?: number;
+}
+
+export async function exportSlides(slides: Slide[], settings: ExportSettings) {
+  const W = settings.mode === 'story' ? 1080 : 1350;
+  const H = settings.mode === 'story' ? 1920 : 1080;
+  for (let i = 0; i < slides.length; i++) {
+    const canvas = await renderSlideToCanvas({ ...slides[i], index: i }, {
+      w: W,
+      h: H,
+      overlay: settings.overlay,
+      text: settings.text,
+      username: settings.username,
+      total: slides.length,
+    });
+    const blob = await new Promise<Blob>((res) =>
+      canvas.toBlob((b) => res(b!), 'image/jpeg', settings.quality ?? 0.92)
+    );
+    saveAs(blob, `slide-${i + 1}.jpg`);
+  }
+}

--- a/apps/webapp/src/features/editor/ExportPanel.tsx
+++ b/apps/webapp/src/features/editor/ExportPanel.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export function ExportPanel() {
-  return <div>TODO: ExportPanel</div>;
-}

--- a/apps/webapp/src/features/editor/ExportSheet.tsx
+++ b/apps/webapp/src/features/editor/ExportSheet.tsx
@@ -1,0 +1,68 @@
+import React, { useState, useRef } from 'react';
+import { Slide } from '../carousel/lib/canvasRender';
+import { exportSlides } from '../carousel/utils/exportSlides';
+
+interface Props {
+  slides: Slide[];
+  settings: {
+    mode: 'story' | 'carousel';
+    overlay: { enabled: boolean; heightPct: number; intensity: number };
+    text: {
+      font: string;
+      size: number;
+      lineHeight: number;
+      align: CanvasTextAlign;
+      color: string;
+      titleColor: string;
+      titleEnabled: boolean;
+    };
+    username: string;
+    quality?: number;
+  };
+  onClose: () => void;
+}
+
+export function ExportSheet({ slides, settings, onClose }: Props) {
+  const [isExporting, setIsExporting] = useState(false);
+  const startY = useRef<number | null>(null);
+
+  const handleExport = async () => {
+    try {
+      setIsExporting(true);
+      await exportSlides(slides, settings);
+    } catch (e) {
+      console.error('Export failed', e);
+    } finally {
+      setIsExporting(false);
+      onClose();
+    }
+  };
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    startY.current = e.touches[0].clientY;
+  };
+
+  const onTouchEnd = (e: React.TouchEvent) => {
+    if (startY.current !== null) {
+      const dy = e.changedTouches[0].clientY - startY.current;
+      if (dy > 50) onClose();
+      startY.current = null;
+    }
+  };
+
+  return (
+    <div className="sheet" onTouchStart={onTouchStart} onTouchEnd={onTouchEnd}>
+      <div className="sheet__inner">
+        <div className="sheet__header">
+          <h3>Export</h3>
+          <div className="sheet__actions">
+            <button onClick={onClose}>Cancel</button>
+            <button onClick={handleExport} className="is-primary" disabled={isExporting}>
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add canvas-based exportSlides utility and export sheet for saving slide images
- restructure toolbar into responsive grid with icons above labels
- redesign PhotosSheet with header actions, swipe-to-close, and scrolling grid

## Testing
- `npm install --prefix apps/webapp --no-package-lock` *(fails: 403 Forbidden - GET https://registry.npmjs.org/file-saver)*
- `npm test --prefix apps/webapp` *(fails: Missing script: "test")*
- `npm run build --prefix apps/webapp` *(fails: Unexpected "===" in src/App.tsx)*


------
https://chatgpt.com/codex/tasks/task_e_68c16b917ca88328bc4fd8eef9eea968