### PR TITLE
Remove drag and drop remnants from preview components

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -447,24 +447,34 @@ export default function App() {
 
         <div className="lg:col-span-7 builder-preview">
           {slides.length ? (
-            <div className="preview-list dnd-area" onDragOver={(e)=>e.preventDefault()}>
+            <div className="preview-list">
               {slides.map((s, i) => {
-                const img = photos.find(p=>p.id===s.imageId)?.url;
+                const img = photos.find(p => p.id === s.imageId)?.url;
                 const [h, b] = settings.headingEnabled && !settings.quoteMode ? splitHeading(s.body || '') : ['', s.body];
                 return (
                   <PreviewCard
                     key={s.id}
-                    index={i}
-                    onReorder={onReorder}
                     onMoveUp={() => onReorder(i, i - 1)}
                     onMoveDown={() => onReorder(i, i + 1)}
                     onDelete={() => deleteSlide(i)}
                     style={{ ...cardStyle, touchAction: 'pan-y' }}
                     mode={mode}
                     image={img}
-                    text={(settings.headingEnabled && !settings.quoteMode
-                        ? (<>{h && <span className="preview-heading">{h}</span>}{b ? <><br/>{b}</> : null}</>)
-                        : s.body) as any}
+                    text={
+                      (settings.headingEnabled && !settings.quoteMode
+                        ? (
+                            <>
+                              {h && <span className="preview-heading">{h}</span>}
+                              {b ? (
+                                <>
+                                  <br />
+                                  {b}
+                                </>
+                              ) : null}
+                            </>
+                          )
+                        : s.body) as any
+                    }
                     username={username.replace(/^@/, '')}
                     textPosition={settings.quoteMode ? 'center' : settings.textPosition}
                     onClick={() => setActiveIndex(i)}

--- a/apps/webapp/src/components/PreviewCard.tsx
+++ b/apps/webapp/src/components/PreviewCard.tsx
@@ -8,8 +8,6 @@ type Props = {
   text: string;
   username: string;
   textPosition?: 'bottom' | 'top';
-  index?: number;
-  onReorder?: (from: number, to: number) => void;
   onMoveUp?: () => void;
   onMoveDown?: () => void;
   onDelete?: () => void;
@@ -21,8 +19,6 @@ export const PreviewCard: React.FC<Props> = ({
   text,
   username,
   textPosition = 'bottom',
-  index,
-  onReorder,
   onMoveUp,
   onMoveDown,
   onDelete,
@@ -54,17 +50,6 @@ export const PreviewCard: React.FC<Props> = ({
       } as React.CSSProperties}
       data-mode={mode}
       data-export-card
-      draggable={typeof index === 'number'}
-      onDragStart={typeof index === 'number' ? (e => {
-        e.dataTransfer.setData('text/plain', String(index));
-      }) : undefined}
-      onDragOver={typeof index === 'number' ? (e => e.preventDefault()) : undefined}
-      onDrop={typeof index === 'number' && onReorder ? (e => {
-        e.preventDefault();
-        const from = Number(e.dataTransfer.getData('text/plain'));
-        const to = index!;
-        if (!Number.isNaN(from) && from !== to) onReorder(from, to);
-      }) : undefined}
       onTouchStart={handleStart}
       onTouchEnd={handleEnd}
       {...rest}
@@ -92,13 +77,25 @@ export const PreviewCard: React.FC<Props> = ({
 
       <div className={`preview-card__actions ${show ? 'preview-card__actions--show' : ''}`}>
         <IconGrip size={20} className="mb-1" />
-        <button aria-label="Move up" onClick={onMoveUp} onDragStart={e=>e.stopPropagation()} className="w-11 h-11 flex items-center justify-center active:scale-[0.96]">
+        <button
+          aria-label="Move up"
+          onClick={onMoveUp}
+          className="w-11 h-11 flex items-center justify-center active:scale-[0.96]"
+        >
           <IconMoveUp size={20} />
         </button>
-        <button aria-label="Move down" onClick={onMoveDown} onDragStart={e=>e.stopPropagation()} className="w-11 h-11 flex items-center justify-center active:scale-[0.96]">
+        <button
+          aria-label="Move down"
+          onClick={onMoveDown}
+          className="w-11 h-11 flex items-center justify-center active:scale-[0.96]"
+        >
           <IconMoveDown size={20} />
         </button>
-        <button aria-label="Delete" onClick={onDelete} onDragStart={e=>e.stopPropagation()} className="w-11 h-11 flex items-center justify-center text-[var(--danger)] active:scale-[0.96]">
+        <button
+          aria-label="Delete"
+          onClick={onDelete}
+          className="w-11 h-11 flex items-center justify-center text-[var(--danger)] active:scale-[0.96]"
+        >
           <IconTrash size={20} />
         </button>
       </div>

--- a/apps/webapp/src/styles/tailwind.css
+++ b/apps/webapp/src/styles/tailwind.css
@@ -11,7 +11,6 @@ html, body, #root { height: 100%; }
 * { -webkit-tap-highlight-color: transparent; }
 body { font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
 [data-floating-label="export"] { display: none !important; }
-.dnd-area { touch-action: none; }
 .preview-card__text--center { top:50%; bottom:auto; transform:translateY(-50%); text-align:center; padding-top:16px; padding-bottom:16px; }
 @layer components {
   .slideCard {


### PR DESCRIPTION
## Summary
- strip drag & drop props and handlers from preview cards and list usage
- drop unused `.dnd-area` style utility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1ffb32c448328aa5f3ae8c9857764