### PR TITLE
feat: sync slides with photos

### DIFF
--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -4,6 +4,7 @@ import {
   usePhotos,
   PhotoId,
   useCarouselStore,
+  slidesActions,
 } from '@/state/store';
 import { ArrowLeftIcon, ArrowRightIcon, TrashIcon } from '@/ui/icons';
 import '@/styles/photos-sheet.css';
@@ -50,7 +51,7 @@ export default function PhotosSheet() {
   const onDone = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    // slidesActions.commitFromPhotos(items); // опционально, если нужен «коммит»
+    slidesActions.syncWithPhotos(items);
     onClose(); // закрыть щит
   };
 


### PR DESCRIPTION
## Summary
- add `slidesActions.syncWithPhotos` to keep slide list in sync with photos
- invoke slide syncing from `PhotosSheet` when user finishes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c6d9cbfb408328b14afd5cb0f93149