### PR TITLE
feat: add done button to photo sheet

### DIFF
--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -48,6 +48,11 @@ export default function PhotosSheet() {
 
   const removeOne = (id: PhotoId) => photosActions.remove(id);
 
+  const onDone = () => {
+    // slidesActions.commitFromPhotos(items); // опционально, если нужен «коммит»
+    onClose(); // закрыть щит
+  };
+
   return (
     <div className="sheet" aria-open="true" onClick={onClose}>
       <div className="sheet__overlay" />
@@ -72,7 +77,7 @@ export default function PhotosSheet() {
             />
           </label>
 
-          <button className="btn-soft" onClick={onClose}>Done</button>
+          <button className="btn-soft" onClick={onDone}>Done</button>
         </div>
         <div className="sheet__content">
           <div className="photos-sheet">

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -24,6 +24,8 @@
   box-shadow:0 2px 12px rgba(0,0,0,.18);
   color:rgba(255,255,255,.92);
   font-weight:600;
+  font-size:15px;
+  line-height:1;
 }
 .btn-soft:hover{ background:color-mix(in srgb, #ffffff 18%, transparent); }
 .btn-soft:active{ transform:translateY(1px); }


### PR DESCRIPTION
## Summary
- add onDone handler to photo sheet for closing after photo additions
- unify Add photo and Done button styles via shared `.btn-soft`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c30777b483289085f60c3e957b7b