### PR TITLE
feat: restore toolbar and surface photo sheet

### DIFF
--- a/apps/webapp/index.html
+++ b/apps/webapp/index.html
@@ -14,6 +14,7 @@
   <body class="bg-neutral-950 text-neutral-100">
     <div id="root"></div>
     <div id="portal-root"></div>
+    <div id="sheets-root"></div>
     <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,47 +1,27 @@
-import { useEffect, useRef } from 'react';
-import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons'
+import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons';
+import { useStore } from '../state/store';
+import '../styles/bottom-bar.css';
 
-type Props = {
-  onOpenSheet: (name: 'template' | 'layout' | 'fonts' | 'photos' | 'info') => void
-}
+export default function BottomBar() {
+  const openSheet = useStore(s => s.openSheet);
 
-export default function BottomBar({ onOpenSheet }: Props) {
-  const ref = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    const el = ref.current
-    if (!el) return
-    const ro = new ResizeObserver(([e]) => {
-      const h = e.contentRect.height
-      document.documentElement.style.setProperty('--toolbar-h', `${h}px`)
-    })
-    ro.observe(el)
-    return () => ro.disconnect()
-  }, [])
+  const actions = [
+    { key: 'template', label: 'Template', icon: <IconTemplate /> },
+    { key: 'layout',   label: 'Layout',   icon: <IconLayout /> },
+    { key: 'fonts',    label: 'Fonts',    icon: <IconFonts /> },
+    { key: 'photos',   label: 'Photos',   icon: <IconPhotos /> },
+    { key: 'info',     label: 'Info',     icon: <IconInfo /> },
+  ];
 
   return (
-    <div className="toolbar" ref={ref}>
-      <button className="toolbar__btn" onClick={() => onOpenSheet('template')}>
-        <span className="toolbar__icon"><IconTemplate /></span>
-        <span className="toolbar__label">Template</span>
-      </button>
-      <button className="toolbar__btn" onClick={() => onOpenSheet('layout')}>
-        <span className="toolbar__icon"><IconLayout /></span>
-        <span className="toolbar__label">Layout</span>
-      </button>
-      <button className="toolbar__btn" onClick={() => onOpenSheet('fonts')}>
-        <span className="toolbar__icon"><IconFonts /></span>
-        <span className="toolbar__label">Fonts</span>
-      </button>
-      <button className="toolbar__btn" onClick={() => onOpenSheet('photos')}>
-        <span className="toolbar__icon"><IconPhotos /></span>
-        <span className="toolbar__label">Photos</span>
-      </button>
-      <button className="toolbar__btn" onClick={() => onOpenSheet('info')}>
-        <span className="toolbar__icon"><IconInfo /></span>
-        <span className="toolbar__label">Info</span>
-      </button>
-    </div>
-  )
+    <nav className="toolbar" role="toolbar">
+      {actions.map(a => (
+        <button key={a.key} className="toolbar__btn" onClick={() => openSheet(a.key as any)}>
+          <span className="toolbar__icon">{a.icon}</span>
+          <span className="toolbar__label">{a.label}</span>
+        </button>
+      ))}
+    </nav>
+  );
 }
 

--- a/apps/webapp/src/components/BottomSheet.tsx
+++ b/apps/webapp/src/components/BottomSheet.tsx
@@ -1,50 +1,28 @@
 import { createPortal } from 'react-dom';
-import { useEffect, useRef } from 'react';
+import '../styles/bottom-sheet.css';
 
-type BottomSheetProps = {
+type Props = {
   open: boolean;
-  title?: string;
   onClose: () => void;
+  title?: string;
   children: React.ReactNode;
 };
 
-export default function BottomSheet({ open, title, onClose, children }: BottomSheetProps) {
-  const startY = useRef<number | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    document.body.classList.add('body--sheet-open');
-    return () => document.body.classList.remove('body--sheet-open');
-  }, [open]);
-
+export default function BottomSheet({ open, onClose, title, children }: Props) {
   if (!open) return null;
+  const root = document.getElementById('sheets-root');
+  if (!root) return null;
 
-  const onTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
-    startY.current = e.touches[0].clientY;
-  };
-  const onTouchMove = (e: React.TouchEvent<HTMLDivElement>) => {
-    if (startY.current === null) return;
-    const dy = e.touches[0].clientY - startY.current;
-    if (dy > 50) onClose();
-  };
-  const onTouchEnd = () => {
-    startY.current = null;
-  };
-
-  return createPortal(
-    <div className="sheet" onClick={onClose}>
-      <div
-        className="sheet__panel"
-        onClick={e => e.stopPropagation()}
-        onTouchStart={onTouchStart}
-        onTouchMove={onTouchMove}
-        onTouchEnd={onTouchEnd}
-      >
+  const sheet = (
+    <div className="sheet__overlay" onClick={onClose}>
+      <div className="sheet" onClick={e => e.stopPropagation()}>
         {title && <div className="sheet__title">{title}</div>}
         <div className="sheet__content">{children}</div>
       </div>
-    </div>,
-    document.body
+    </div>
   );
+
+  return createPortal(sheet, root);
 }
+
 

--- a/apps/webapp/src/components/PhotosSheet.tsx
+++ b/apps/webapp/src/components/PhotosSheet.tsx
@@ -5,6 +5,7 @@ import type { PhotoMeta } from '../types';
 export default function PhotosSheet({
   open,
   onClose,
+  onDone,
   photos,
   onAdd,
   onDelete,
@@ -12,6 +13,7 @@ export default function PhotosSheet({
 }: {
   open: boolean;
   onClose: () => void;
+  onDone: () => void;
   photos: PhotoMeta[];
   onAdd: (urls: string[]) => void;
   onDelete: (id: string) => void;
@@ -34,14 +36,14 @@ export default function PhotosSheet({
 
   return (
     <BottomSheet open={open} onClose={onClose} title="Photos">
-      <div className="flex gap-2 mb-4">
-        <button onClick={() => fileRef.current?.click()} className="btn btn-secondary">
-          Add photo
-        </button>
-        <button onClick={onClose} className="btn btn-primary">
-          Done
-        </button>
-      </div>
+        <div className="flex gap-2 mb-4">
+          <button onClick={() => fileRef.current?.click()} className="btn btn-secondary">
+            Add photo
+          </button>
+          <button onClick={onDone} className="btn btn-primary">
+            Done
+          </button>
+        </div>
 
       <input
         ref={fileRef}

--- a/apps/webapp/src/features/editor/PreviewCarousel.tsx
+++ b/apps/webapp/src/features/editor/PreviewCarousel.tsx
@@ -4,13 +4,13 @@ import BottomBar from '../../components/BottomBar';
 import LayoutSheet from '../../components/sheets/LayoutSheet';
 import BottomSheet from '../../components/BottomSheet';
 import PhotosSheet from '../../components/PhotosSheet';
-
-type Sheet = null | 'template' | 'layout' | 'fonts' | 'photos' | 'info';
+import { useStore } from '../../state/store';
 
 export default function PreviewCarousel() {
-  const [slides, setSlides] = useState<Slide[]>([]);
-  const [activeSheet, setActiveSheet] = useState<Sheet>(null);
-  const [mode] = useState<'story' | 'carousel'>('carousel');
+    const [slides, setSlides] = useState<Slide[]>([]);
+    const [mode] = useState<'story' | 'carousel'>('carousel');
+    const activeSheet = useStore(s => s.activeSheet);
+    const closeSheet = useStore(s => s.closeSheet);
 
   const username = 'user';
   const overlayEnabled = true;
@@ -64,8 +64,6 @@ export default function PreviewCarousel() {
     });
   };
 
-  const openSheet = (name: Sheet) => setActiveSheet(name);
-  const closeSheet = () => setActiveSheet(null);
 
   const SlideCard: React.FC<{ slide: Slide; index: number }> = ({ slide, index }) => {
     const [open, setOpen] = useState(false);
@@ -164,7 +162,7 @@ export default function PreviewCarousel() {
           <SlideCard key={s.id} slide={s} index={i} />
         ))}
       </div>
-      <BottomBar onOpenSheet={openSheet} />
+        <BottomBar />
       <TemplateSheet open={activeSheet === 'template'} onClose={closeSheet} />
       <LayoutSheet open={activeSheet === 'layout'} onClose={closeSheet} />
       <FontsSheet open={activeSheet === 'fonts'} onClose={closeSheet} />

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -32,14 +32,16 @@ const FRAME_SPECS: Record<'story' | 'carousel', FrameSpec> = {
   },
 };
 
+export type UISheet = null | 'template' | 'layout' | 'fonts' | 'photos' | 'info';
+
 export type StoreState = {
   slides: Slide[];
   defaults: Defaults;
   mode: 'story' | 'carousel';
   frame: FrameSpec;
-  openSheet: null | 'template' | 'layout' | 'fonts' | 'photos' | 'info';
-  sheetOpen: boolean;
-  setOpenSheet: (name: StoreState['openSheet']) => void;
+  activeSheet: UISheet;
+  openSheet: (s: Exclude<UISheet, null>) => void;
+  closeSheet: () => void;
   updateDefaults: (partial: Partial<Defaults>) => void;
   updateSlide: (id: SlideId, partial: Partial<Slide> | { overrides: Partial<Slide['overrides']> }) => void;
   reorderSlides: (fromIndex: number, toIndex: number) => void;
@@ -58,8 +60,9 @@ export const useStore = create<StoreState>((set) => ({
   },
   mode: 'story',
   frame: FRAME_SPECS.story,
-  openSheet: null,
-  sheetOpen: false,
+  activeSheet: null,
+  openSheet: (s) => set({ activeSheet: s }),
+  closeSheet: () => set({ activeSheet: null }),
   updateDefaults: (partial) => set((state) => ({ defaults: { ...state.defaults, ...partial } })),
   updateSlide: (id, partial) => set((state) => ({
     slides: state.slides.map((s) => {
@@ -77,16 +80,6 @@ export const useStore = create<StoreState>((set) => ({
     return { slides };
   }),
   setMode: (mode) => set(() => ({ mode, frame: FRAME_SPECS[mode] })),
-  setOpenSheet: (name) => {
-    set({ openSheet: null, sheetOpen: false });
-    document.body.classList.remove('body--sheet-open');
-    if (name) {
-      setTimeout(() => {
-        set({ openSheet: name, sheetOpen: true });
-        document.body.classList.add('body--sheet-open');
-      }, 0);
-    }
-  },
 }));
 
 export const getState = () => useStore.getState();

--- a/apps/webapp/src/styles/bottom-bar.css
+++ b/apps/webapp/src/styles/bottom-bar.css
@@ -1,0 +1,17 @@
+:root {
+  --toolbar-h: calc(64px + env(safe-area-inset-bottom));
+}
+.toolbar{
+  position: fixed; left: 0; right: 0; bottom: 0;
+  height: var(--toolbar-h);
+  padding: 8px 10px env(safe-area-inset-bottom);
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 4px;
+  background: rgba(22,22,24,.72);
+  backdrop-filter: blur(20px);
+  z-index: 900;
+}
+.toolbar__btn{ display:flex; flex-direction:column; align-items:center; gap:4px; }
+.toolbar__icon{ line-height:0; }
+.toolbar__label{ font-size:12px; opacity:.9; }

--- a/apps/webapp/src/styles/bottom-sheet.css
+++ b/apps/webapp/src/styles/bottom-sheet.css
@@ -1,0 +1,19 @@
+:root {
+  --toolbar-h: calc(64px + env(safe-area-inset-bottom));
+}
+.sheet__overlay{
+  position: fixed; inset: 0;
+  z-index: 1000;
+  background: rgba(0,0,0,.0);
+}
+.sheet{
+  position: absolute; left: 0; right: 0;
+  bottom: 0;
+  max-height: min(70vh, 560px);
+  padding-bottom: max(12px, env(safe-area-inset-bottom));
+  border-radius: 16px 16px 0 0;
+  background: #1c1c1e;
+  overflow: auto;
+}
+.sheet__title{ font-weight:600; padding:16px 20px 8px; }
+.sheet__content{ padding: 0 16px 16px; }

--- a/apps/webapp/src/styles/builder-preview.css
+++ b/apps/webapp/src/styles/builder-preview.css
@@ -1,91 +1,10 @@
-/* Bottom bar */
-:root{
-  --toolbar-h: 88px;
-}
-
-body{
-  padding-bottom: calc(var(--toolbar-h, 88px) + env(safe-area-inset-bottom, 0));
-}
-
-.toolbar{
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 40;
-  display: flex;
-  gap: 12px;
-  padding: 6px 16px calc(6px + env(safe-area-inset-bottom, 0));
-  background: rgba(20,20,20,.9);
-  -webkit-backdrop-filter: blur(12px);
-  backdrop-filter: blur(12px);
-  border-top: 1px solid rgba(255,255,255,.08);
-}
-
-.toolbar__btn{
-  display: grid;
-  grid-template-rows: auto auto;
-  justify-items: center;
-  align-items: center;
-  gap: 4px;
-  padding: 8px 10px;
-  border-radius: 12px;
-}
-
-.toolbar__icon{
-  width: 24px;
-  height: 24px;
-}
-
-.toolbar__label{
-  font-size: 12px;
-  line-height: 16px;
-  font-weight: 500;
-  opacity: .95;
-}
-
-/* Bottom sheet */
-.sheet{
-  position: fixed;
-  inset: 0;
-  z-index: 49;
-  background: rgba(0,0,0,.4);
-}
-
-.sheet__panel{
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: calc(var(--toolbar-h, 88px) + env(safe-area-inset-bottom,0));
-  z-index: 50;
-  border-top-left-radius: 22px;
-  border-top-right-radius: 22px;
-  background: #151515;
-  padding: 16px 16px calc(16px + env(safe-area-inset-bottom,0));
-  max-height: min(70vh, 600px);
-  overflow: auto;
-  overscroll-behavior: contain;
-  -webkit-overflow-scrolling: touch;
-  display: flex;
-  flex-direction: column;
-}
-
-.sheet__content{
-  padding-bottom: env(safe-area-inset-bottom,0);
-}
-
-.sheet__title{
-  font-weight: 600;
-  margin-bottom: 12px;
-}
-
 /* Misc styles retained from original file */
 .builder-preview {
-  padding: 0 12px calc(var(--toolbar-h, 88px) + env(safe-area-inset-bottom, 0));
+  padding: 0 12px calc(var(--toolbar-h) + env(safe-area-inset-bottom, 0));
 }
 
 .carousel-page{
-  padding-bottom: calc(var(--toolbar-h, 88px) + env(safe-area-inset-bottom, 0));
+  padding-bottom: calc(var(--toolbar-h) + env(safe-area-inset-bottom, 0));
 }
 
 .segmented {

--- a/apps/webapp/src/styles/preview-list.css
+++ b/apps/webapp/src/styles/preview-list.css
@@ -1,7 +1,7 @@
 .preview-list {
   display: grid;
   gap: 16px;
-  padding-bottom: calc(120px + env(safe-area-inset-bottom, 0));
+  padding-bottom: calc(var(--toolbar-h) + 12px);
   overscroll-behavior: contain;
   /* если у тебя горизонтальная лента – сделай flex + overflow-x */
   /* overflow-y: auto;  // для вертикального скролла */


### PR DESCRIPTION
## Summary
- add global `sheets-root` portal and render BottomSheet through it
- restore fixed bottom toolbar and show photos in a sheet above it
- manage active sheet with Zustand and include new CSS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c476e37dbc832898782583f833603d