### PR TITLE
Fix share functionality and toolbar layout

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons';
 import ShareIcon from '../icons/ShareIcon';
-import { useStore } from '../state/store';
-import { shareSlides } from '../features/carousel/utils/exportSlides';
+import { useCarouselStore } from '@/state/store';
+import { shareSlides } from '@/features/carousel/utils/exportSlides';
 import '../styles/bottom-bar.css';
 
 export default function BottomBar() {
-  const openSheet = useStore(s => s.openSheet);
-  const slides = useStore(s => s.slides);
+  const openSheet = useCarouselStore((s) => s.openSheet);
+  const story = useCarouselStore((s) => s.story);
   const [isSharing, setIsSharing] = useState(false);
 
   const actions = [
@@ -22,10 +22,10 @@ export default function BottomBar() {
     if (isSharing) return;
     try {
       setIsSharing(true);
-      await shareSlides({ slides });
+      await shareSlides(story);
     } catch (e) {
       console.error(e);
-      alert('Не удалось открыть системное меню "Поделиться". Попробуйте ещё раз.');
+      alert('Не удалось поделиться. Попробуйте ещё раз.');
     } finally {
       setIsSharing(false);
     }

--- a/apps/webapp/src/core/story.ts
+++ b/apps/webapp/src/core/story.ts
@@ -1,3 +1,6 @@
+import type { Slide } from '@/types';
+
+export type Story = { slides: Slide[] };
 export type SlideSpec = { title?: string; subtitle?: string; body?: string[] }
 
 export function makeStory(raw: string, n: number): SlideSpec[] {

--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,70 +1,28 @@
-import { renderSlideToCanvas, Slide } from '../lib/canvasRender';
+import { renderSlideToCanvas } from '@/features/carousel/lib/canvasRender';
+import type { Story } from '@/core/story';
 
-export type Story = {
-  slides: Slide[];
-};
-
-export type ExportOpts = {
-  width?: number;
-  height?: number;
-};
-
-export async function exportSlidesAsFiles(
-  story: Story,
-  opts: ExportOpts = {}
-): Promise<File[]> {
+export async function exportSlidesAsFiles(story: Story): Promise<File[]> {
   const files: File[] = [];
-  const width = opts.width ?? 1080;
-  const height = opts.height ?? 1080;
-
   for (let i = 0; i < story.slides.length; i++) {
-    const slide = story.slides[i];
-    const canvas = await renderSlideToCanvas({ ...slide, index: i }, {
-      w: width,
-      h: height,
-      overlay: { enabled: false, heightPct: 0, intensity: 0 },
-      text: {
-        font: 'sans-serif',
-        size: 32,
-        lineHeight: 1.2,
-        align: 'center',
-        color: '#fff',
-        titleColor: '#fff',
-        titleEnabled: false,
-        content: '',
-      },
-      username: '',
-      total: story.slides.length,
-    });
-
+    const canvas = await renderSlideToCanvas(story, i);
     const blob: Blob = await new Promise((resolve) =>
       canvas.toBlob((b) => resolve(b as Blob), 'image/png', 0.92)
     );
-
-    const file = new File(
-      [blob],
-      `slide-${String(i + 1).padStart(2, '0')}.png`,
-      { type: 'image/png' }
+    files.push(
+      new File([blob], `slide-${String(i + 1).padStart(2, '0')}.png`, {
+        type: 'image/png',
+      })
     );
-    files.push(file);
   }
-
   return files;
 }
 
-export async function shareSlides(
-  story: Story,
-  opts: ExportOpts = {}
-): Promise<void> {
-  const files = (await exportSlidesAsFiles(story, opts)).slice(0, 10);
-
+export async function shareSlides(story: Story): Promise<void> {
+  const files = (await exportSlidesAsFiles(story)).slice(0, 10);
   const nav: any = navigator;
 
-  if (nav?.canShare?.({ files })) {
-    await nav.share({
-      files,
-      title: 'Carousel',
-    });
+  if (files.length && nav?.canShare?.({ files }) && nav?.share) {
+    await nav.share({ files, title: 'Carousel' });
     return;
   }
 
@@ -79,4 +37,3 @@ export async function shareSlides(
     URL.revokeObjectURL(url);
   }
 }
-

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import type { Slide, Defaults, SlideId } from '../types';
+import type { Story } from '@/core/story';
 
 export type FrameSpec = {
   width: number;
@@ -83,3 +84,10 @@ export const useStore = create<StoreState>((set) => ({
 }));
 
 export const getState = () => useStore.getState();
+
+export const useCarouselStore = <T>(
+  selector: (s: StoreState & { story: Story }) => T,
+): T =>
+  useStore((state) =>
+    selector({ ...(state as StoreState), story: { slides: state.slides } })
+  );

--- a/apps/webapp/src/styles/bottom-bar.css
+++ b/apps/webapp/src/styles/bottom-bar.css
@@ -1,17 +1,41 @@
 :root {
   --toolbar-h: calc(64px + env(safe-area-inset-bottom));
 }
-.toolbar{
-  position: fixed; left: 0; right: 0; bottom: 0;
+.toolbar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
   height: var(--toolbar-h);
-  padding: 8px 10px env(safe-area-inset-bottom);
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 4px;
+  grid-template-columns: repeat(6, 1fr);
+  align-items: center;
+  gap: 0;
+  padding: 8px calc(env(safe-area-inset-left) + 8px)
+           max(8px, env(safe-area-inset-bottom))
+           calc(env(safe-area-inset-right) + 8px);
   background: rgba(22,22,24,.72);
   backdrop-filter: blur(20px);
   z-index: 900;
+  -webkit-user-select: none;
 }
-.toolbar__btn{ display:flex; flex-direction:column; align-items:center; gap:4px; }
-.toolbar__icon{ line-height:0; }
-.toolbar__label{ font-size:12px; opacity:.9; }
+
+.toolbar__btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 0;
+  padding: 6px 4px;
+}
+
+.toolbar__icon {
+  display: block;
+  line-height: 1;
+}
+
+.toolbar__label {
+  display: block;
+  font-size: 12px;
+  margin-top: 4px;
+  opacity: .9;
+}

--- a/apps/webapp/tsconfig.json
+++ b/apps/webapp/tsconfig.json
@@ -10,7 +10,9 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
-    "paths": {}
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/apps/webapp/vite.config.ts
+++ b/apps/webapp/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'path';
 
 export default defineConfig({
   base: '/btc-game-mvp/',
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- ensure bottom toolbar fits six buttons in a single row
- add slide export and share helper with Web Share fallback
- wire up share button with loading state

## Testing
- `npm --prefix apps/webapp run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4927bdba48328b894564c9f1c50a3