### PR TITLE
feat: share or download PNG slides

### DIFF
--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,5 +1,4 @@
-import { renderSlideToBlob, Slide, OverlayOpts } from '../lib/canvasRender';
-import { downloadBlob } from '../../../core/export';
+import { renderSlideToCanvas, Slide, OverlayOpts } from '../lib/canvasRender';
 
 type TextOpts = {
   font: string;
@@ -19,12 +18,17 @@ type ExportOpts = {
   username: string;
 };
 
-export async function exportSlides(slides: Slide[], opts: ExportOpts) {
+export async function exportSlides(slides: Slide[], opts: ExportOpts): Promise<Blob[]> {
+  const out: Blob[] = [];
   for (let i = 0; i < slides.length; i++) {
-    const blob = await renderSlideToBlob(
+    const canvas = await renderSlideToCanvas(
       { ...(slides[i] as any), index: i },
       { ...opts, text: { ...opts.text, content: (slides[i] as any).body || '' }, total: slides.length }
     );
-    await downloadBlob(blob, `slide-${i + 1}.jpg`);
+    const blob = await new Promise<Blob>((res) =>
+      canvas.toBlob((b) => res(b!), 'image/png', 1)
+    );
+    out.push(blob);
   }
+  return out;
 }


### PR DESCRIPTION
## Summary
- export slides to PNG blobs instead of JPG download
- add Export button logic to share PNG slides via Web Share API or download fallback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c2063aff50832896611e71b84c9266