### PR TITLE
Implement safe Telegram wrappers and slide export polyfill

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -25,7 +25,6 @@ async function handleShare() {
       return;
     }
 
-    // Пакуем в File[] (без деструктуризации)
     const files: File[] = [];
     for (let i = 0; i < blobs.length; i++) {
       const b = blobs[i];
@@ -37,7 +36,7 @@ async function handleShare() {
       return;
     }
 
-    // Web Share Level 2 (если доступно)
+    // Web Share Level 2
     try {
       const canShareFiles =
         typeof (navigator as any).canShare === 'function' && (navigator as any).canShare({ files });
@@ -49,7 +48,7 @@ async function handleShare() {
       console.warn('[share] native share failed, fallback to download', e);
     }
 
-    // Фолбэк: скачивание (по одному файлу, чтобы Safari не ругался)
+    // Фолбэк: последовательное скачивание
     for (let i = 0; i < files.length; i++) {
       const f = files[i];
       const url = URL.createObjectURL(f);
@@ -60,7 +59,7 @@ async function handleShare() {
       a.click();
       a.remove();
       URL.revokeObjectURL(url);
-      // маленькая пауза между скачиваниями — помогает мобильным браузерам
+      // маленькая пауза помогает iOS
       // eslint-disable-next-line no-await-in-loop
       await new Promise((r) => setTimeout(r, 120));
     }

--- a/apps/webapp/src/features/carousel/utils/exportSlides.ts
+++ b/apps/webapp/src/features/carousel/utils/exportSlides.ts
@@ -4,26 +4,53 @@ import type { Story } from '@/core/story';
 type ExportOpts = {
   width?: number;
   height?: number;
-  /** Явное количество слайдов на экспорт (перекрывает story.slides.length). */
-  count?: number;
+  count?: number; // сколько экспортировать — не полагаться на story.slides
 };
 
+// Полифилл для Safari (когда canvas.toBlob недоступен или возвращает null)
+async function canvasToBlobSafe(canvas: HTMLCanvasElement, type = 'image/png', quality?: number): Promise<Blob> {
+  const blob = await new Promise<Blob | null>((resolve) => {
+    try {
+      canvas.toBlob((b) => resolve(b), type, quality);
+    } catch {
+      resolve(null);
+    }
+  });
+  if (blob) return blob;
+
+  // fallback через dataURL
+  const dataURL = canvas.toDataURL(type, quality);
+  const base64 = dataURL.split(',')[1];
+  const bin = atob(base64);
+  const arr = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) arr[i] = bin.charCodeAt(i);
+  return new Blob([arr], { type });
+}
+
 export async function exportSlides(story: Story, opts: ExportOpts = {}): Promise<Blob[]> {
-  const requested =
-    typeof opts.count === 'number' ? opts.count : story.slides.length;
-  const count = Math.min(Math.max(requested, 0), story.slides.length);
-  if (count === 0) return [];
+  const count = typeof opts.count === 'number' ? opts.count : Array.isArray((story as any)?.slides) ? (story as any).slides.length : 0;
+  if (!count || count <= 0) return [];
 
   const blobs: Blob[] = [];
+
   for (let i = 0; i < count; i++) {
-    const canvas = await renderSlideToCanvas(story, i, {
-      width: opts.width,
-      height: opts.height,
-    });
-    const blob = await new Promise<Blob>((resolve, reject) => {
-      canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('toBlob: empty'))), 'image/png');
-    });
+    // адаптер под разные формы ответа renderSlideToCanvas
+    const maybe = await renderSlideToCanvas(story, i, { width: opts.width, height: opts.height });
+    const canvas: HTMLCanvasElement | null =
+      (maybe && typeof (maybe as any).toDataURL === 'function')
+        ? (maybe as HTMLCanvasElement)
+        : (maybe && (maybe as any).canvas && typeof (maybe as any).canvas.toDataURL === 'function')
+          ? ((maybe as any).canvas as HTMLCanvasElement)
+          : null;
+
+    if (!canvas) {
+      throw new Error('renderSlideToCanvas() did not return a canvas');
+    }
+
+    const blob = await canvasToBlobSafe(canvas, 'image/png');
     blobs.push(blob);
   }
+
   return blobs;
 }
+

--- a/apps/webapp/src/lib/tg.ts
+++ b/apps/webapp/src/lib/tg.ts
@@ -6,8 +6,7 @@ function cmpVersion(a = '0.0', b = '0.0') {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const da = pa[i] ?? 0;
-    const db = pb[i] ?? 0;
+    const da = pa[i] ?? 0, db = pb[i] ?? 0;
     if (da !== db) return da > db ? 1 : -1;
   }
   return 0;
@@ -16,40 +15,44 @@ function cmpVersion(a = '0.0', b = '0.0') {
 export const tgSupport = {
   hasShowAlert(): boolean {
     const tg = getTg();
-    return !!(tg && typeof tg.showAlert === 'function' && cmpVersion(tg.version, '6.2') >= 0);
+    return !!(tg && typeof tg.showAlert === 'function');
   },
   hasHaptics(): boolean {
     const tg = getTg();
     return !!(tg && tg.HapticFeedback && typeof tg.HapticFeedback.impactOccurred === 'function');
   },
+  webAppVersionAtLeast(v: string): boolean {
+    const tg = getTg();
+    return !!(tg && cmpVersion(tg.version, v) >= 0);
+  },
 };
 
-export function showAlertSafe(msg: string) {
-  try {
-    const tg = getTg();
-    if (tgSupport.hasShowAlert()) {
-      tg.showAlert(msg);
-      return;
-    }
-  } catch (_) {}
-  // фолбэк: обычный alert
-  try { window.alert(msg); } catch (_) {}
-}
-
 export const haptic = {
-  impact(style: 'light' | 'medium' | 'heavy' | 'rigid' | 'soft' = 'light') {
+  impact(style: 'light'|'medium'|'heavy'|'rigid'|'soft' = 'light') {
     try {
       const tg = getTg();
       if (tgSupport.hasHaptics()) {
         tg.HapticFeedback.impactOccurred(style);
         return true;
       }
-    } catch (_) {}
+    } catch {}
     if ('vibrate' in navigator) {
       (navigator as any).vibrate?.(20);
       return true;
     }
     return false;
-  },
+  }
 };
+
+export function showAlertSafe(message: string) {
+  try {
+    const tg = getTg();
+    if (tgSupport.hasShowAlert()) {
+      tg.showAlert(message);
+      return;
+    }
+  } catch {}
+  // Фолбэк браузера
+  alert(message);
+}
 

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -3,35 +3,33 @@ import type { Slide, Defaults, SlideId } from '../types';
 import type { Story } from '@/core/story';
 
 export type FrameSpec = {
-  width: number;
-  height: number;
-  paddingX: number;
-  paddingTop: number;
-  paddingBottom: number;
-  safeNickname: number;
-  safePagination: number;
+  width: number; height: number;
+  paddingX: number; paddingTop: number; paddingBottom: number;
+  safeNickname: number; safePagination: number;
 };
 
-const FRAME_SPECS: Record<'story' | 'carousel', FrameSpec> = {
-  story: { width: 1080, height: 1920, paddingX: 72, paddingTop: 72, paddingBottom: 72, safeNickname: 120, safePagination: 120 },
-  carousel: { width: 1080, height: 1350, paddingX: 72, paddingTop: 72, paddingBottom: 72, safeNickname: 120, safePagination: 120 },
+const FRAME_SPECS: Record<'story'|'carousel', FrameSpec> = {
+  story:   { width:1080, height:1920, paddingX:72, paddingTop:72, paddingBottom:72, safeNickname:120, safePagination:120 },
+  carousel:{ width:1080, height:1350, paddingX:72, paddingTop:72, paddingBottom:72, safeNickname:120, safePagination:120 },
 };
 
 export type UISheet = null | 'template' | 'layout' | 'fonts' | 'photos' | 'info';
 
-type StoreState = {
+export type StoreState = {
   slides: Slide[];
   story: Story;
   defaults: Defaults;
-  mode: 'story' | 'carousel';
+  mode: 'story'|'carousel';
   frame: FrameSpec;
   activeSheet: UISheet;
-  openSheet: (s: Exclude<UISheet, null>) => void;
+
+  openSheet: (s: Exclude<UISheet,null>) => void;
   closeSheet: () => void;
+
   updateDefaults: (partial: Partial<Defaults>) => void;
   updateSlide: (id: SlideId, partial: Partial<Slide> | { overrides: Partial<Slide['overrides']> }) => void;
   reorderSlides: (fromIndex: number, toIndex: number) => void;
-  setMode: (mode: 'story' | 'carousel') => void;
+  setMode: (mode: 'story'|'carousel') => void;
 };
 
 function createStore() {
@@ -49,9 +47,13 @@ function createStore() {
     mode: 'story',
     frame: FRAME_SPECS.story,
     activeSheet: null,
+
     openSheet: (s) => set({ activeSheet: s }),
     closeSheet: () => set({ activeSheet: null }),
-    updateDefaults: (partial) => set((state) => ({ defaults: { ...state.defaults, ...partial } })),
+
+    updateDefaults: (partial) =>
+      set((state) => ({ defaults: { ...state.defaults, ...partial } })),
+
     updateSlide: (id, partial) =>
       set((state) => {
         const slides = state.slides.map((s) => {
@@ -63,6 +65,7 @@ function createStore() {
         });
         return { slides, story: { slides } };
       }),
+
     reorderSlides: (fromIndex, toIndex) =>
       set((state) => {
         const slides = [...state.slides];
@@ -70,21 +73,22 @@ function createStore() {
         slides.splice(toIndex, 0, moved);
         return { slides, story: { slides } };
       }),
+
     setMode: (mode) => set(() => ({ mode, frame: FRAME_SPECS[mode] })),
   }));
 }
 
-// один инстанс стора (чтобы CodeSandbox/GH Pages кэш не создавал копии)
+// единый экземпляр стора
 export const useCarouselStore =
   (window as any).__CAROUSEL_STORE__ ?? ((window as any).__CAROUSEL_STORE__ = createStore());
 
-export const useStore = useCarouselStore;
+export const useStore  = useCarouselStore;
+export const getState = () => useCarouselStore.getState();
 
-// безопасные геттеры (без деструктуризации)
-export const getSlides = () => useCarouselStore.getState().slides;
-export const getSlidesCount = () => (useCarouselStore.getState().slides?.length ?? 0);
+export const getSlides = () => getState().slides;
+export const getSlidesCount = () => getState().slides?.length ?? 0;
 
-// для экспорта всегда собираем стори из ТЕКУЩИХ slides
+// Для экспорта всегда собираем story из актуальных slides
 export const buildCurrentStory = (): Story => {
   const slides = getSlides();
   return { slides: Array.isArray(slides) ? slides : [] } as Story;


### PR DESCRIPTION
## Summary
- add Telegram WebApp helpers with haptic fallback and safe alert
- expose stable Zustand store getters for current slides and story
- export slides with Safari canvas polyfill and sequential share fallback

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c60108b66c8328a92bdb826ee0bfae