### PR TITLE
Refactor editor to floating carousel with slide sheets

### DIFF
--- a/apps/webapp/src/components/BottomBar.tsx
+++ b/apps/webapp/src/components/BottomBar.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import { IconTemplate, IconLayout, IconPhotos, IconText } from '../ui/icons';
+import { IconTemplate, IconPhotos } from '../ui/icons';
 import ShareIcon from '../icons/ShareIcon';
-import { useCarouselStore } from '@/state/store';
-import { buildCurrentStory, getSlidesCount } from '@/state/store';
+import { useCarouselStore, buildCurrentStory, getSlidesCount } from '@/state/store';
 import { exportSlides } from '@/features/carousel/utils/exportSlides';
 import { haptic, showAlertSafe } from '@/lib/tg';
 import '../styles/bottom-bar.css';
@@ -90,24 +89,24 @@ async function handleShare() {
 export default function BottomBar() {
   const openSheet = useCarouselStore((s) => s.openSheet);
 
-  const actions = [
-    { key: 'share',    label: 'Export',  icon: <ShareIcon />, onClick: handleShare },
-    { key: 'text',     label: 'Text',    icon: <IconText />,  onClick: () => openSheet('text') },
-    { key: 'template', label: 'Template',icon: <IconTemplate />, onClick: () => openSheet('template') },
-    { key: 'photos',   label: 'Photos',  icon: <IconPhotos />, onClick: () => openSheet('photos') },
-    { key: 'layout',   label: 'Layout',  icon: <IconLayout />, onClick: () => openSheet('layout') },
+  const items = [
+    { key: 'export',   label: 'Export',   icon: <ShareIcon />,                  onClick: handleShare },
+    { key: 'text',     label: 'Text',     icon: <span className="icon-aa">Aa</span>, onClick: () => openSheet('text') },
+    { key: 'template', label: 'Template', icon: <IconTemplate />,               onClick: () => openSheet('template') },
+    { key: 'photos',   label: 'Photos',   icon: <IconPhotos />,                 onClick: () => openSheet('photos') },
+    { key: 'layout',   label: 'Layout',   icon: <span className="icon-layout"/>, onClick: () => openSheet('layout') },
   ] as const;
 
   return (
     <nav className="toolbar" role="toolbar">
-      {actions.map(a => (
+      {items.map((i) => (
         <button
-          key={a.key}
+          key={i.key}
           className="toolbar__btn"
-          onClick={withHaptic(a.onClick, a.key === 'share' ? 'medium' : 'light')}
+          onClick={withHaptic(i.onClick, i.key === 'export' ? 'medium' : 'light')}
         >
-          <span className="toolbar__icon">{a.icon}</span>
-          <span className="toolbar__label">{a.label}</span>
+          <span className="toolbar__icon">{i.icon}</span>
+          <span className="toolbar__label">{i.label}</span>
         </button>
       ))}
     </nav>

--- a/apps/webapp/src/components/sheets/SlideActionsSheet.tsx
+++ b/apps/webapp/src/components/sheets/SlideActionsSheet.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useCarouselStore } from '@/state/store';
+import '../../styles/bottom-sheet.css';
+
+export default function SlideActionsSheet() {
+  const {
+    activeIndex,
+    slides,
+    reorderSlides,
+    closeSheet,
+    setSlides,
+    setActiveIndex,
+  } = useCarouselStore();
+
+  const onDelete = () => {
+    const arr = slides.filter((_, i) => i !== activeIndex);
+    setSlides(arr);
+    setActiveIndex(Math.max(0, activeIndex - 1));
+    closeSheet();
+  };
+
+  const move = (dir: -1 | 1) => {
+    const from = activeIndex;
+    const to = Math.min(slides.length - 1, Math.max(0, from + dir));
+    if (to !== from) reorderSlides(from, to);
+    closeSheet();
+  };
+
+  return (
+    <div className="sheet">
+      <div className="sheet__title">Slide actions</div>
+      <div className="sheet__group">
+        <button className="btn btn--danger" onClick={onDelete}>Delete slide</button>
+        <button className="btn" onClick={() => move(-1)}>Move left</button>
+        <button className="btn" onClick={() => move(1)}>Move right</button>
+      </div>
+    </div>
+  );
+}
+

--- a/apps/webapp/src/components/sheets/TextSheet.tsx
+++ b/apps/webapp/src/components/sheets/TextSheet.tsx
@@ -1,39 +1,32 @@
-import React, { useState, useEffect } from 'react';
-import BottomSheet from '../BottomSheet';
-import { useStore } from '@/state/store';
-import type { SlideId } from '../../types';
+import React from 'react';
+import { useCarouselStore } from '@/state/store';
+import '../../styles/bottom-sheet.css';
 
-export default function TextSheet({ open, onClose, currentSlideId }: { open: boolean; onClose: () => void; currentSlideId?: SlideId }) {
-  const slide = useStore(s => s.slides.find(x => x.id === currentSlideId));
-  const updateSlide = useStore(s => s.updateSlide);
-  const [value, setValue] = useState('');
+export default function TextSheet() {
+  const slides = useCarouselStore((s) => s.slides);
+  const active = useCarouselStore((s) => s.activeIndex);
+  const update = useCarouselStore((s) => s.updateSlide);
 
-  useEffect(() => {
-    if (open) setValue(slide?.body ?? '');
-  }, [open, slide?.id]);
+  const slide = slides[active];
 
   return (
-    <BottomSheet open={open} onClose={onClose} title="Text">
+    <div className="sheet">
+      <div className="sheet__title">Text</div>
       <textarea
-        className="w-full h-48 p-3 rounded-lg bg-neutral-900 border border-neutral-800 resize-none"
-        placeholder="Вставьте или напишите текст…"
-        value={value}
-        onChange={(e) => {
-          setValue(e.target.value);
-          slide && updateSlide(slide.id, { body: e.target.value });
-        }}
+        className="sheet__textarea"
+        value={slide?.body ?? ''}
+        placeholder="Вставь текст сюда…"
+        onChange={(e) => slide && update(slide.id, { body: e.target.value })}
+        rows={8}
       />
-      <div className="mt-3 flex justify-end">
-        <button
-          className="px-4 py-2 rounded-lg bg-neutral-800"
-          onClick={() => {
-            setValue('');
-            slide && updateSlide(slide.id, { body: '' });
-          }}
-        >
-          Очистить
-        </button>
-      </div>
-    </BottomSheet>
+      <label className="sheet__field">
+        <span>@username</span>
+        <input
+          value={slide?.nickname ?? ''}
+          onChange={(e) => slide && update(slide.id, { nickname: e.target.value })}
+        />
+      </label>
+    </div>
   );
 }
+

--- a/apps/webapp/src/features/editor/PreviewCarousel.tsx
+++ b/apps/webapp/src/features/editor/PreviewCarousel.tsx
@@ -1,108 +1,106 @@
-import React, { useState, useRef } from 'react';
-import { useStore, useCarouselStore } from '@/state/store';
-import BottomBar from '../../components/BottomBar';
-import LayoutSheet from '../../components/sheets/LayoutSheet';
-import PhotosSheet from '../../components/PhotosSheet';
-import TextSheet from '../../components/sheets/TextSheet';
-import SlideQuickActions from '../../components/SlideQuickActions';
-import BottomSheet from '../../components/BottomSheet';
-import '../../styles/preview-carousel.css';
+import React, { useEffect, useRef, useState } from 'react';
+import { useCarouselStore } from '@/state/store';
+import BottomBar from '@/components/BottomBar';
+import LayoutSheet from '@/components/sheets/LayoutSheet';
+import PhotosSheet from '@/components/PhotosSheet';
+import TextSheet from '@/components/sheets/TextSheet';
+import SlideActionsSheet from '@/components/sheets/SlideActionsSheet';
+import BottomSheet from '@/components/BottomSheet';
+import '@/styles/carousel.css';
 
 export default function PreviewCarousel() {
-  const slides = useCarouselStore(s => s.slides);
-  const activeSheet = useStore(s => s.activeSheet);
-  const closeSheet = useStore(s => s.closeSheet);
-  const reorderSlides = useStore(s => s.reorderSlides);
-  const setSlides = useStore(s => s.setSlides);
+  const slides = useCarouselStore((s) => s.slides);
+  const activeIndex = useCarouselStore((s) => s.activeIndex);
+  const setActiveIndex = useCarouselStore((s) => s.setActiveIndex);
+  const activeSheet = useCarouselStore((s) => s.activeSheet);
+  const closeSheet = useCarouselStore((s) => s.closeSheet);
+  const reorderSlides = useCarouselStore((s) => s.reorderSlides);
+  const setSlides = useCarouselStore((s) => s.setSlides);
 
-  const [index, setIndex] = useState(0);
-  const [qaOpen, setQaOpen] = useState(false);
-  const startX = useRef<number | null>(null);
-  const startY = useRef<number | null>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [dragStart, setDragStart] = useState<{ x: number; y: number } | null>(null);
+
+  useEffect(() => {
+    const root = trackRef.current;
+    if (!root) return;
+    const cards = Array.from(root.children) as HTMLElement[];
+    const io = new IntersectionObserver(
+      (entries) => {
+        let bestIdx = activeIndex;
+        let bestRatio = 0;
+        entries.forEach((e) => {
+          const idx = cards.indexOf(e.target as HTMLElement);
+          if (e.intersectionRatio > bestRatio) {
+            bestIdx = idx;
+            bestRatio = e.intersectionRatio;
+          }
+        });
+        if (bestRatio > 0.6) setActiveIndex(bestIdx);
+      },
+      { root, threshold: [0.1, 0.3, 0.6, 0.9] }
+    );
+    cards.forEach((c) => io.observe(c));
+    return () => io.disconnect();
+  }, [trackRef.current, slides.length]);
 
   const onPointerDown = (e: React.PointerEvent) => {
-    startX.current = e.clientX;
-    startY.current = e.clientY;
-  };
-  const onPointerMove = (e: React.PointerEvent) => {
-    if (startX.current == null || startY.current == null) return;
-    const dx = e.clientX - startX.current;
-    const dy = e.clientY - startY.current;
-    if (!qaOpen && dy > 22 && Math.abs(dx) < 18) {
-      setQaOpen(true);
-    }
+    setDragStart({ x: e.clientX, y: e.clientY });
   };
   const onPointerUp = (e: React.PointerEvent) => {
-    if (startX.current == null) return;
-    const dx = e.clientX - startX.current;
-    if (Math.abs(dx) > 40) {
-      setIndex(i => Math.min(slides.length - 1, Math.max(0, i + (dx < 0 ? 1 : -1))));
+    if (!dragStart) return;
+    const dx = e.clientX - dragStart.x;
+    const dy = e.clientY - dragStart.y;
+    setDragStart(null);
+    if (Math.abs(dx) < 28 && dy > 56) {
+      useCarouselStore.getState().openSheet('slideActions');
     }
-    startX.current = startY.current = null;
-  };
-
-  const onMoveLeft = () => {
-    reorderSlides(index, index - 1);
-    setIndex(i => Math.max(0, i - 1));
-    setQaOpen(false);
-  };
-  const onMoveRight = () => {
-    reorderSlides(index, index + 1);
-    setIndex(i => Math.min(slides.length - 1, i + 1));
-    setQaOpen(false);
-  };
-  const onDelete = () => {
-    const arr = slides.filter((_, i) => i !== index);
-    setSlides(arr);
-    setIndex(i => Math.max(0, Math.min(i, arr.length - 1)));
-    setQaOpen(false);
   };
 
   return (
     <div>
-      <div className="carousel" onPointerDown={onPointerDown} onPointerMove={onPointerMove} onPointerUp={onPointerUp}>
-        {slides.map((s, i) => {
-          const d = i - index;
-          return (
-            <div key={s.id} className="carousel__card" style={{ '--shift': d } as React.CSSProperties}>
-              <div className="carousel__content">
-                {s.image ? (
-                  <img src={s.image} className="w-full h-full object-cover" />
-                ) : (
-                  <div className="p-4 text-white text-center">{s.body}</div>
-                )}
-              </div>
+      <div className="carousel">
+        <div className="carousel__track" ref={trackRef}>
+          {slides.map((s, i) => (
+            <div
+              key={s.id}
+              className={`carousel__item ${i === activeIndex ? 'is-active' : 'is-side'}`}
+              onPointerDown={onPointerDown}
+              onPointerUp={onPointerUp}
+            >
+              {s.image ? (
+                <img src={s.image} className="w-full h-full object-cover" />
+              ) : (
+                <div className="p-4 text-white text-center">{s.body}</div>
+              )}
             </div>
-          );
-        })}
-        {qaOpen && (
-          <SlideQuickActions
-            onMoveLeft={onMoveLeft}
-            onDelete={onDelete}
-            onMoveRight={onMoveRight}
-            onClose={() => setQaOpen(false)}
-          />
-        )}
+          ))}
+        </div>
       </div>
       <BottomBar />
-      <TemplateSheet open={activeSheet === 'template'} onClose={closeSheet} />
-      <LayoutSheet open={activeSheet === 'layout'} onClose={closeSheet} currentSlideId={slides[index]?.id} />
-      <PhotosSheet
-        open={activeSheet === 'photos'}
-        onClose={closeSheet}
-        onDone={closeSheet}
-        photos={slides.filter(s => s.image).map(s => ({ id: s.id, url: s.image! }))}
-        onAdd={(urls) => {
-          const next = urls.map(url => ({ id: Math.random().toString(36).slice(2), body: '', image: url }));
-          setSlides([...slides, ...next]);
-        }}
-        onDelete={(id) => setSlides(slides.filter(s => s.id !== id))}
-        onMove={(id, dir) => {
-          const idx = slides.findIndex(s => s.id === id);
-          if (idx !== -1) reorderSlides(idx, idx + dir);
-        }}
-      />
-      <TextSheet open={activeSheet === 'text'} onClose={closeSheet} currentSlideId={slides[index]?.id} />
+
+      {activeSheet === 'template' && <TemplateSheet open={true} onClose={closeSheet} />}
+      {activeSheet === 'layout' && (
+        <LayoutSheet open={true} onClose={closeSheet} currentSlideId={slides[activeIndex]?.id} />
+      )}
+      {activeSheet === 'photos' && (
+        <PhotosSheet
+          open={true}
+          onClose={closeSheet}
+          onDone={closeSheet}
+          photos={slides.filter((s) => s.image).map((s) => ({ id: s.id, url: s.image! }))}
+          onAdd={(urls) => {
+            const next = urls.map((url) => ({ id: Math.random().toString(36).slice(2), body: '', image: url, nickname: '' }));
+            setSlides([...slides, ...next]);
+          }}
+          onDelete={(id) => setSlides(slides.filter((s) => s.id !== id))}
+          onMove={(id, dir) => {
+            const idx = slides.findIndex((s) => s.id === id);
+            if (idx !== -1) reorderSlides(idx, idx + dir);
+          }}
+        />
+      )}
+      {activeSheet === 'text' && <TextSheet />}
+      {activeSheet === 'slideActions' && <SlideActionsSheet />}
     </div>
   );
 }
@@ -110,3 +108,4 @@ export default function PreviewCarousel() {
 function TemplateSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
   return <BottomSheet open={open} onClose={onClose} title="Template" />;
 }
+

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -38,7 +38,14 @@ const FRAME_SPECS: Record<'story' | 'carousel', FrameSpec> = {
   },
 };
 
-export type UISheet = null | 'text' | 'template' | 'layout' | 'photos';
+export type UISheet =
+  | null
+  | 'export'
+  | 'text'
+  | 'template'
+  | 'layout'
+  | 'photos'
+  | 'slideActions';
 
 export type StoreState = {
   /** Сырые слайды — ИСТИНА для UI и экспорта */
@@ -56,8 +63,10 @@ export type StoreState = {
   frame: FrameSpec;
 
   activeSheet: UISheet;
+  activeIndex: number;
   openSheet: (s: Exclude<UISheet, null>) => void;
   closeSheet: () => void;
+  setActiveIndex: (i: number) => void;
 
   updateDefaults: (partial: Partial<Defaults>) => void;
 
@@ -83,7 +92,7 @@ const DEFAULT_TEXTS = [
 ];
 
 function makeDefaultSlides(): Slide[] {
-  return DEFAULT_TEXTS.map((t, i) => ({ id: `def-${i + 1}`, body: t }));
+  return DEFAULT_TEXTS.map((t, i) => ({ id: `def-${i + 1}`, body: t, nickname: '' }));
 }
 
 const initialSlides: Slide[] = makeDefaultSlides();
@@ -108,8 +117,10 @@ const createStore = () => create<StoreState>((set) => ({
   frame: FRAME_SPECS.story,
 
   activeSheet: null,
+  activeIndex: 0,
   openSheet: (s) => set({ activeSheet: s }),
   closeSheet: () => set({ activeSheet: null }),
+  setActiveIndex: (i) => set({ activeIndex: i }),
 
   updateDefaults: (partial) =>
     set((state) => ({

--- a/apps/webapp/src/styles/carousel.css
+++ b/apps/webapp/src/styles/carousel.css
@@ -1,0 +1,38 @@
+.carousel {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 160px);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+}
+.carousel__track {
+  display: flex;
+  gap: 18px;
+  overflow-x: auto;
+  padding: 0 24px;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+}
+.carousel__item {
+  position: relative;
+  width: min(86vw, 360px);
+  height: min(86vh, 580px);
+  border-radius: 26px;
+  overflow: hidden;
+  box-shadow: 0 24px 64px rgba(0,0,0,.35);
+  background: #111;
+  scroll-snap-align: center;
+  transition: transform .24s ease, opacity .24s ease, filter .24s ease;
+}
+.carousel__item.is-side {
+  transform: scale(.94);
+  opacity: .65;
+  filter: saturate(.9) brightness(.9);
+}
+.carousel__item.is-active {
+  transform: scale(1);
+  opacity: 1;
+  filter: none;
+}
+

--- a/apps/webapp/src/types.ts
+++ b/apps/webapp/src/types.ts
@@ -6,6 +6,7 @@ export type Slide = {
   title?: string;               // заголовок (опционально)
   image?: string;               // dataURL/URL выбранной фотки
   imageId?: string | null;
+  nickname?: string;
 
   // визуальные пер-слайд настройки (если не задано — берём из defaults)
   overrides?: {


### PR DESCRIPTION
## Summary
- Replace editor carousel with scroll-snap based version and slide action sheet
- Add text sheet with @username field and store active slide index
- Update bottom bar and default slides for new workflow

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c60f13ac8083289d25f120ffae5608