### PR TITLE
Fix slide sharing with safe image loading and fallbacks

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons';
 import ShareIcon from '../icons/ShareIcon';
 import { useCarouselStore } from '@/state/store';
@@ -44,6 +44,7 @@ function withHaptic<T extends any[]>(fn: (...args: T) => void, style: Parameters
 export default function BottomBar() {
   const openSheet = useCarouselStore((s) => s.openSheet);
   const story = useCarouselStore((s) => s.story);
+  const [busy, setBusy] = useState(false);
 
   const actions = [
     { key: 'template', label: 'Template', icon: <IconTemplate /> },
@@ -54,10 +55,15 @@ export default function BottomBar() {
   ];
 
   const onShare = async () => {
+    if (busy) return;
+    setBusy(true);
     try {
       await shareSlides(story);
     } catch (e) {
-      console.error('[share] handler failed:', e);
+      console.error('[share] failed', e);
+      alert('Не удалось поделиться. Попробуйте ещё раз.');
+    } finally {
+      setBusy(false);
     }
   };
 

--- a/apps/webapp/src/features/carousel/lib/canvasRender.ts
+++ b/apps/webapp/src/features/carousel/lib/canvasRender.ts
@@ -16,13 +16,14 @@ export async function loadImageSafe(src: string): Promise<HTMLImageElement> {
   img.decoding = 'async';
   img.loading = 'eager';
   img.src = src;
-  await img.decode().catch(
-    () =>
-      new Promise((res, rej) => {
-        img.onload = () => res(null as any);
-        img.onerror = rej;
-      }),
-  );
+  try {
+    await img.decode();
+  } catch {
+    await new Promise<void>((res, rej) => {
+      img.onload = () => res();
+      img.onerror = () => rej(new Error('image load failed'));
+    });
+  }
   return img;
 }
 

--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,18 +1,15 @@
 import { renderSlideToCanvas } from '@/features/carousel/lib/canvasRender';
 import type { Story } from '@/core/story';
 
-// unified logger
-function log(...args: any[]) {
-  console.info('[share]', ...args);
-}
+function log(...args: any[]) { console.info('[share]', ...args); }
 
 async function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
-  const blob = await new Promise<Blob | null>(res =>
+  const blob = await new Promise<Blob|null>(res =>
     canvas.toBlob(b => res(b), 'image/png', 0.92)
   );
   if (blob) return blob;
 
-  // диагностический фолбэк — полезно при tainted canvas/шрифтах
+  // iOS иногда даёт null → безопасный фолбэк
   log('toBlob(null) → fallback toDataURL');
   const dataUrl = canvas.toDataURL('image/png');
   const bin = atob(dataUrl.split(',')[1]);
@@ -21,46 +18,40 @@ async function canvasToPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
   return new Blob([bytes], { type: 'image/png' });
 }
 
-/** Рендерим (макс. 10) слайдов в файловый массив PNG */
 export async function exportSlidesAsFiles(story: Story): Promise<File[]> {
   const files: File[] = [];
-  const limit = Math.min(10, story.slides.length); // iOS не любит много файлов
-
+  const limit = Math.min(10, story.slides.length); // лимит для Instagram/iOS
   for (let i = 0; i < limit; i++) {
     const canvas = await renderSlideToCanvas(story, i);
     const blob = await canvasToPngBlob(canvas);
-    if (!blob || blob.size === 0) log(`slide #${i + 1}: empty blob`, blob);
-    files.push(
-      new File([blob], `slide-${String(i + 1).padStart(2, '0')}.png`, {
-        type: 'image/png',
-      })
-    );
+    if (!blob || blob.size === 0) log(`slide #${i+1}: empty blob`);
+    files.push(new File([blob], `slide-${String(i+1).padStart(2,'0')}.png`, { type:'image/png' }));
+    // даём браузеру «вздохнуть», чтобы не потерять user-gesture
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(r => setTimeout(r, 0));
   }
   return files;
 }
 
-/** Пытаемся открыть системный share-sheet; иначе — скачиваем PNG по одному */
 export async function shareSlides(story: Story): Promise<void> {
   const files = await exportSlidesAsFiles(story);
   const nav: any = navigator;
 
-  // Диагностика перед вызовом
-  log('candidates:', files.map((f, i) => ({ i, name: f.name, type: f.type, size: f.size })));
-  log('support:', { hasShare: !!nav?.share, hasCanShare: !!nav?.canShare, filesCount: files.length });
+  log('candidates:', files.map((f,i)=>({i,name:f.name,type:f.type,size:f.size})));
+  const can = !!nav?.canShare?.({ files });
+  log('support:', { hasShare: !!nav?.share, hasCanShare: !!nav?.canShare, canShareFiles: can });
 
-  let can = false;
-  if (nav?.canShare) {
-    try {
-      can = nav.canShare({ files });
-    } catch (e) {
-      log('canShare threw:', e);
-    }
+  const isTelegram = /Telegram/i.test(navigator.userAgent);
+  const isIOS = /iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+  if (!nav?.share && isTelegram && isIOS) {
+    alert('Встроенный браузер Telegram блокирует сохранение. Нажмите ••• и выберите "Open in Safari", затем снова Share.');
   }
-  log('canShare({files}) =', can);
 
+  // В Safari стабильнее передавать ТОЛЬКО files (+title)
   if (files.length && nav?.share && can) {
     try {
-      await nav.share({ files, title: 'Carousel' }); // без text/url — так стабильнее в Safari
+      await nav.share({ files, title: 'Carousel' });
       log('share(): OK');
       return;
     } catch (e) {
@@ -68,8 +59,8 @@ export async function shareSlides(story: Story): Promise<void> {
     }
   }
 
-  // Фолбэк — скачивание по одному (без ZIP)
-  log('fallback: download one-by-one');
+  // Фолбэк: последовательное скачивание PNG (если WebView блокирует — см. пункт 4)
+  log('fallback: download');
   for (const f of files) {
     const url = URL.createObjectURL(f);
     const a = document.createElement('a');
@@ -79,6 +70,9 @@ export async function shareSlides(story: Story): Promise<void> {
     a.click();
     a.remove();
     URL.revokeObjectURL(url);
+    // маленькая пауза между файлами
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise(r => setTimeout(r, 120));
   }
 }
 


### PR DESCRIPTION
## Summary
- load carousel images with anonymous cross-origin to avoid canvas tainting
- export slides to PNG with 10 slide limit, dataURL fallback, and Telegram iOS alert
- ensure share handler preserves user gesture

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4b3f8b22c8328a2cc3d3c13a4570b