### PR TITLE
feat: enable single-file export

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -18,17 +18,19 @@ export default function BottomBar({ disabledExport }: { disabledExport?: boolean
     label,
     name,
     disabled,
+    onClick,
   }: {
     icon: React.ReactNode;
     label: string;
     name: typeof openSheet;
     disabled?: boolean;
+    onClick?: () => void;
   }) => (
     <button
       className={
         'toolbar__btn' + (openSheet === name ? ' text-white' : ' text-white/70')
       }
-      onClick={disabled ? undefined : () => setOpenSheet(name)}
+      onClick={disabled ? undefined : onClick ? onClick : () => setOpenSheet(name)}
       disabled={disabled}
       aria-label={label}
     >
@@ -37,14 +39,25 @@ export default function BottomBar({ disabledExport }: { disabledExport?: boolean
     </button>
   );
 
+  const openExportSheet = () => {
+    console.log('openExportSheet');
+    setOpenSheet('export');
+  };
+
   return (
-    <div className="toolbar fixed inset-x-0 bottom-0 z-[60] p-4 pb-[env(safe-area-inset-bottom,0px)] bg-black/60 backdrop-blur-xl">
+    <div className="toolbar fixed inset-x-0 bottom-0 z-[50] p-4 pb-[env(safe-area-inset-bottom,0px)] bg-black/60 backdrop-blur-xl">
       <Item icon={<IconTemplate className="h-6 w-6" />} label="Template" name="template" />
       <Item icon={<IconLayout className="h-6 w-6" />} label="Layout" name="layout" />
       <Item icon={<IconFonts className="h-6 w-6" />} label="Fonts" name="fonts" />
       <Item icon={<IconPhotos className="h-6 w-6" />} label="Photos" name="photos" />
       <Item icon={<IconInfo className="h-6 w-6" />} label="Info" name="info" />
-      <Item icon={<IconExport className="h-6 w-6" />} label="Export" name="export" disabled={disabledExport} />
+      <Item
+        icon={<IconExport className="h-6 w-6" />}
+        label="Export"
+        name="export"
+        disabled={disabledExport}
+        onClick={openExportSheet}
+      />
     </div>
   );
 }

--- a/apps/webapp/src/core/export.ts
+++ b/apps/webapp/src/core/export.ts
@@ -1,3 +1,114 @@
+import { renderSlideToCanvas, CarouselSettings } from './render';
+import type { Slide } from '../types';
+import { useStore } from '../state/store';
+
+export type ExportOptions = {
+  format: 'jpg' | 'png';
+  quality?: number;
+  range: 'all' | 'current';
+  size: { width: number; height: number };
+  onProgress?: (index: number, total: number) => void;
+  onFallback?: (url: string) => void;
+};
+
+export async function exportSlides(
+  slides: Slide[],
+  options: ExportOptions,
+  currentIndex = 0
+): Promise<void> {
+  const { format, quality = 0.8, range, size, onProgress, onFallback } = options;
+  const { defaults, frame } = useStore.getState();
+  const canvas = document.createElement('canvas');
+  canvas.width = size.width;
+  canvas.height = size.height;
+  const ctx = canvas.getContext('2d')!;
+  const targets = range === 'current' ? [slides[currentIndex]].filter(Boolean) : slides;
+  const names = targets.map((_, i) => `carousel-${i + 1}.${format}`);
+  const blobs: Blob[] = [];
+  for (let i = 0; i < targets.length; i++) {
+    const slide = targets[i];
+    await renderSlideToCanvas(slide as any, ctx, {
+      frame: { ...frame, width: size.width, height: size.height },
+      theme: 'photo',
+      defaults,
+      username: 'user',
+      page:
+        range === 'all'
+          ? { index: i + 1, total: targets.length, showArrow: i + 1 < targets.length }
+          : undefined,
+      settings: {
+        fontFamily: 'Inter',
+        fontWeight: 600,
+        fontItalic: false,
+        fontApplyHeading: true,
+        fontApplyBody: true,
+        overlayEnabled: false,
+        overlayHeight: 0.3,
+        overlayOpacity: 0.3,
+        headingEnabled: false,
+        headingColor: '#ffffff',
+        textSize: 0,
+        lineHeight: defaults.lineHeight,
+        textPosition: defaults.textPosition,
+        template: 'photo',
+        quoteMode: false,
+      } as CarouselSettings,
+    });
+    const blob: Blob = await new Promise((resolve, reject) => {
+      canvas.toBlob(
+        b => (b ? resolve(b) : reject(new Error('toBlob failed'))),
+        format === 'jpg' ? 'image/jpeg' : 'image/png',
+        format === 'jpg' ? quality : undefined,
+      );
+    });
+    blobs.push(blob);
+    onProgress?.(i + 1, targets.length);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    await delay(50);
+  }
+  const files = blobs.map((b, i) => new File([b], names[i], { type: b.type }));
+  let success = false;
+  try {
+    if (navigator.canShare?.({ files })) {
+      await (navigator as any).share({ files, title: 'Carousel' });
+      success = true;
+    }
+  } catch (err) {
+    console.warn('share failed', err);
+  }
+  if (!success) {
+    try {
+      for (let i = 0; i < files.length; i++) {
+        const url = URL.createObjectURL(files[i]);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = names[i];
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+        await delay(250);
+      }
+      success = true;
+    } catch (err) {
+      console.warn('download failed', err);
+    }
+  }
+  if (!success && blobs[0]) {
+    try {
+      const dataUrl = await new Promise<string>((res, rej) => {
+        const reader = new FileReader();
+        reader.onload = () => res(reader.result as string);
+        reader.onerror = () => rej(reader.error);
+        reader.readAsDataURL(blobs[0]);
+      });
+      onFallback?.(dataUrl);
+    } catch (err) {
+      console.error('fallback failed', err);
+    }
+  }
+}
+
 export async function shareOrDownloadAll(blobs: Blob[]) {
   const files = blobs.map((b, i) => new File([b], `slide_${String(i+1).padStart(2,'0')}.jpg`, { type: 'image/jpeg' }))
 

--- a/apps/webapp/src/features/editor/ExportSheet.tsx
+++ b/apps/webapp/src/features/editor/ExportSheet.tsx
@@ -1,37 +1,117 @@
 import React, { useState } from 'react';
 import BottomSheet from '../../components/BottomSheet';
-import { exportSlides } from '../carousel/utils/exportSlides';
+import { exportSlides, ExportOptions } from '../../core/export';
 import { useStore } from '../../state/store';
 
 export function ExportSheet() {
   const slides = useStore(s => s.slides);
-  const [progress, setProgress] = useState<string>('');
+  const frame = useStore(s => s.frame);
+  const [format, setFormat] = useState<'jpg' | 'png'>('jpg');
+  const [quality, setQuality] = useState(0.8);
+  const [range, setRange] = useState<'all' | 'current'>('all');
+  const [progress, setProgress] = useState('');
+  const [fallback, setFallback] = useState<string | null>(null);
 
-  const runExport = async (mode: 'all' | 'current') => {
-    setProgress('Export 0/0');
-    const indices = mode === 'current' ? [0] : undefined; // placeholder index
-    await exportSlides({
-      containerSelector: '#preview-list',
-      hideSelectors: ['.toolbar', '.drag-ghost', '.sheet-backdrop'],
-      format: 'jpeg',
-      quality: 0.92,
-      indices,
-      onProgress: (i, total) => setProgress(`Export ${i}/${total}...`),
-    });
-    setProgress('');
+  const handleExport = async () => {
+    if (!slides.length) return;
+    setProgress('Rendering 0/0...');
+    const opts: ExportOptions = {
+      format,
+      quality,
+      range,
+      size: { width: frame.width, height: frame.height },
+      onProgress: (i, total) => setProgress(`Rendering ${i}/${total}...`),
+      onFallback: (url) => setFallback(url),
+    };
+    try {
+      await exportSlides(slides, opts, 0);
+      setProgress('');
+    } catch (e) {
+      console.error(e);
+      setProgress('');
+      alert('Export failed');
+    }
   };
 
   return (
     <BottomSheet name="export" title="Export">
       <div className="flex flex-col gap-4">
-        <button className="btn btn-primary" onClick={() => runExport('all')} disabled={!slides.length}>
-          Save all (ZIP)
+        <div className="flex items-center gap-4">
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              name="format"
+              value="jpg"
+              checked={format === 'jpg'}
+              onChange={() => setFormat('jpg')}
+            />
+            <span>JPG</span>
+          </label>
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              name="format"
+              value="png"
+              checked={format === 'png'}
+              onChange={() => setFormat('png')}
+            />
+            <span>PNG</span>
+          </label>
+        </div>
+        {format === 'jpg' && (
+          <div className="flex items-center gap-2">
+            <span>Quality</span>
+            <input
+              type="range"
+              min={0.5}
+              max={1}
+              step={0.05}
+              value={quality}
+              onChange={e => setQuality(parseFloat(e.target.value))}
+            />
+            <span>{quality.toFixed(2)}</span>
+          </div>
+        )}
+        <div className="flex items-center gap-4">
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              name="range"
+              value="all"
+              checked={range === 'all'}
+              onChange={() => setRange('all')}
+            />
+            <span>All slides</span>
+          </label>
+          <label className="flex items-center gap-1">
+            <input
+              type="radio"
+              name="range"
+              value="current"
+              checked={range === 'current'}
+              onChange={() => setRange('current')}
+            />
+            <span>Current</span>
+          </label>
+        </div>
+        <button
+          className="btn btn-primary"
+          onClick={handleExport}
+          disabled={!slides.length}
+        >
+          Export
         </button>
-        <button className="btn btn-secondary" onClick={() => runExport('current')} disabled={!slides.length}>
-          Save current
-        </button>
-        {progress && <p className="mt-4 text-center text-sm opacity-80">{progress}</p>}
+        {progress && (
+          <p className="mt-4 text-center text-sm opacity-80">{progress}</p>
+        )}
+        {fallback && (
+          <div className="mt-4 text-center">
+            <p className="mb-2 text-sm opacity-80">Нажми и удерживай, чтобы сохранить</p>
+            <img src={fallback} alt="" className="mx-auto max-w-full" />
+          </div>
+        )}
       </div>
     </BottomSheet>
   );
 }
+


### PR DESCRIPTION
## Summary
- make bottom bar export button clickable and adjust z-index
- add export sheet with format, quality and range settings
- implement canvas-based slide export with share/download fallbacks

## Testing
- `npm test --prefix apps/webapp` (fails: Missing script)
- `npm run build --prefix apps/webapp`


------
https://chatgpt.com/codex/tasks/task_e_68c1c7b1bbf0832891440c15547b85ed