### PR TITLE
Use safe Telegram wrappers and fix sharing

### DIFF
--- a/apps/webapp/src/lib/tg.ts
+++ b/apps/webapp/src/lib/tg.ts
@@ -1,0 +1,56 @@
+export function getTg() {
+  return (window as any)?.Telegram?.WebApp;
+}
+
+function cmpVersion(a = '0.0', b = '0.0') {
+  const pa = a.split('.').map(Number), pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const da = pa[i] ?? 0, db = pb[i] ?? 0;
+    if (da !== db) return da > db ? 1 : -1;
+  }
+  return 0;
+}
+
+export const tgSupport = {
+  hasShowAlert(): boolean {
+    const tg = getTg();
+    return !!(tg && typeof tg.showAlert === 'function' && cmpVersion(tg.version, '6.2') >= 0);
+  },
+  hasHaptics(): boolean {
+    const tg = getTg();
+    return !!(tg && tg.HapticFeedback && typeof tg.HapticFeedback.impactOccurred === 'function');
+  },
+};
+
+export function showAlertSafe(message: string) {
+  try {
+    if (tgSupport.hasShowAlert()) {
+      getTg().showAlert(message);
+      return;
+    }
+  } catch {}
+  // максимально безопасный fallback
+  try { window.alert(message); } catch {}
+}
+
+export const haptic = {
+  impact(style: 'light'|'medium'|'heavy'|'rigid'|'soft' = 'light') {
+    try {
+      if (tgSupport.hasHaptics()) {
+        getTg().HapticFeedback.impactOccurred(style);
+        return true;
+      }
+    } catch {}
+    if ('vibrate' in navigator) { try { (navigator as any).vibrate?.(20); } catch {} }
+    return false;
+  },
+  selection() {
+    try {
+      if (tgSupport.hasHaptics()) {
+        getTg().HapticFeedback.selectionChanged();
+        return true;
+      }
+    } catch {}
+    return false;
+  },
+};

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -139,8 +139,14 @@ export const useCarouselStore = (window as any).__CAROUSEL_STORE__ ?? ((window a
 
 export const useStore = useCarouselStore;
 export const getState = () => useCarouselStore.getState();
-
-export const getSlidesCount = () => getState().slides.length;
-export const getSlides = () => getState().slides;
 export const getStory = () => getState().story;
+
+export const getSlides = () => useCarouselStore.getState().slides;
+export const getSlidesCount = () => (useCarouselStore.getState().slides?.length ?? 0);
+
+// Для экспорта всегда строим "актуальную story" из текущих slides
+export const buildCurrentStory = (): Story => {
+  const slides = getSlides();
+  return { slides: Array.isArray(slides) ? slides : [] } as Story;
+};
 


### PR DESCRIPTION
## Summary
- add Telegram WebApp utility with version checks, safe alerts and haptic fallbacks
- expose slide getters and builder in store to always use live slides
- rework bottom toolbar Share to use new utilities and download/share PNGs without Telegram popups

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c574f5dd548328b02aff5f0af7739d