### PR TITLE
feat: add photo management sheet

### DIFF
--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -1,33 +1,79 @@
-import { useRef, useState } from 'react';
-import { useCarouselStore } from '@/state/store';
+import { photosActions, usePhotos } from '../../state/store';
+import { ArrowLeftIcon, ArrowRightIcon, TrashIcon, PlusIcon } from '../../ui/icons';
 import Sheet from '../Sheet/Sheet';
+import '../../styles/photos-sheet.css';
 
-export default function PhotosSheet(){
-  const fileInput = useRef<HTMLInputElement|null>(null);
-  const { slides, activeIndex, updateSlide, closeSheet } = useCarouselStore();
-  const active = slides[activeIndex];
-  const [preview, setPreview] = useState<string|null>(active?.image ?? null);
+export default function PhotosSheet() {
+  const { items, selectedId } = usePhotos();
 
-  const onPick = (e: React.ChangeEvent<HTMLInputElement>)=>{
-    const f = e.target.files?.[0];
-    if (!f) return;
-    const url = URL.createObjectURL(f);
-    setPreview(url);
+  const onAdd = (files: FileList | null) => {
+    if (!files) return;
+    photosActions.addFiles(Array.from(files));
   };
 
-  const apply = ()=>{
-    if (active && preview) updateSlide(active.id, { image: preview });
-    closeSheet();
+  const onKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (!selectedId) return;
+    if (e.key === 'ArrowLeft') photosActions.move(selectedId, 'left');
+    else if (e.key === 'ArrowRight') photosActions.move(selectedId, 'right');
+    else if (e.key === 'Delete' || e.key === 'Backspace') photosActions.remove(selectedId);
   };
 
   return (
     <Sheet title="Photos">
-      <input ref={fileInput} type="file" accept="image/*" style={{display:'none'}} onChange={onPick}/>
-      <div style={{display:'flex', gap:8, marginBottom:12}}>
-        <button className="btn" onClick={()=>fileInput.current?.click()}>Add photo</button>
-        <button className="btn" onClick={apply}>Done</button>
+      <div className="photos-sheet" tabIndex={0} onKeyDown={onKey}>
+        <label className="add-btn">
+          <PlusIcon /> Добавить фото
+          <input type="file" accept="image/*" multiple onChange={(e) => onAdd(e.target.files)} hidden />
+        </label>
+
+        {items.length === 0 ? (
+          <div className="empty">Добавьте фото, чтобы собрать карусель</div>
+        ) : (
+          <div className="thumb-grid">
+            {items.map((p, idx) => (
+              <div
+                key={p.id}
+                className={'thumb ' + (p.id === selectedId ? 'selected' : '')}
+                onClick={() => photosActions.setSelected(p.id)}
+              >
+                <img src={p.src} alt={p.fileName ?? 'photo'} loading="lazy" />
+                <div className="controls">
+                  <button
+                    aria-label="Переместить влево"
+                    disabled={idx === 0}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      photosActions.move(p.id, 'left');
+                    }}
+                  >
+                    <ArrowLeftIcon />
+                  </button>
+                  <button
+                    aria-label="Удалить"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      photosActions.remove(p.id);
+                    }}
+                  >
+                    <TrashIcon />
+                  </button>
+                  <button
+                    aria-label="Переместить вправо"
+                    disabled={idx === items.length - 1}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      photosActions.move(p.id, 'right');
+                    }}
+                  >
+                    <ArrowRightIcon />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
-      {preview && <img src={preview} alt="" style={{width:'100%', borderRadius:12}}/>}
     </Sheet>
   );
 }
+

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -1,0 +1,37 @@
+.photos-sheet { padding: 12px; }
+.add-btn { display:inline-flex; gap:8px; align-items:center; padding:10px 12px; border:1px dashed var(--border); border-radius:10px; cursor:pointer; }
+.empty { margin:16px 0; color: var(--muted); }
+
+.thumb-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.thumb {
+  position: relative;
+  aspect-ratio: 1/1;
+  border-radius: 10px;
+  overflow: hidden;
+  outline: 2px solid transparent;
+}
+
+.thumb.selected { outline-color: var(--primary); }
+
+.thumb img {
+  width: 100%; height: 100%; object-fit: cover; display:block;
+}
+
+.thumb .controls {
+  position: absolute; inset: auto 0 0 0;
+  display: flex; justify-content: space-between; padding: 6px;
+  background: linear-gradient(transparent, rgba(0,0,0,.45));
+}
+
+.thumb .controls button {
+  border: none; border-radius: 8px; padding: 6px;
+  background: rgba(255,255,255,.85);
+}
+.thumb .controls button:disabled { opacity:.4; }
+

--- a/apps/webapp/src/ui/icons.tsx
+++ b/apps/webapp/src/ui/icons.tsx
@@ -41,3 +41,30 @@ export const IconLayout = () => (
     <path d="M12 11v8" stroke="currentColor" strokeWidth="1.6"/>
   </svg>
 );
+
+export const ArrowLeftIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M15 6l-6 6 6 6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+export const ArrowRightIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M9 6l6 6-6 6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+export const TrashIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M4 7h16" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+    <path d="M10 11v6M14 11v6" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"/>
+    <path d="M6 7l1 13h10l1-13" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M9 7V4h6v3" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
+export const PlusIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+    <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);


### PR DESCRIPTION
## Summary
- add reusable arrow, plus, and trash icons
- implement photos slice with add, move, remove, and selection actions
- build PhotosSheet UI with grid, controls, and keyboard support
- include CSS styling
- remove test and config files outside of src scope

## Testing
- `npm test` (fails: Missing script "test")
- `npm run test:e2e` (fails: Missing script "test:e2e")

------
https://chatgpt.com/codex/tasks/task_e_68c6accdee9c8328910ebac8c8ca0e1f