### PR TITLE
feat: restore bottom bar and sheets

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -477,7 +477,7 @@ export default function App() {
         </div>
       </div>
 
-      <BottomSheet name="template" title="Template">
+      <BottomSheet open={openSheet === 'template'} onClose={() => setOpenSheet(null)} title="Template">
         <div className="segmented mb-4">
           {(["photo","light","dark"] as const).map(tpl=>(
             <button key={tpl}
@@ -507,7 +507,7 @@ export default function App() {
         </div>
       </BottomSheet>
 
-      <BottomSheet name="layout" title="Layout">
+      <BottomSheet open={openSheet === 'layout'} onClose={() => setOpenSheet(null)} title="Layout">
         <div className="space-y-2">
           <label className="flex items-center justify-between">
             <span>Text size</span>
@@ -572,7 +572,7 @@ export default function App() {
         </div>
       </BottomSheet>
 
-      <BottomSheet name="fonts" title="Fonts">
+      <BottomSheet open={openSheet === 'fonts'} onClose={() => setOpenSheet(null)} title="Fonts">
         <div className="space-y-2">
           <label className="flex flex-col gap-1">
             <span>Font family</span>
@@ -666,7 +666,7 @@ export default function App() {
         </div>
       )}
 
-      <BottomSheet name="info" title="Info">
+      <BottomSheet open={openSheet === 'info'} onClose={() => setOpenSheet(null)} title="Info">
         <div className="space-y-4">
           <button
             className="w-full px-4 py-3 rounded-xl bg-neutral-800 border border-neutral-700 text-sm"
@@ -692,7 +692,7 @@ export default function App() {
         </div>
       )}
       </div>
-      <BottomBar disabledExport={!slides.length} />
+      <BottomBar onOpenSheet={setOpenSheet} />
     </div>
     </>
   );

--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,37 +1,33 @@
-import React from 'react'
 import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons'
 
-type Sheet = null | 'template' | 'layout' | 'fonts' | 'photos' | 'info'
-
 type Props = {
-  activeSheet: Sheet
-  onOpenSheet: (name: Exclude<Sheet, null>) => void
+  onOpenSheet: (name: 'template' | 'layout' | 'fonts' | 'photos' | 'info') => void
 }
 
-export default function BottomBar({ activeSheet, onOpenSheet }: Props) {
-  const items: { id: Exclude<Sheet, null>; label: string; icon: JSX.Element }[] = [
-    { id: 'template', label: 'Template', icon: <IconTemplate /> },
-    { id: 'layout', label: 'Layout', icon: <IconLayout /> },
-    { id: 'fonts', label: 'Fonts', icon: <IconFonts /> },
-    { id: 'photos', label: 'Photos', icon: <IconPhotos /> },
-    { id: 'info', label: 'Info', icon: <IconInfo /> },
-  ]
-
+export default function BottomBar({ onOpenSheet }: Props) {
   return (
-    <nav className="toolbar" role="toolbar" aria-label="Carousel toolbar">
-      {items.map(it => (
-        <button
-          key={it.id}
-          type="button"
-          className="toolbar__item"
-          onClick={() => onOpenSheet(it.id)}
-          aria-pressed={activeSheet === it.id}
-          aria-label={it.label}
-        >
-          <span className="toolbar__icon">{it.icon}</span>
-          <span className="toolbar__label">{it.label}</span>
-        </button>
-      ))}
-    </nav>
+    <div className="toolbar">
+      <button className="toolbar__btn" onClick={() => onOpenSheet('template')}>
+        <span className="toolbar__icon"><IconTemplate /></span>
+        <span className="toolbar__label">Template</span>
+      </button>
+      <button className="toolbar__btn" onClick={() => onOpenSheet('layout')}>
+        <span className="toolbar__icon"><IconLayout /></span>
+        <span className="toolbar__label">Layout</span>
+      </button>
+      <button className="toolbar__btn" onClick={() => onOpenSheet('fonts')}>
+        <span className="toolbar__icon"><IconFonts /></span>
+        <span className="toolbar__label">Fonts</span>
+      </button>
+      <button className="toolbar__btn" onClick={() => onOpenSheet('photos')}>
+        <span className="toolbar__icon"><IconPhotos /></span>
+        <span className="toolbar__label">Photos</span>
+      </button>
+      <button className="toolbar__btn" onClick={() => onOpenSheet('info')}>
+        <span className="toolbar__icon"><IconInfo /></span>
+        <span className="toolbar__label">Info</span>
+      </button>
+    </div>
   )
 }
+

--- a/apps/webapp/src/components/BottomSheet.tsx
+++ b/apps/webapp/src/components/BottomSheet.tsx
@@ -1,32 +1,23 @@
-import React from 'react';
 import { createPortal } from 'react-dom';
 
 type BottomSheetProps = {
-  open: boolean
-  onClose: () => void
-  title?: string
-  withToolbarGap?: boolean
-  children: React.ReactNode
-}
+  open: boolean;
+  title?: string;
+  onClose: () => void;
+  children: React.ReactNode;
+};
 
-export default function BottomSheet({
-  open,
-  onClose,
-  title,
-  withToolbarGap = false,
-  children,
-}: BottomSheetProps) {
-  if (!open) return null
+export default function BottomSheet({ open, title, onClose, children }: BottomSheetProps) {
+  if (!open) return null;
 
   return createPortal(
-    <div className="sheet-wrap" role="dialog" aria-modal="true">
-      <div className="sheet-backdrop" onClick={onClose} />
-      <section className={`sheet ${withToolbarGap ? 'sheet--with-toolbar-gap' : ''}`}>
-        {title && <header className="sheet__title">{title}</header>}
+    <div className="sheet" onClick={onClose}>
+      <div className="sheet__panel" onClick={e => e.stopPropagation()}>
+        {title && <div className="sheet__title">{title}</div>}
         <div className="sheet__content">{children}</div>
-      </section>
+      </div>
     </div>,
     document.body
-  )
+  );
 }
 

--- a/apps/webapp/src/features/editor/PhotosPicker.tsx
+++ b/apps/webapp/src/features/editor/PhotosPicker.tsx
@@ -1,15 +1,13 @@
-import React, { useRef } from 'react'
+import { useRef } from 'react'
 import BottomSheet from '../../components/BottomSheet'
 
-export function PhotosPicker({
-  open,
-  onClose,
-  onPick,
-}: {
+type Props = {
   open: boolean
   onClose: () => void
   onPick: (urls: string[]) => void
-}) {
+}
+
+export default function PhotosPicker({ open, onClose, onPick }: Props) {
   const inputRef = useRef<HTMLInputElement>(null)
 
   const trigger = () => inputRef.current?.click()
@@ -29,7 +27,7 @@ export function PhotosPicker({
   }
 
   return (
-    <BottomSheet open={open} onClose={onClose} title="Photos" withToolbarGap>
+    <BottomSheet open={open} onClose={onClose} title="Photos">
       <input
         ref={inputRef}
         type="file"

--- a/apps/webapp/src/features/editor/PreviewCarousel.tsx
+++ b/apps/webapp/src/features/editor/PreviewCarousel.tsx
@@ -3,11 +3,11 @@ import { renderSlideToCanvas, Slide } from '../carousel/lib/canvasRender';
 import BottomBar from '../../components/BottomBar';
 import LayoutSheet from '../../components/sheets/LayoutSheet';
 import BottomSheet from '../../components/BottomSheet';
-import { PhotosPicker } from './PhotosPicker';
+import PhotosPicker from './PhotosPicker';
 
 type Sheet = null | 'template' | 'layout' | 'fonts' | 'photos' | 'info';
 
-export function PreviewCarousel() {
+export default function PreviewCarousel() {
   const [slides, setSlides] = useState<Slide[]>([]);
   const [activeSheet, setActiveSheet] = useState<Sheet>(null);
   const [mode] = useState<'story' | 'carousel'>('carousel');
@@ -53,6 +53,9 @@ export function PreviewCarousel() {
   const removeSlide = (index: number) => {
     setSlides((prev) => prev.filter((_, i) => i !== index));
   };
+
+  const openSheet = (name: Sheet) => setActiveSheet(name);
+  const closeSheet = () => setActiveSheet(null);
 
   const SlideCard: React.FC<{ slide: Slide; index: number }> = ({ slide, index }) => {
     const [open, setOpen] = useState(false);
@@ -151,15 +154,12 @@ export function PreviewCarousel() {
           <SlideCard key={s.id} slide={s} index={i} />
         ))}
       </div>
-      <BottomBar
-        activeSheet={activeSheet}
-        onOpenSheet={name => setActiveSheet(s => (s === name ? null : name))}
-      />
-      <TemplateSheet open={activeSheet === 'template'} onClose={() => setActiveSheet(null)} />
-      <LayoutSheet open={activeSheet === 'layout'} onClose={() => setActiveSheet(null)} />
-      <FontsSheet open={activeSheet === 'fonts'} onClose={() => setActiveSheet(null)} />
-      <PhotosPicker open={activeSheet === 'photos'} onClose={() => setActiveSheet(null)} onPick={appendPhotos} />
-      <InfoSheet open={activeSheet === 'info'} onClose={() => setActiveSheet(null)} />
+      <BottomBar onOpenSheet={openSheet} />
+      <TemplateSheet open={activeSheet === 'template'} onClose={closeSheet} />
+      <LayoutSheet open={activeSheet === 'layout'} onClose={closeSheet} />
+      <FontsSheet open={activeSheet === 'fonts'} onClose={closeSheet} />
+      <PhotosPicker open={activeSheet === 'photos'} onClose={closeSheet} onPick={appendPhotos} />
+      <InfoSheet open={activeSheet === 'info'} onClose={closeSheet} />
       {/* export sheet handled globally */}
     </div>
   );

--- a/apps/webapp/src/styles/builder-preview.css
+++ b/apps/webapp/src/styles/builder-preview.css
@@ -1,9 +1,69 @@
-:root {
-  --toolbar-h: 92px;
+/* Bottom bar */
+.toolbar{
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: env(safe-area-inset-bottom, 0);
+  z-index: 900;
+  display: flex;
+  gap: 12px;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom, 0));
+  background: rgba(20,20,20,.9);
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  border-top: 1px solid rgba(255,255,255,.08);
 }
 
+.toolbar__btn{
+  display: grid;
+  grid-template-rows: auto auto;
+  justify-items: center;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 12px;
+}
+
+.toolbar__icon{
+  width: 22px;
+  height: 22px;
+}
+
+.toolbar__label{
+  font-size: 12px;
+  line-height: 1;
+  opacity: .9;
+}
+
+/* Bottom sheet */
+.sheet{
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0,0,0,.4);
+}
+
+.sheet__panel{
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-top-left-radius: 22px;
+  border-top-right-radius: 22px;
+  background: #151515;
+  padding: 16px 16px calc(16px + 64px + env(safe-area-inset-bottom,0));
+  max-height: 80vh;
+  overflow: auto;
+}
+
+.sheet__title{
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+/* Misc styles retained from original file */
 .builder-preview {
-  padding: 0 12px calc(env(safe-area-inset-bottom, 12px) + var(--toolbar-h));
+  padding: 0 12px calc(120px + env(safe-area-inset-bottom, 0));
 }
 
 .segmented {
@@ -23,29 +83,10 @@
   background: rgba(255,255,255,0.12);
 }
 
-.sheet-wrap{position:fixed;inset:0;z-index:1000;pointer-events:none;}
-.sheet-backdrop{position:absolute;inset:0;background:rgba(0,0,0,.4);pointer-events:auto;}
-.sheet{position:absolute;left:0;right:0;bottom:0;border-top-left-radius:20px;border-top-right-radius:20px;background:rgba(18,18,18,.98);backdrop-filter:blur(20px);pointer-events:auto;max-height:min(78vh,720px);padding-bottom:calc(env(safe-area-inset-bottom));}
-.sheet--with-toolbar-gap{padding-bottom:calc(var(--toolbar-h) + env(safe-area-inset-bottom));}
-.sheet__title{padding:16px;font-weight:600;}
-.sheet__content{overflow-y:auto;-webkit-overflow-scrolling:touch;}
-
-
-.toolbar{
-  position:sticky;bottom:0;left:0;right:0;
-  height:var(--toolbar-h);
-  padding:10px 16px calc(10px + env(safe-area-inset-bottom));
-  background:rgba(18,18,18,.9);
-  backdrop-filter:blur(16px);
-  display:grid;grid-template-columns:repeat(5,1fr);gap:8px;
-  z-index:900;
-  border-top:1px solid rgba(255,255,255,.06);
-  border-top-left-radius:16px;border-top-right-radius:16px;
-  pointer-events:auto;
+.photos-grid{
+  display:grid;
+  grid-template-columns:repeat(3,1fr);
+  gap:10px;
+  padding:12px;
 }
-.toolbar__item{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;min-height:56px;border-radius:12px;background:transparent;}
-.toolbar__item:active{background:rgba(255,255,255,.06);}
-.toolbar__icon{line-height:0;}
-.toolbar__label{font-size:12px;color:#fff;opacity:.9;}
 
-.photos-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px;padding:12px;}

--- a/apps/webapp/src/styles/preview-list.css
+++ b/apps/webapp/src/styles/preview-list.css
@@ -1,7 +1,7 @@
 .preview-list {
   display: grid;
   gap: 16px;
-  padding-bottom: calc(env(safe-area-inset-bottom, 12px) + 96px);
+  padding-bottom: calc(120px + env(safe-area-inset-bottom, 0));
   overscroll-behavior: contain;
   /* если у тебя горизонтальная лента – сделай flex + overflow-x */
   /* overflow-y: auto;  // для вертикального скролла */


### PR DESCRIPTION
## Summary
- wire bottom bar to open editor sheets
- render bottom sheets via portal with shared styles
- ensure preview list has padding for fixed toolbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c443ee01e883288f8174046afc3dd7