### PR TITLE
Refactor PhotosSheet input and button behavior

### DIFF
--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, ChangeEvent } from 'react';
+import { useState, useEffect, MouseEvent } from 'react';
 import {
   photosActions,
   usePhotos,
@@ -30,8 +30,7 @@ export default function PhotosSheet() {
     return () => window.removeEventListener('keydown', onEsc);
   }, [onClose]);
 
-  const onAdd = (e: ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
+  const onAdd = (files: FileList | null) => {
     if (!files) return;
     photosActions.addFiles(Array.from(files));
   };
@@ -48,17 +47,29 @@ export default function PhotosSheet() {
 
   const removeOne = (id: PhotoId) => photosActions.remove(id);
 
-  const onDone = () => {
+  const onDone = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
     // slidesActions.commitFromPhotos(items); // опционально, если нужен «коммит»
     onClose(); // закрыть щит
   };
+
+  const inputId = 'photos-file-input';
 
   return (
     <div className="sheet" aria-open="true" onClick={onClose}>
       <div className="sheet__overlay" />
       <div className="sheet__panel" onClick={(e) => e.stopPropagation()}>
         <div className="actions-row">
-          <label className="btn-soft add-btn">
+          <input
+            id={inputId}
+            type="file"
+            accept="image/*"
+            multiple
+            hidden
+            onChange={(e) => onAdd(e.target.files)}
+          />
+          <label className="btn-soft add-btn" htmlFor={inputId}>
             <svg width="18" height="18" viewBox="0 0 24 24">
               <path
                 d="M12 5v14M5 12h14"
@@ -68,16 +79,11 @@ export default function PhotosSheet() {
               />
             </svg>
             <span>Add photo</span>
-            <input
-              type="file"
-              accept="image/*"
-              multiple
-              hidden
-              onChange={onAdd}
-            />
           </label>
 
-          <button className="btn-soft" onClick={onDone}>Done</button>
+          <button type="button" className="btn-soft" onClick={onDone}>
+            Done
+          </button>
         </div>
         <div className="sheet__content">
           <div className="photos-sheet">

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -9,12 +9,14 @@
 
 /* ряд с кнопками наверху шита */
 .actions-row{
+  position:relative; z-index:2;
   display:flex; align-items:center; gap:10px;
-  padding: 8px 12px 4px;
+  padding:8px 12px 4px;
 }
 
 /* мягкая кнопка — используется и для Add photo, и для Done */
 .btn-soft{
+  position:relative; z-index:1;
   display:inline-flex; align-items:center; gap:8px;
   padding:10px 14px;
   border-radius:14px;
@@ -48,7 +50,7 @@
 .btn-circle-soft svg{ width:16px; height:16px; }
 
 /* блок «Add photo» */
-.add-btn{ margin-left: 0; }
+.add-btn{ margin-left: 0; pointer-events:auto; }
 
 /* миниатюры */
 .thumb{ position:relative; border-radius:14px; overflow:hidden; }


### PR DESCRIPTION
## Summary
- Move file input outside label and link via `htmlFor`
- Prevent bubble on Done button and close sheet explicitly
- Ensure actions row buttons stay clickable with z-index and pointer events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6c54c55dc8328aa7a23d41f71ec02