### PR TITLE
fix share export and Web Share API support

### DIFF
--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -1,24 +1,20 @@
 import { renderSlideToCanvas } from '@/features/carousel/lib/canvasRender';
 import type { Story } from '@/core/story';
 
-type ExportOpts = { width?: number; height?: number; indices?: number[] };
+type ExportOpts = { width?: number; height?: number };
 
 export async function exportSlides(story: Story, opts: ExportOpts = {}): Promise<Blob[]> {
-  const { indices } = opts;
   const blobs: Blob[] = [];
-
-  const slideIndexes = indices ?? story.slides.map((_, i) => i); // no filtering by content
-
-  for (const i of slideIndexes) {
+  for (let i = 0; i < story.slides.length; i++) {
     const canvas = await renderSlideToCanvas(story, i, opts);
-    const blob: Blob = await new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob((b) => {
-        if (!b) return reject(new Error('canvas.toBlob returned null'));
-        resolve(b);
-      }, 'image/png', 0.92);
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (b) => (b ? resolve(b) : reject(new Error('toBlob returned null'))),
+        'image/png',
+        0.95,
+      );
     });
     blobs.push(blob);
   }
-
   return blobs;
 }

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -37,6 +37,7 @@ export type UISheet = null | 'template' | 'layout' | 'fonts' | 'photos' | 'info'
 
 export type StoreState = {
   slides: Slide[];
+  story: Story;
   defaults: Defaults;
   mode: 'story' | 'carousel';
   frame: FrameSpec;
@@ -44,13 +45,17 @@ export type StoreState = {
   openSheet: (s: Exclude<UISheet, null>) => void;
   closeSheet: () => void;
   updateDefaults: (partial: Partial<Defaults>) => void;
-  updateSlide: (id: SlideId, partial: Partial<Slide> | { overrides: Partial<Slide['overrides']> }) => void;
+  updateSlide: (
+    id: SlideId,
+    partial: Partial<Slide> | { overrides: Partial<Slide['overrides']> }
+  ) => void;
   reorderSlides: (fromIndex: number, toIndex: number) => void;
   setMode: (mode: 'story' | 'carousel') => void;
 };
 
-export const useStore = create<StoreState>((set) => ({
+export const useCarouselStore = create<StoreState>((set) => ({
   slides: [],
+  story: { slides: [] },
   defaults: {
     fontSize: 44,
     lineHeight: 1.28,
@@ -64,30 +69,29 @@ export const useStore = create<StoreState>((set) => ({
   activeSheet: null,
   openSheet: (s) => set({ activeSheet: s }),
   closeSheet: () => set({ activeSheet: null }),
-  updateDefaults: (partial) => set((state) => ({ defaults: { ...state.defaults, ...partial } })),
-  updateSlide: (id, partial) => set((state) => ({
-    slides: state.slides.map((s) => {
-      if (s.id !== id) return s;
-      if ('overrides' in partial) {
-        return { ...s, overrides: { ...s.overrides, ...(partial as any).overrides } };
-      }
-      return { ...s, ...partial };
+  updateDefaults: (partial) =>
+    set((state) => ({ defaults: { ...state.defaults, ...partial } })),
+  updateSlide: (id, partial) =>
+    set((state) => {
+      const slides = state.slides.map((s) => {
+        if (s.id !== id) return s;
+        if ('overrides' in partial) {
+          return { ...s, overrides: { ...s.overrides, ...(partial as any).overrides } };
+        }
+        return { ...s, ...partial };
+      });
+      return { slides, story: { slides } };
     }),
-  })),
-  reorderSlides: (fromIndex, toIndex) => set((state) => {
-    const slides = [...state.slides];
-    const [moved] = slides.splice(fromIndex, 1);
-    slides.splice(toIndex, 0, moved);
-    return { slides };
-  }),
+  reorderSlides: (fromIndex, toIndex) =>
+    set((state) => {
+      const slides = [...state.slides];
+      const [moved] = slides.splice(fromIndex, 1);
+      slides.splice(toIndex, 0, moved);
+      return { slides, story: { slides } };
+    }),
   setMode: (mode) => set(() => ({ mode, frame: FRAME_SPECS[mode] })),
 }));
 
-export const getState = () => useStore.getState();
+export const useStore = useCarouselStore;
 
-export const useCarouselStore = <T>(
-  selector: (s: StoreState & { story: Story }) => T,
-): T =>
-  useStore((state) =>
-    selector({ ...(state as StoreState), story: { slides: state.slides } })
-  );
+export const getStory = () => useCarouselStore.getState().story;


### PR DESCRIPTION
## Summary
- expose `useCarouselStore` and `getStory` helper for safe Zustand state access
- render all slides to PNG and share via Web Share API with download fallback
- export each slide by index to ensure full story is captured

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c5a4116c8328a832c9ab86f19f5b