### PR TITLE
Fix share flow to export slides as files

### DIFF
--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -10,18 +10,13 @@ export async function exportSlides(story: Story, opts: ExportOpts = {}): Promise
   const slideIndexes = indices ?? story.slides.map((_, i) => i); // no filtering by content
 
   for (const i of slideIndexes) {
-    const canvas = await renderSlideToCanvas(story, i, {
-      width: opts.width,
-      height: opts.height,
-    });
-
+    const canvas = await renderSlideToCanvas(story, i, opts);
     const blob: Blob = await new Promise<Blob>((resolve, reject) => {
       canvas.toBlob((b) => {
         if (!b) return reject(new Error('canvas.toBlob returned null'));
         resolve(b);
       }, 'image/png', 0.92);
     });
-
     blobs.push(blob);
   }
 


### PR DESCRIPTION
## Summary
- Use carousel store state directly and export slides to share files with native sharing
- Ensure slide export returns blobs with correct index handling

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c36cda848328b9f06347f2e9a0a9