### PR TITLE
feat: restore bottom toolbar

### DIFF
--- a/apps/webapp/src/styles/builder-preview.css
+++ b/apps/webapp/src/styles/builder-preview.css
@@ -1,5 +1,9 @@
+:root {
+  --tb-h: 96px;
+}
+
 .builder-preview {
-  padding: 0 12px calc(env(safe-area-inset-bottom, 12px) + 96px);
+  padding: 0 12px calc(env(safe-area-inset-bottom, 12px) + var(--tb-h));
 }
 
 .segmented {
@@ -21,23 +25,32 @@
 
 
 .sheet-backdrop{
-  position:fixed;inset:0;background:rgba(0,0,0,.25);z-index:55;
+  position:fixed;inset:0;background:rgba(0,0,0,.25);z-index:39;
 }
 .sheet{
-  position:fixed;left:0;right:0;bottom:0;background:#111;
-  border-top-left-radius:16px;border-top-right-radius:16px;z-index:60;display:flex;flex-direction:column;
-  max-height:calc(100vh - var(--header-h,56px) - env(safe-area-inset-top) - 12px);padding-bottom:calc(16px + env(safe-area-inset-bottom));
+  position:fixed;left:0;right:0;bottom:0;
+  z-index:40;
+  padding-bottom:calc(var(--tb-h) + env(safe-area-inset-bottom));
+  border-top-left-radius:20px;border-top-right-radius:20px;
+  background:rgba(18,18,18,.98);backdrop-filter:blur(20px);
 }
-.sheet__content{overflow-y:auto;-webkit-overflow-scrolling:touch;}
+.sheet__body{overflow-y:auto;-webkit-overflow-scrolling:touch;}
 
 
 .toolbar{
-  position:fixed;left:16px;right:16px;bottom:16px;z-index:50;background:rgba(20,20,20,.92);
-  backdrop-filter:blur(12px);border-radius:16px;padding:10px 12px calc(10px + env(safe-area-inset-bottom));display:grid;grid-template-columns:repeat(6,1fr);gap:8px;
+  position:fixed;left:0;right:0;bottom:0;
+  height:var(--tb-h);
+  padding:10px 16px calc(10px + env(safe-area-inset-bottom));
+  background:rgba(18,18,18,.9);
+  backdrop-filter:blur(16px);
+  display:grid;grid-template-columns:repeat(6,1fr);gap:8px;
+  z-index:30;
+  border-top:1px solid rgba(255,255,255,.06);
+  border-top-left-radius:16px;border-top-right-radius:16px;
 }
-.toolbar__item{display:flex;flex-direction:column;align-items:center;gap:6px;padding:10px 0;border-radius:12px;}
-.toolbar__icon svg{width:22px;height:22px;display:block;}
-.toolbar__label{font-size:12px;line-height:14px;color:#ddd;}
+.toolbar__item{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;min-height:56px;border-radius:12px;background:transparent;}
 .toolbar__item:active{background:rgba(255,255,255,.06);}
+.toolbar__icon{line-height:0;}
+.toolbar__label{font-size:12px;color:#fff;opacity:.9;}
 
 .photos-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;padding:12px;}


### PR DESCRIPTION
## Summary
- Reintroduce fixed bottom toolbar with six actions and direct export sharing
- Update global styles for toolbar height and sheet stacking

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Rollup failed to resolve import '@/features/carousel/utils/exportSlides')*

------
https://chatgpt.com/codex/tasks/task_e_68c353f83a148328b22cf8cba063129c