### PR TITLE
feat: add haptic feedback to menu buttons

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -5,6 +5,42 @@ import { useCarouselStore } from '@/state/store';
 import { shareSlides } from '@/features/carousel/utils/exportSlides';
 import '../styles/bottom-bar.css';
 
+// Хаптик: Telegram WebApp (iOS/Android) → fallback на Vibration API (Android)
+const haptic = {
+  impact(style: 'light'|'medium'|'heavy'|'rigid'|'soft' = 'light') {
+    try {
+      const tg = (window as any).Telegram?.WebApp;
+      if (tg?.HapticFeedback?.impactOccurred) {
+        tg.HapticFeedback.impactOccurred(style);
+        return true;
+      }
+    } catch {}
+    if ('vibrate' in navigator) {
+      // короткий «тик», чтобы не раздражал
+      (navigator as any).vibrate?.(20);
+      return true;
+    }
+    return false;
+  },
+  selection() {
+    try {
+      const tg = (window as any).Telegram?.WebApp;
+      if (tg?.HapticFeedback?.selectionChanged) {
+        tg.HapticFeedback.selectionChanged();
+        return true;
+      }
+    } catch {}
+    return false;
+  },
+};
+
+function withHaptic<T extends any[]>(fn: (...args: T) => void, style: Parameters<typeof haptic.impact>[0] = 'light') {
+  return (...args: T) => {
+    haptic.impact(style);
+    fn(...args);
+  };
+}
+
 export default function BottomBar() {
   const openSheet = useCarouselStore((s) => s.openSheet);
   const story = useCarouselStore((s) => s.story);
@@ -28,14 +64,18 @@ export default function BottomBar() {
   return (
     <nav className="toolbar" role="toolbar">
       {actions.map(a => (
-        <button key={a.key} className="toolbar__btn" onClick={() => openSheet(a.key as any)}>
+        <button
+          key={a.key}
+          className="toolbar__btn"
+          onClick={withHaptic(() => openSheet(a.key as any), 'light')}
+        >
           <span className="toolbar__icon">{a.icon}</span>
           <span className="toolbar__label">{a.label}</span>
         </button>
       ))}
       <button
         className="toolbar__btn"
-        onClick={onShare}
+        onClick={withHaptic(onShare, 'medium')}
         aria-label="Share"
       >
         <span className="toolbar__icon">


### PR DESCRIPTION
## Summary
- add cross-platform haptic helper and wrapper
- trigger light haptic for sheet open buttons
- trigger medium haptic for share action

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68c4afc5b7ec832895abe22c979d993f