### PR TITLE
feat: add export sheet and toolbar state

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -4,6 +4,7 @@ import { CANVAS_PRESETS } from "./core/constants";
 import BottomSheet from "./components/BottomSheet";
 import PreviewCard from "./components/PreviewCard";
 import BottomBar from "./components/BottomBar";
+import { ExportSheet } from "./features/editor/ExportSheet";
 import "./styles/tailwind.css";
 import "./styles/builder-preview.css";
 import "./styles/preview-list.css";
@@ -706,28 +707,8 @@ export default function App() {
         </div>
       )}
       </div>
-      <BottomBar
-        onTemplate={() => setOpenTemplate(true)}
-        onLayout={() => setOpenLayout(true)}
-        onFonts={() => setOpenFonts(true)}
-        onPhotos={openPhotos}
-        onInfo={() => setOpenInfo(true)}
-        onExport={handleExport}
-        disabledExport={!slides.length || exporting}
-        active={
-          openTemplate
-            ? 'template'
-            : openLayout
-            ? 'layout'
-            : openFonts
-            ? 'fonts'
-            : isPhotosOpen
-            ? 'photos'
-            : openInfo
-            ? 'info'
-            : undefined
-        }
-      />
+      <BottomBar disabledExport={!slides.length || exporting} />
+      <ExportSheet />
     </div>
     </>
   );

--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -7,44 +7,28 @@ import {
   IconInfo,
   IconExport,
 } from '../ui/icons';
+import { useStore } from '../state/store';
 
-interface Props {
-  onTemplate: () => void;
-  onLayout: () => void;
-  onFonts: () => void;
-  onPhotos: () => void;
-  onInfo: () => void;
-  onExport: () => void;
-  disabledExport?: boolean;
-  active?: 'template' | 'layout' | 'fonts' | 'photos' | 'info';
-}
+export default function BottomBar({ disabledExport }: { disabledExport?: boolean }) {
+  const openSheet = useStore(s => s.openSheet);
+  const setOpenSheet = useStore(s => s.setOpenSheet);
 
-export default function BottomBar({
-  onTemplate,
-  onLayout,
-  onFonts,
-  onPhotos,
-  onInfo,
-  onExport,
-  disabledExport,
-  active,
-}: Props) {
   const Item = ({
     icon,
     label,
-    onClick,
+    name,
     disabled,
-    isActive,
   }: {
     icon: React.ReactNode;
     label: string;
-    onClick?: () => void;
+    name: typeof openSheet;
     disabled?: boolean;
-    isActive?: boolean;
   }) => (
     <button
-      className={`toolbar__item ${isActive ? 'text-white' : 'text-white/70'}`}
-      onClick={disabled ? undefined : onClick}
+      className={
+        'toolbar__btn' + (openSheet === name ? ' text-white' : ' text-white/70')
+      }
+      onClick={disabled ? undefined : () => setOpenSheet(name)}
       disabled={disabled}
       aria-label={label}
     >
@@ -54,15 +38,13 @@ export default function BottomBar({
   );
 
   return (
-    <div className="toolbar fixed inset-x-4 bottom-6 z-[60] rounded-2xl backdrop-blur-xl bg-black/50 ring-1 ring-white/10 p-10">
-      <div className="grid grid-cols-6 gap-8">
-        <Item icon={<IconTemplate className="h-6 w-6" />} label="Template" onClick={onTemplate} isActive={active === 'template'} />
-        <Item icon={<IconLayout className="h-6 w-6" />} label="Layout" onClick={onLayout} isActive={active === 'layout'} />
-        <Item icon={<IconFonts className="h-6 w-6" />} label="Fonts" onClick={onFonts} isActive={active === 'fonts'} />
-        <Item icon={<IconPhotos className="h-6 w-6" />} label="Photos" onClick={onPhotos} isActive={active === 'photos'} />
-        <Item icon={<IconInfo className="h-6 w-6" />} label="Info" onClick={onInfo} isActive={active === 'info'} />
-        <Item icon={<IconExport className="h-6 w-6" />} label="Export" onClick={onExport} disabled={disabledExport} />
-      </div>
+    <div className="toolbar fixed inset-x-0 bottom-0 z-[60] p-4 pb-[calc(env(safe-area-inset-bottom,12px)+14px)] bg-black/60 backdrop-blur-xl">
+      <Item icon={<IconTemplate className="h-6 w-6" />} label="Template" name="template" />
+      <Item icon={<IconLayout className="h-6 w-6" />} label="Layout" name="layout" />
+      <Item icon={<IconFonts className="h-6 w-6" />} label="Fonts" name="fonts" />
+      <Item icon={<IconPhotos className="h-6 w-6" />} label="Photos" name="photos" />
+      <Item icon={<IconInfo className="h-6 w-6" />} label="Info" name="info" />
+      <Item icon={<IconExport className="h-6 w-6" />} label="Export" name="export" disabled={disabledExport} />
     </div>
   );
 }

--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -179,12 +179,17 @@ export async function renderSlideToCanvas(
 
   if (slide.image) {
     const img = new Image();
+    img.crossOrigin = 'anonymous';
     img.src = slide.image;
-    try { await img.decode(); } catch { /* ignore */ }
+    try { await img.decode(); } catch (err) { console.warn('Image decode failed', err); }
     const r = Math.max(width / img.width, height / img.height);
     const dw = Math.round(img.width * r);
     const dh = Math.round(img.height * r);
-    ctx.drawImage(img, Math.round((width - dw) / 2), Math.round((height - dh) / 2), dw, dh);
+    try {
+      ctx.drawImage(img, Math.round((width - dw) / 2), Math.round((height - dh) / 2), dw, dh);
+    } catch (err) {
+      console.warn('drawImage failed', err);
+    }
   } else {
     ctx.fillStyle = '#000';
     ctx.fillRect(0, 0, width, height);

--- a/apps/webapp/src/features/carousel/lib/canvasRender.ts
+++ b/apps/webapp/src/features/carousel/lib/canvasRender.ts
@@ -33,17 +33,24 @@ async function drawImageFit(
   h: number
 ) {
   const img = new Image();
+  img.crossOrigin = 'anonymous';
   img.src = src;
-  await new Promise((res) => {
-    img.onload = res;
-    img.onerror = res;
-  });
+  try {
+    await img.decode();
+  } catch (err) {
+    console.warn('Image load failed', src, err);
+    return;
+  }
   const r = Math.max(w / img.width, h / img.height);
   const nw = img.width * r;
   const nh = img.height * r;
   const dx = (w - nw) / 2;
   const dy = (h - nh) / 2;
-  ctx.drawImage(img, dx, dy, nw, nh);
+  try {
+    ctx.drawImage(img, dx, dy, nw, nh);
+  } catch (err) {
+    console.warn('drawImage failed', src, err);
+  }
 }
 
 function drawSlideText(

--- a/apps/webapp/src/features/carousel/lib/exportFallback.ts
+++ b/apps/webapp/src/features/carousel/lib/exportFallback.ts
@@ -1,0 +1,19 @@
+import { renderSlideToCanvas } from '../../../core/render';
+
+export async function renderSlidesFallback(slides: any[], opts: any) {
+  const canvas = document.createElement('canvas');
+  canvas.width = opts.w;
+  canvas.height = opts.h;
+  const ctx = canvas.getContext('2d')!;
+  const blobs: Blob[] = [];
+  for (let i = 0; i < slides.length; i++) {
+    await renderSlideToCanvas(slides[i], ctx, opts);
+    const blob = await new Promise<Blob>((res, rej) =>
+      canvas.toBlob(b => (b ? res(b) : rej('toBlob failed')), 'image/jpeg', 0.92)
+    );
+    blobs.push(blob);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    canvas.width = canvas.width;
+  }
+  return blobs;
+}

--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,10 +1,32 @@
 import domtoimage from 'dom-to-image-more';
+import { shareOrDownloadAll, downloadOne } from '../../../core/export';
 
 interface Options {
   containerSelector: string;
   hideSelectors?: string[];
   format?: 'png' | 'jpeg';
   quality?: number;
+  indices?: number[]; // which slides to export, undefined = all
+  onProgress?: (i: number, total: number) => void;
+}
+
+async function waitAssetsReady(container: HTMLElement) {
+  const imgs = Array.from(container.querySelectorAll('img'));
+  const imgPromises = imgs.map(img => {
+    img.crossOrigin = 'anonymous';
+    const clone = new Image();
+    clone.crossOrigin = 'anonymous';
+    clone.src = img.currentSrc || img.src;
+    return clone.decode().catch(() => {});
+  });
+  await Promise.all(imgPromises);
+  await (document as any).fonts?.ready?.catch(() => {});
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement, type: string, quality?: number) {
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(b => (b ? resolve(b) : reject(new Error('toBlob failed'))), type, quality);
+  });
 }
 
 export async function exportSlides({
@@ -12,12 +34,15 @@ export async function exportSlides({
   hideSelectors = [],
   format = 'jpeg',
   quality = 0.92,
+  indices,
+  onProgress,
 }: Options) {
   const container = document.querySelector<HTMLElement>(containerSelector);
   if (!container) throw new Error('Container not found');
-  const cards = Array.from(
-    container.querySelectorAll<HTMLElement>('[data-export-card]')
-  );
+  const cards = Array.from(container.querySelectorAll<HTMLElement>('[data-export-card]'));
+  const targets = indices ? indices.map(i => cards[i]).filter(Boolean) : cards;
+
+  await waitAssetsReady(container);
 
   const hidden: HTMLElement[] = [];
   hideSelectors.forEach(sel => {
@@ -28,23 +53,30 @@ export async function exportSlides({
     });
   });
 
-  for (let i = 0; i < cards.length; i++) {
-    const cardEl = cards[i];
-    const blob = await domtoimage.toBlob(cardEl, {
+  const blobs: Blob[] = [];
+  for (let i = 0; i < targets.length; i++) {
+    const cardEl = targets[i];
+    const canvas = await domtoimage.toCanvas(cardEl, {
       quality,
       bgcolor: 'transparent',
       style: { transform: 'none' },
     });
-    const ext = format === 'png' ? 'png' : 'jpeg';
-    const a = document.createElement('a');
-    a.href = URL.createObjectURL(blob);
-    a.download = `slide-${i + 1}.${ext}`;
-    a.click();
-    URL.revokeObjectURL(a.href);
+    const blob = await canvasToBlob(canvas, `image/${format}`, quality);
+    blobs.push(blob);
+    if (onProgress) onProgress(i + 1, targets.length);
+    const ctx = canvas.getContext('2d');
+    if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+    canvas.width = canvas.width;
   }
 
   hidden.forEach(el => {
     el.style.visibility = (el as any).dataset._prevVisibility || '';
     delete (el as any).dataset._prevVisibility;
   });
+
+  if (blobs.length === 1) {
+    await downloadOne(blobs[0]);
+  } else if (blobs.length > 1) {
+    await shareOrDownloadAll(blobs);
+  }
 }

--- a/apps/webapp/src/features/editor/PreviewCarousel.tsx
+++ b/apps/webapp/src/features/editor/PreviewCarousel.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { renderSlideToCanvas, Slide } from '../carousel/lib/canvasRender';
-import { ExportSheet } from './ExportSheet';
 
 export function PreviewCarousel() {
   const [slides, setSlides] = useState<Slide[]>([]);
@@ -262,13 +261,7 @@ export function PreviewCarousel() {
         </button>
       </div>
       {activeSheet === 'photos' && <PhotosSheet />}
-      {activeSheet === 'export' && (
-        <ExportSheet
-          slides={slides}
-          settings={exportSettings}
-          onClose={() => setActiveSheet(null)}
-        />
-      )}
+      {/* export sheet handled globally */}
       <style>{`
         .carousel-page{ overflow-y:auto; -webkit-overflow-scrolling:touch; }
         .slidesScroll { overflow: auto; touch-action: pan-y; -webkit-overflow-scrolling: touch; }

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -37,6 +37,8 @@ export type StoreState = {
   defaults: Defaults;
   mode: 'story' | 'carousel';
   frame: FrameSpec;
+  openSheet: null | 'template' | 'layout' | 'fonts' | 'photos' | 'info' | 'export';
+  setOpenSheet: (name: StoreState['openSheet']) => void;
   updateDefaults: (partial: Partial<Defaults>) => void;
   updateSlide: (id: SlideId, partial: Partial<Slide> | { overrides: Partial<Slide['overrides']> }) => void;
   reorderSlides: (fromIndex: number, toIndex: number) => void;
@@ -55,6 +57,7 @@ export const useStore = create<StoreState>((set) => ({
   },
   mode: 'story',
   frame: FRAME_SPECS.story,
+  openSheet: null,
   updateDefaults: (partial) => set((state) => ({ defaults: { ...state.defaults, ...partial } })),
   updateSlide: (id, partial) => set((state) => ({
     slides: state.slides.map((s) => {
@@ -72,4 +75,5 @@ export const useStore = create<StoreState>((set) => ({
     return { slides };
   }),
   setMode: (mode) => set(() => ({ mode, frame: FRAME_SPECS[mode] })),
+  setOpenSheet: (name) => set(() => ({ openSheet: name })),
 }));

--- a/apps/webapp/src/styles/builder-preview.css
+++ b/apps/webapp/src/styles/builder-preview.css
@@ -1,5 +1,5 @@
 .builder-preview {
-  padding: 0 12px 100px;
+  padding: 0 12px calc(env(safe-area-inset-bottom, 12px) + 78px);
 }
 
 .segmented {

--- a/apps/webapp/src/styles/preview-list.css
+++ b/apps/webapp/src/styles/preview-list.css
@@ -1,6 +1,7 @@
 .preview-list {
   display: grid;
   gap: 16px;
+  padding-bottom: calc(env(safe-area-inset-bottom, 12px) + 78px);
   /* если у тебя горизонтальная лента – сделай flex + overflow-x */
   /* overflow-y: auto;  // для вертикального скролла */
   /* max-height: calc(100vh - 260px); // если нужно ограничить высоту секцией над списком */

--- a/apps/webapp/src/styles/tailwind.css
+++ b/apps/webapp/src/styles/tailwind.css
@@ -59,13 +59,25 @@ body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-seri
     opacity: 0.8;
   }
 
-  .toolbar__item{
-    @apply flex flex-col items-center justify-center gap-2 px-2 py-3 rounded-xl hover:bg-white/5 active:bg-white/10;
+  .toolbar{
+    @apply grid grid-cols-6 gap-12;
+  }
+  .toolbar__btn{
+    @apply flex flex-col items-center justify-center rounded-[14px] px-1.5 py-2.5;
   }
   .toolbar__icon{
-    @apply w-6 h-6 flex items-center justify-center;
+    @apply w-6 h-6 leading-none;
   }
   .toolbar__label{
-    @apply text-[11px] leading-tight opacity-90;
+    @apply mt-1.5 text-[12px] opacity-90;
   }
+  @media (max-width:380px){
+    .toolbar{ @apply gap-8; }
+    .toolbar__label{ @apply text-[11px]; }
+  }
+  .sheet-backdrop{ @apply fixed inset-0 z-[60] bg-black/40; }
+  .sheet{ @apply fixed left-0 right-0 bottom-0 z-[70]; }
+  .sheet__inner{ @apply bg-neutral-900 text-white rounded-t-2xl border border-neutral-800 shadow-2xl pb-[env(safe-area-inset-bottom)]; }
+  .sheet__header{ @apply p-4 flex items-center justify-between border-b border-neutral-800; }
+  .sheet__body{ @apply p-4 max-h-[70vh] overflow-y-auto; }
 }

--- a/apps/webapp/src/workers/render.worker.ts
+++ b/apps/webapp/src/workers/render.worker.ts
@@ -1,4 +1,15 @@
-self.onmessage = () => {
-  // TODO: implement worker rendering
+import { renderSlideToCanvas } from '../core/render';
+
+self.onmessage = async (e: MessageEvent) => {
+  const { slide, opts } = e.data;
+  if (typeof OffscreenCanvas === 'undefined') {
+    (self as any).postMessage({ type: 'fallback' });
+    return;
+  }
+  const canvas = new OffscreenCanvas(opts.w, opts.h);
+  const ctx = canvas.getContext('2d')!;
+  await renderSlideToCanvas(slide, ctx as any, opts);
+  const blob = await canvas.convertToBlob({ type: 'image/jpeg', quality: 0.92 });
+  (self as any).postMessage({ type: 'done', blob }, [blob]);
 };
 export {};


### PR DESCRIPTION
## Summary
- add global sheet state to manage toolbar sheets
- redesign toolbar with compact two-line layout and bottom padding
- implement slide export with asset preloading and toBlob output

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Rollup failed to resolve import "dom-to-image-more")

------
https://chatgpt.com/codex/tasks/task_e_68c1c08aa7a88328ac892c001db466bc