### PR TITLE
fix: stable share with singleton store

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -9,7 +9,7 @@ import "./styles/tailwind.css";
 import "./styles/builder-preview.css";
 import "./styles/preview-list.css";
 import { getWelcomeText, SEED_KEY } from "./core/seed";
-import { useStore } from "./state/store";
+import { useStore } from "@/state/store";
 import type { Slide, CanvasMode, PhotoMeta } from "./types";
 
 type SlideCount = "auto" | 1|2|3|4|5|6|7|8|9|10;

--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IconTemplate, IconLayout, IconFonts, IconPhotos, IconInfo } from '../ui/icons';
 import ShareIcon from '../icons/ShareIcon';
-import { useCarouselStore, getStory } from '@/state/store';
+import { useCarouselStore, getStory, getSlidesCount } from '@/state/store';
 import { exportSlides } from '@/features/carousel/utils/exportSlides';
 import '../styles/bottom-bar.css';
 
@@ -31,20 +31,17 @@ async function handleShare() {
   const tg = (window as any).Telegram?.WebApp;
 
   try {
-    // 1) Берём актуальный story из стора (не из UI)
-    const story = getStory(); // ВАЖНО: см. правку в store.ts ниже
-    const slidesCount = story?.slides?.length ?? 0;
+    const story = getStory();
+    const count = getSlidesCount();
 
-    console.info('[share] slides in story =', slidesCount);
+    console.info('[share] slides in story =', count);
 
-    if (slidesCount === 0) {
-      // Никаких showPopup — его нет в v6.0
+    if (!count) {
       tg?.showAlert?.('Добавьте текст или фотографию.');
       return;
     }
 
-    // 2) Рендерим PNG для всех текущих слайдов
-    const blobs = await exportSlides(story);
+    const blobs = await exportSlides(story, { count });
     console.info('[share] blobs:', blobs.length);
 
     if (!blobs.length) {

--- a/apps/webapp/src/components/SlideEditor.tsx
+++ b/apps/webapp/src/components/SlideEditor.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import BottomSheet from './BottomSheet';
-import { useStore } from '../state/store';
+import { useStore } from '@/state/store';
 import type { SlideId } from '../types';
 
 export default function SlideEditor({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {

--- a/apps/webapp/src/components/sheets/ColorSheet.tsx
+++ b/apps/webapp/src/components/sheets/ColorSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import BottomSheet from '../BottomSheet';
-import { useStore } from '../../state/store';
+import { useStore } from '@/state/store';
 import type { SlideId } from '../../types';
 
 export default function ColorSheet({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {

--- a/apps/webapp/src/components/sheets/LayoutSheet.tsx
+++ b/apps/webapp/src/components/sheets/LayoutSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import BottomSheet from '../BottomSheet';
-import { useStore } from '../../state/store';
+import { useStore } from '@/state/store';
 import type { SlideId } from '../../types';
 
 export default function LayoutSheet({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {

--- a/apps/webapp/src/core/render.ts
+++ b/apps/webapp/src/core/render.ts
@@ -1,5 +1,5 @@
 import type { Slide, Defaults, Theme } from '../types';
-import type { FrameSpec } from '../state/store';
+import type { FrameSpec } from '@/state/store';
 
 const BASE_FAMILY = '"SF Pro Display","Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial';
 

--- a/apps/webapp/src/core/textLayout.ts
+++ b/apps/webapp/src/core/textLayout.ts
@@ -1,5 +1,5 @@
 export type LayoutInput = {
-  frame: import('../state/store').FrameSpec;
+  frame: import('@/state/store').FrameSpec;
   fontFamily: string;
   fontSize: number;
   lineHeight: number;

--- a/apps/webapp/src/features/editor/PreviewCarousel.tsx
+++ b/apps/webapp/src/features/editor/PreviewCarousel.tsx
@@ -4,7 +4,7 @@ import BottomBar from '../../components/BottomBar';
 import LayoutSheet from '../../components/sheets/LayoutSheet';
 import BottomSheet from '../../components/BottomSheet';
 import PhotosSheet from '../../components/PhotosSheet';
-import { useStore } from '../../state/store';
+import { useStore } from '@/state/store';
 
 export default function PreviewCarousel() {
     const [slides, setSlides] = useState<Slide[]>([]);

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -71,7 +71,7 @@ export type StoreState = {
   setMode: (mode: 'story' | 'carousel') => void;
 };
 
-export const useCarouselStore = create<StoreState>((set) => ({
+const createStore = () => create<StoreState>((set) => ({
   slides: [],
   story: { slides: [] }, // не используется для экспорта; поддерживается для совместимости
   defaults: {
@@ -129,23 +129,10 @@ export const useCarouselStore = create<StoreState>((set) => ({
     })),
 }));
 
-/** Сокращение на случай, если где-то импортируется useStore */
+export const useCarouselStore = (window as any).__CAROUSEL_STORE__ ?? ((window as any).__CAROUSEL_STORE__ = createStore());
+
 export const useStore = useCarouselStore;
 
-/**
- * ЕДИНЫЙ способ получить Story для рендера/экспорта/шеринга.
- * Собирает объект на лету из текущего состояния стора — без риска взять «устаревший» story.
- */
-export const getStory = (): Story => {
-  const s = useCarouselStore.getState();
+export const getStory = () => useCarouselStore.getState().story;
+export const getSlidesCount = () => useCarouselStore.getState().slides.length;
 
-  // Если тип Story в вашем проекте ожидает больше полей — добавьте их здесь.
-  // Минимально известно, что там точно есть slides.
-  return {
-    slides: s.slides,
-    // Пример, если Story ожидает ещё настройки:
-    // defaults: s.defaults,
-    // mode: s.mode,
-    // frame: s.frame,
-  } as Story;
-};


### PR DESCRIPTION
## Summary
- make carousel store a window singleton and expose getStory/getSlidesCount helpers
- share handler exports slides and uses Web Share when available, falling back to download
- unify store imports to avoid duplicate Zustand instances

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c54b8e1c448328acbbaa06aa75298a