### PR TITLE
feat: add photo management sheet

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -22,6 +24,8 @@
     "postcss": "^8.4.0",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^1.2.0",
+    "@playwright/test": "^1.41.1"
   }
 }

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});
+

--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -1,33 +1,79 @@
-import { useRef, useState } from 'react';
-import { useCarouselStore } from '@/state/store';
+import { photosActions, usePhotos } from '../../state/store';
+import { ArrowLeftIcon, ArrowRightIcon, TrashIcon, PlusIcon } from '../../ui/icons';
 import Sheet from '../Sheet/Sheet';
+import '../../styles/photos-sheet.css';
 
-export default function PhotosSheet(){
-  const fileInput = useRef<HTMLInputElement|null>(null);
-  const { slides, activeIndex, updateSlide, closeSheet } = useCarouselStore();
-  const active = slides[activeIndex];
-  const [preview, setPreview] = useState<string|null>(active?.image ?? null);
+export default function PhotosSheet() {
+  const { items, selectedId } = usePhotos();
 
-  const onPick = (e: React.ChangeEvent<HTMLInputElement>)=>{
-    const f = e.target.files?.[0];
-    if (!f) return;
-    const url = URL.createObjectURL(f);
-    setPreview(url);
+  const onAdd = (files: FileList | null) => {
+    if (!files) return;
+    photosActions.addFiles(Array.from(files));
   };
 
-  const apply = ()=>{
-    if (active && preview) updateSlide(active.id, { image: preview });
-    closeSheet();
+  const onKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!selectedId) return;
+    if (e.key === 'ArrowLeft') photosActions.move(selectedId, 'left');
+    else if (e.key === 'ArrowRight') photosActions.move(selectedId, 'right');
+    else if (e.key === 'Delete' || e.key === 'Backspace') photosActions.remove(selectedId);
   };
 
   return (
     <Sheet title="Photos">
-      <input ref={fileInput} type="file" accept="image/*" style={{display:'none'}} onChange={onPick}/>
-      <div style={{display:'flex', gap:8, marginBottom:12}}>
-        <button className="btn" onClick={()=>fileInput.current?.click()}>Add photo</button>
-        <button className="btn" onClick={apply}>Done</button>
+      <div className="photos-sheet" tabIndex={0} onKeyDown={onKey}>
+        <label className="add-btn">
+          <PlusIcon /> Добавить фото
+          <input type="file" accept="image/*" multiple onChange={(e) => onAdd(e.target.files)} hidden />
+        </label>
+
+        {items.length === 0 ? (
+          <div className="empty">Добавьте фото, чтобы собрать карусель</div>
+        ) : (
+          <div className="thumb-grid">
+            {items.map((p, idx) => (
+              <div
+                key={p.id}
+                className={'thumb ' + (p.id === selectedId ? 'selected' : '')}
+                onClick={() => photosActions.setSelected(p.id)}
+              >
+                <img src={p.src} alt={p.fileName ?? 'photo'} loading="lazy" />
+                <div className="controls">
+                  <button
+                    aria-label="Переместить влево"
+                    disabled={idx === 0}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      photosActions.move(p.id, 'left');
+                    }}
+                  >
+                    <ArrowLeftIcon />
+                  </button>
+                  <button
+                    aria-label="Удалить"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      photosActions.remove(p.id);
+                    }}
+                  >
+                    <TrashIcon />
+                  </button>
+                  <button
+                    aria-label="Переместить вправо"
+                    disabled={idx === items.length - 1}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      photosActions.move(p.id, 'right');
+                    }}
+                  >
+                    <ArrowRightIcon />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-      {preview && <img src={preview} alt="" style={{width:'100%', borderRadius:12}}/>}
     </Sheet>
   );
 }
+

--- a/apps/webapp/src/state/store.test.ts
+++ b/apps/webapp/src/state/store.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { photosActions, usePhotos } from './store';
+
+const png = new File([new Uint8Array([137,80,78,71,1])], 'a.png', { type: 'image/png' });
+
+beforeEach(() => {
+  // reset state
+  photosActions.clear();
+  // mock URL methods
+  (globalThis.URL as any).createObjectURL = vi.fn(() => 'blob:' + Math.random());
+  (globalThis.URL as any).revokeObjectURL = vi.fn();
+});
+
+describe('photosActions', () => {
+  it('addFiles adds photos preserving order', () => {
+    const files = [
+      new File(['1'], '1.png', { type: 'image/png' }),
+      new File(['2'], '2.png', { type: 'image/png' }),
+    ];
+    photosActions.addFiles(files);
+    const { items } = usePhotos.getState();
+    expect(items).toHaveLength(2);
+    expect(items[0].fileName).toBe('1.png');
+    expect(items[1].fileName).toBe('2.png');
+  });
+
+  it('move swaps items correctly and ignores edges', () => {
+    const files = [
+      new File(['1'], '1.png', { type: 'image/png' }),
+      new File(['2'], '2.png', { type: 'image/png' }),
+      new File(['3'], '3.png', { type: 'image/png' }),
+    ];
+    photosActions.addFiles(files);
+    const firstId = usePhotos.getState().items[0].id;
+    photosActions.move(firstId, 'left'); // ignore edge
+    expect(usePhotos.getState().items[0].id).toBe(firstId);
+    photosActions.move(firstId, 'right');
+    expect(usePhotos.getState().items[1].id).toBe(firstId);
+  });
+
+  it('remove deletes photo and revokes url', () => {
+    photosActions.addFiles([png]);
+    const id = usePhotos.getState().items[0].id;
+    photosActions.remove(id);
+    expect(usePhotos.getState().items).toHaveLength(0);
+    expect((URL.revokeObjectURL as any)).toHaveBeenCalled();
+  });
+});
+

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -1,0 +1,37 @@
+.photos-sheet { padding: 12px; }
+.add-btn { display:inline-flex; gap:8px; align-items:center; padding:10px 12px; border:1px dashed var(--border); border-radius:10px; cursor:pointer; }
+.empty { margin:16px 0; color: var(--muted); }
+
+.thumb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.thumb {
+  position: relative;
+  aspect-ratio: 1/1;
+  border-radius: 10px;
+  overflow: hidden;
+  outline: 2px solid transparent;
+}
+
+.thumb.selected { outline-color: var(--primary); }
+
+.thumb img {
+  width: 100%; height: 100%; object-fit: cover; display:block;
+}
+
+.thumb .controls {
+  position: absolute; inset: auto 0 0 0;
+  display: flex; justify-content: space-between; padding: 6px;
+  background: linear-gradient(transparent, rgba(0,0,0,.45));
+}
+
+.thumb .controls button {
+  border: none; border-radius: 8px; padding: 6px;
+  background: rgba(255,255,255,.85);
+}
+.thumb .controls button:disabled { opacity:.4; }
+

--- a/apps/webapp/src/ui/icons.tsx
+++ b/apps/webapp/src/ui/icons.tsx
@@ -41,3 +41,30 @@ export const IconLayout = () => (
     <path d="M12 11v8" stroke="currentColor" strokeWidth="1.6"/>
   </svg>
 );
+
+export const ArrowLeftIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M15 6l-6 6 6 6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+export const ArrowRightIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M9 6l6 6-6 6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+export const TrashIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M4 7h16" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+    <path d="M10 11v6M14 11v6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+    <path d="M6 7l1 13h10l1-13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M9 7V4h6v3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+export const PlusIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);

--- a/apps/webapp/tests/photos-sheet.spec.ts
+++ b/apps/webapp/tests/photos-sheet.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+const png = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Q4n1b8AAAAASUVORK5CYII=',
+  'base64'
+);
+
+test('upload, reorder and remove photos', async ({ page }) => {
+  await page.goto('http://localhost:5173');
+  await page.click('text=Photos');
+
+  await page.setInputFiles('input[type=file]', [
+    { name: '1.png', mimeType: 'image/png', buffer: png },
+    { name: '2.png', mimeType: 'image/png', buffer: png },
+    { name: '3.png', mimeType: 'image/png', buffer: png },
+  ]);
+
+  await expect(page.locator('.thumb')).toHaveCount(3);
+
+  await page.locator('.thumb').nth(2).locator('button[aria-label="Переместить влево"]').click();
+  const alts = await page.locator('.thumb img').allAttribute('alt');
+  expect(alts).toEqual(['1.png', '3.png', '2.png']);
+
+  await page.locator('.thumb').nth(1).locator('button[aria-label="Удалить"]').click();
+  await expect(page.locator('.thumb')).toHaveCount(2);
+
+  await expect(page.locator('.thumb').first().locator('button[aria-label="Переместить влево"]').first()).toBeDisabled();
+  await expect(page.locator('.thumb').last().locator('button[aria-label="Переместить вправо"]').first()).toBeDisabled();
+});
+


### PR DESCRIPTION
## Summary
- add reusable arrow, plus, and trash icons
- implement photos slice with add, move, remove, and selection actions
- build PhotosSheet UI with grid, controls, and keyboard support
- include CSS styling and unit & e2e tests

## Testing
- `npm test` (fails: vitest not found)
- `npm run test:e2e` (fails: playwright not found)


------
https://chatgpt.com/codex/tasks/task_e_68c6accdee9c8328910ebac8c8ca0e1f