### PR TITLE
feat: add share button for slide export

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,9 +1,14 @@
+import React, { useState } from 'react';
 import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons';
+import ShareIcon from '../icons/ShareIcon';
 import { useStore } from '../state/store';
+import { shareSlides } from '../features/carousel/utils/exportSlides';
 import '../styles/bottom-bar.css';
 
 export default function BottomBar() {
   const openSheet = useStore(s => s.openSheet);
+  const slides = useStore(s => s.slides);
+  const [isSharing, setIsSharing] = useState(false);
 
   const actions = [
     { key: 'template', label: 'Template', icon: <IconTemplate /> },
@@ -13,6 +18,19 @@ export default function BottomBar() {
     { key: 'info',     label: 'Info',     icon: <IconInfo /> },
   ];
 
+  const onShare = async () => {
+    if (isSharing) return;
+    try {
+      setIsSharing(true);
+      await shareSlides({ slides });
+    } catch (e) {
+      console.error(e);
+      alert('Не удалось открыть системное меню "Поделиться". Попробуйте ещё раз.');
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
   return (
     <nav className="toolbar" role="toolbar">
       {actions.map(a => (
@@ -21,7 +39,17 @@ export default function BottomBar() {
           <span className="toolbar__label">{a.label}</span>
         </button>
       ))}
+      <button
+        className="toolbar__btn"
+        onClick={onShare}
+        aria-label="Share"
+        disabled={isSharing}
+      >
+        <span className="toolbar__icon">
+          <ShareIcon />
+        </span>
+        <span className="toolbar__label">Share</span>
+      </button>
     </nav>
   );
 }
-

--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,0 +1,82 @@
+import { renderSlideToCanvas, Slide } from '../lib/canvasRender';
+
+export type Story = {
+  slides: Slide[];
+};
+
+export type ExportOpts = {
+  width?: number;
+  height?: number;
+};
+
+export async function exportSlidesAsFiles(
+  story: Story,
+  opts: ExportOpts = {}
+): Promise<File[]> {
+  const files: File[] = [];
+  const width = opts.width ?? 1080;
+  const height = opts.height ?? 1080;
+
+  for (let i = 0; i < story.slides.length; i++) {
+    const slide = story.slides[i];
+    const canvas = await renderSlideToCanvas({ ...slide, index: i }, {
+      w: width,
+      h: height,
+      overlay: { enabled: false, heightPct: 0, intensity: 0 },
+      text: {
+        font: 'sans-serif',
+        size: 32,
+        lineHeight: 1.2,
+        align: 'center',
+        color: '#fff',
+        titleColor: '#fff',
+        titleEnabled: false,
+        content: '',
+      },
+      username: '',
+      total: story.slides.length,
+    });
+
+    const blob: Blob = await new Promise((resolve) =>
+      canvas.toBlob((b) => resolve(b as Blob), 'image/png', 0.92)
+    );
+
+    const file = new File(
+      [blob],
+      `slide-${String(i + 1).padStart(2, '0')}.png`,
+      { type: 'image/png' }
+    );
+    files.push(file);
+  }
+
+  return files;
+}
+
+export async function shareSlides(
+  story: Story,
+  opts: ExportOpts = {}
+): Promise<void> {
+  const files = (await exportSlidesAsFiles(story, opts)).slice(0, 10);
+
+  const nav: any = navigator;
+
+  if (nav?.canShare?.({ files })) {
+    await nav.share({
+      files,
+      title: 'Carousel',
+    });
+    return;
+  }
+
+  for (const f of files) {
+    const url = URL.createObjectURL(f);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = f.name;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+}
+

--- a/apps/webapp/src/icons/ShareIcon.tsx
+++ b/apps/webapp/src/icons/ShareIcon.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+export default function ShareIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" width="24" height="24" fill="none" {...props}>
+      <path d="M12 3v10" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+      <path d="M8 7l4-4 4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+      <path d="M5 13v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- add utilities to render and share slides as PNG files via Web Share API with fallback download
- extend bottom toolbar with Share button and icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c480b7ef288328958161970c209428