### PR TITLE
feat: refine photo sheet with selection and done

### DIFF
--- a/apps/webapp/src/components/Sheet/Sheet.css
+++ b/apps/webapp/src/components/Sheet/Sheet.css
@@ -9,11 +9,13 @@
 }
 @keyframes sheet-in { from{ transform:translateY(12%); opacity:.8 } to{ transform:translateY(0); opacity:1 } }
 .sheet__header{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
-.sheet__header h3{ margin:0; font-size:18px; }
+.sheet__header h3{ margin:0; font-size:18px; flex:1; text-align:center; }
+.sheet__header-left, .sheet__header-right{ display:flex; }
 .sheet__close{ background:none; border:0; color:#fff; font-size:22px; line-height:1; }
 .sheet__content{ margin-top:12px; }
-.sheet__footer{ margin-top:16px; display:flex; justify-content:flex-end; gap:8px; }
+.sheet__footer{ position:sticky; bottom:0; padding:12px 16px calc(8px + env(safe-area-inset-bottom)); background:linear-gradient(180deg, rgba(20,20,24,0) 0%, rgba(20,20,24,.9) 48%, rgba(20,20,24,1) 100%); display:flex; justify-content:flex-end; }
 .btn{ appearance:none; background:#2a2a2f; border:1px solid #3a3a40; border-radius:10px; color:#fff; padding:10px 14px; }
+.btn.primary{ background:#007aff; border-color:#007aff; }
 .field textarea{
   width:100%;
   min-height:180px;

--- a/apps/webapp/src/components/Sheet/Sheet.tsx
+++ b/apps/webapp/src/components/Sheet/Sheet.tsx
@@ -1,8 +1,8 @@
-import { PropsWithChildren, useEffect } from 'react';
+import { PropsWithChildren, ReactNode, useEffect } from 'react';
 import { useCarouselStore } from '@/state/store';
 
-export default function Sheet({ title, children }: PropsWithChildren<{ title: string }>) {
-  const close = useCarouselStore(s=>s.closeSheet);
+export default function Sheet({ title, left, right, children }: PropsWithChildren<{ title: string; left?: ReactNode; right?: ReactNode }>) {
+  const close = useCarouselStore(s => s.closeSheet);
   useEffect(() => {
     const onEsc = (e:KeyboardEvent)=>{ if(e.key==='Escape') close(); };
     window.addEventListener('keydown', onEsc); return ()=>window.removeEventListener('keydown', onEsc);
@@ -13,8 +13,13 @@ export default function Sheet({ title, children }: PropsWithChildren<{ title: st
       <div className="sheet__overlay" />
       <div className="sheet__panel" onClick={e=>e.stopPropagation()}>
         <div className="sheet__header">
+          {left && <div className="sheet__header-left">{left}</div>}
           <h3>{title}</h3>
-          <button className="sheet__close" onClick={close}>×</button>
+          {right ? (
+            <div className="sheet__header-right">{right}</div>
+          ) : (
+            <button className="sheet__close" onClick={close}>×</button>
+          )}
         </div>
         <div className="sheet__content">{children}</div>
       </div>

--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -1,79 +1,151 @@
-import { photosActions, usePhotos } from '../../state/store';
-import { ArrowLeftIcon, ArrowRightIcon, TrashIcon, PlusIcon } from '../../ui/icons';
+import { useState, useRef } from 'react';
+import { photosActions, usePhotos, PhotoId, useCarouselStore } from '@/state/store';
+import { ArrowLeftIcon, ArrowRightIcon, TrashIcon, PlusIcon } from '@/ui/icons';
 import Sheet from '../Sheet/Sheet';
-import '../../styles/photos-sheet.css';
+import '@/styles/photos-sheet.css';
+
+const impact = (style: 'light' | 'medium' = 'light') => {
+  try {
+    (window as any).Telegram?.WebApp?.HapticFeedback?.impactOccurred?.(style);
+  } catch {}
+  try {
+    navigator.vibrate?.(10);
+  } catch {}
+};
 
 export default function PhotosSheet() {
-  const { items, selectedId } = usePhotos();
+  const { items } = usePhotos();
+  const [selected, setSelected] = useState<PhotoId[]>([]);
+  const fileRef = useRef<HTMLInputElement>(null);
 
   const onAdd = (files: FileList | null) => {
     if (!files) return;
     photosActions.addFiles(Array.from(files));
   };
 
-  const onKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (!selectedId) return;
-    if (e.key === 'ArrowLeft') photosActions.move(selectedId, 'left');
-    else if (e.key === 'ArrowRight') photosActions.move(selectedId, 'right');
-    else if (e.key === 'Delete' || e.key === 'Backspace') photosActions.remove(selectedId);
+  const onPick = () => fileRef.current?.click();
+
+  const toggleSelect = (id: PhotoId) => {
+    setSelected((s) =>
+      s.includes(id) ? s.filter((i) => i !== id) : [...s, id]
+    );
+    impact('light');
+  };
+
+  const moveLeft = (id: PhotoId) => photosActions.move(id, 'left');
+  const moveRight = (id: PhotoId) => photosActions.move(id, 'right');
+
+  const removeOne = (id: PhotoId) => photosActions.remove(id);
+
+  const onDone = () => {
+    if (!selected.length) return;
+    impact('medium');
+    const { slides, activeIndex, updateSlide, addSlide, closeSheet } = useCarouselStore.getState();
+    const photos = selected
+      .map((id) => items.find((p) => p.id === id))
+      .filter(Boolean) as typeof items;
+    let idx = activeIndex;
+    for (const p of photos) {
+      if (idx >= slides.length) {
+        addSlide({ image: p.src });
+      } else {
+        updateSlide(slides[idx].id, { image: p.src });
+      }
+      idx++;
+    }
+    setSelected([]);
+    closeSheet();
   };
 
   return (
-    <Sheet title="Photos">
-      <div className="photos-sheet" tabIndex={0} onKeyDown={onKey}>
-        <label className="add-btn">
-          <PlusIcon /> Добавить фото
-          <input type="file" accept="image/*" multiple onChange={(e) => onAdd(e.target.files)} hidden />
-        </label>
-
+    <Sheet
+      title="Photos"
+      left={
+        <button className="btn" onClick={onPick}>
+          <PlusIcon /> Add photo
+        </button>
+      }
+      right={
+        <button className="btn primary" disabled={!selected.length} onClick={onDone}>
+          Done
+        </button>
+      }
+    >
+      <div className="photos-sheet">
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/*"
+          multiple
+          onChange={(e) => onAdd(e.target.files)}
+          hidden
+        />
         {items.length === 0 ? (
           <div className="empty">Добавьте фото, чтобы собрать карусель</div>
         ) : (
-          <div className="thumb-grid">
-            {items.map((p, idx) => (
-              <div
-                key={p.id}
-                className={'thumb ' + (p.id === selectedId ? 'selected' : '')}
-                onClick={() => photosActions.setSelected(p.id)}
-              >
-                <img src={p.src} alt={p.fileName ?? 'photo'} loading="lazy" />
-                <div className="controls">
-                  <button
-                    aria-label="Переместить влево"
-                    disabled={idx === 0}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      photosActions.move(p.id, 'left');
-                    }}
-                  >
-                    <ArrowLeftIcon />
-                  </button>
-                  <button
-                    aria-label="Удалить"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      photosActions.remove(p.id);
-                    }}
-                  >
-                    <TrashIcon />
-                  </button>
-                  <button
-                    aria-label="Переместить вправо"
-                    disabled={idx === items.length - 1}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      photosActions.move(p.id, 'right');
-                    }}
-                  >
-                    <ArrowRightIcon />
-                  </button>
+          <div className="photoGrid">
+            {items.map((p, idx) => {
+              const isActive = selected.includes(p.id);
+              const order = selected.indexOf(p.id);
+              return (
+                <div
+                  key={p.id}
+                  className={'photoCard' + (isActive ? ' is-active' : '')}
+                  onClick={() => toggleSelect(p.id)}
+                >
+                  <img
+                    className="photoCard__img"
+                    src={p.src}
+                    alt={p.fileName ?? 'photo'}
+                    loading="lazy"
+                  />
+                  <div className="photoCard__badge">{order + 1}</div>
+                  <div className="photoCard__actions">
+                    <button
+                      className="photoBtn"
+                      aria-label="Переместить влево"
+                      disabled={!isActive || idx === 0}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        moveLeft(p.id);
+                      }}
+                    >
+                      <ArrowLeftIcon />
+                    </button>
+                    <button
+                      className="photoBtn"
+                      aria-label="Удалить"
+                      disabled={!isActive}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        removeOne(p.id);
+                      }}
+                    >
+                      <TrashIcon />
+                    </button>
+                    <button
+                      className="photoBtn"
+                      aria-label="Переместить вправо"
+                      disabled={!isActive || idx === items.length - 1}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        moveRight(p.id);
+                      }}
+                    >
+                      <ArrowRightIcon />
+                    </button>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
+        <div className="sheet__footer">
+          <button className="btn primary" disabled={!selected.length} onClick={onDone}>
+            Done
+          </button>
+        </div>
       </div>
     </Sheet>
   );
 }
-

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -1,37 +1,73 @@
 .photos-sheet { padding: 12px; }
-.add-btn { display:inline-flex; gap:8px; align-items:center; padding:10px 12px; border:1px dashed var(--border); border-radius:10px; cursor:pointer; }
-.empty { margin:16px 0; color: var(--muted); }
-
-.thumb-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(88px, 1fr));
-  gap: 10px;
-  margin-top: 12px;
+.empty { margin:16px 0; color:rgba(255,255,255,.5); }
+.photoGrid {
+  display:grid;
+  grid-template-columns:repeat(auto-fill, minmax(88px,1fr));
+  gap:10px;
+  margin-top:12px;
 }
-
-.thumb {
-  position: relative;
-  aspect-ratio: 1/1;
-  border-radius: 10px;
-  overflow: hidden;
-  outline: 2px solid transparent;
+.photoCard {
+  position:relative;
+  border-radius:14px;
+  overflow:hidden;
 }
-
-.thumb.selected { outline-color: var(--primary); }
-
-.thumb img {
-  width: 100%; height: 100%; object-fit: cover; display:block;
+.photoCard__img {
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  display:block;
 }
-
-.thumb .controls {
-  position: absolute; inset: auto 0 0 0;
-  display: flex; justify-content: space-between; padding: 6px;
-  background: linear-gradient(transparent, rgba(0,0,0,.45));
+.photoCard__actions {
+  position:absolute;
+  right:8px;
+  bottom:8px;
+  display:flex;
+  gap:6px;
+  opacity:0;
+  transform:translateY(4px);
+  transition:opacity .15s ease, transform .15s ease;
 }
-
-.thumb .controls button {
-  border: none; border-radius: 8px; padding: 6px;
-  background: rgba(255,255,255,.85);
+.photoCard.is-active .photoCard__actions,
+.photoCard:hover .photoCard__actions {
+  opacity:1;
+  transform:translateY(0);
 }
-.thumb .controls button:disabled { opacity:.4; }
-
+.photoBtn {
+  width:30px;
+  height:30px;
+  display:grid;
+  place-items:center;
+  background:rgba(28,28,30,.55);
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:12px;
+  backdrop-filter:saturate(180%) blur(4px);
+  box-shadow:0 6px 14px rgba(0,0,0,.35);
+  color:rgba(255,255,255,.9);
+}
+.photoBtn svg{ width:18px; height:18px; }
+.photoBtn:active {
+  transform:scale(.96);
+}
+.photoCard__badge {
+  position:absolute;
+  left:8px;
+  top:8px;
+  min-width:22px;
+  height:22px;
+  padding:0 6px;
+  display:grid;
+  place-items:center;
+  border-radius:11px;
+  background:rgba(0,0,0,.55);
+  color:#fff;
+  font-size:12px;
+  font-weight:600;
+  backdrop-filter:blur(4px);
+  opacity:0;
+  transform:translateY(-4px);
+  transition:opacity .15s, transform .15s;
+}
+.photoCard.is-active .photoCard__badge {
+  opacity:1;
+  transform:translateY(0);
+}


### PR DESCRIPTION
## Summary
- Style photo cards with subtle glass buttons and selection badges
- Add photo selection workflow with Done action populating slides
- Support header controls in sheets and sticky footer buttons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6b5c7840c83289a231e8f967a2fac