### PR TITLE
feat: add nickname text sheet and slide overlay

### DIFF
--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -8,7 +8,7 @@ import LayoutSheet from './components/sheets/LayoutSheet';
 
 export default function App() {
   const sheet = useCarouselStore(s => s.activeSheet);
-  const slides = useCarouselStore(s => s.slides.map(sl => ({ imageUrl: sl.image })));
+  const slides = useCarouselStore(s => s.slides);
 
   return (
     <>

--- a/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
+++ b/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
@@ -1,12 +1,13 @@
+import { Slide } from '@/state/store';
 import { SlideCard } from './SlideCard';
 
 const TARGET_AR = 0.8; // 4:5 — единый для всех
 
-export function PreviewCarousel({ slides }: { slides: { imageUrl?: string }[] }) {
+export function PreviewCarousel({ slides }: { slides: Slide[] }) {
   return (
     <div className="carousel">
       {slides.map((s, i) => (
-        <div className="slide" key={i}>
+        <div className="slide" key={s.id ?? i}>
           <SlideCard slide={s} aspect={TARGET_AR} />
         </div>
       ))}

--- a/apps/webapp/src/components/Carousel/SlideCard.tsx
+++ b/apps/webapp/src/components/Carousel/SlideCard.tsx
@@ -1,18 +1,25 @@
+import { Slide } from '@/state/store';
+
 export function SlideCard({
   slide,
   aspect,
 }: {
-  slide: { imageUrl?: string };
+  slide: Slide;
   aspect: number;
 }) {
   return (
     <div className="ig-frame" style={{ aspectRatio: aspect }}>
-      {slide.imageUrl ? (
-        <img src={slide.imageUrl} alt="" draggable={false} />
+      {slide.image ? (
+        <img src={slide.image} alt="" draggable={false} />
       ) : (
         <div className="ig-placeholder" />
+      )}
+      {(slide.body || slide.nickname) && (
+        <div className="overlay">
+          {slide.body && <div className="caption">{slide.body}</div>}
+          {slide.nickname && <div className="nick">{slide.nickname}</div>}
+        </div>
       )}
     </div>
   );
 }
-

--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -4,6 +4,7 @@
   --gap: 10px;
   --peek: 0px;        /* 0 = не «подглядываем» соседний слайд */
 
+  margin-top: 8px;
   padding-inline: var(--side-pad);
   display: flex;
   gap: var(--gap);
@@ -31,6 +32,7 @@
 
 /* Кадр Instagram 4:5 */
 .ig-frame{
+  position: relative;
   width: 100%;
   aspect-ratio: 0.8;     /* единый аспект */
   border-radius: 16px;   /* можно 14–16 как нравится */
@@ -49,3 +51,18 @@
 }
 
 .ig-placeholder{ width:100%; height:100%; background:#111; }
+
+.overlay{
+  position:absolute; inset:auto 12px 12px 12px; display:flex; flex-direction:column; gap:8px;
+}
+.caption{
+  white-space:pre-wrap; line-height:1.25; font-weight:600;
+  text-shadow: 0 1px 2px rgba(0,0,0,.6);
+}
+.nick{
+  align-self:flex-start; opacity:.8; font-weight:600; font-size:12px;
+  padding:6px 10px; border-radius:999px;
+  background: color-mix(in srgb, #000 45%, transparent);
+  border:1px solid rgba(255,255,255,.18);
+  backdrop-filter: blur(6px);
+}

--- a/apps/webapp/src/components/sheets/TextSheet.tsx
+++ b/apps/webapp/src/components/sheets/TextSheet.tsx
@@ -1,21 +1,48 @@
-import { useState } from 'react';
 import { useCarouselStore } from '@/state/store';
 import Sheet from '../Sheet/Sheet';
+import '@/styles/text-sheet.css';
 
-export default function TextSheet(){
-  const { slides, activeIndex, updateSlide, closeSheet } = useCarouselStore();
-  const active = slides[activeIndex];
-  const [val, setVal] = useState(active?.body ?? '');
+export default function TextSheet() {
+  const nickname = useCarouselStore((s) => s.text.nickname);
+  const bulkText = useCarouselStore((s) => s.text.bulkText);
+  const setTextField = useCarouselStore((s) => s.setTextField);
+  const applyTextToSlides = useCarouselStore((s) => s.applyTextToSlides);
+  const close = useCarouselStore((s) => s.closeSheet);
+
+  const onDone = () => {
+    applyTextToSlides();
+    close();
+  };
 
   return (
     <Sheet title="Text">
-      <div className="field">
-        <textarea value={val} onChange={e=>setVal(e.target.value)} placeholder="Вставь текст сюда…" />
+      <div className="text-sheet">
+        {/* Никнейм */}
+        <label className="field">
+          <div className="label">Никнейм</div>
+          <input
+            className="input"
+            type="text"
+            placeholder="@alexvoit"
+            value={nickname}
+            onChange={(e) => setTextField({ nickname: e.target.value })}
+          />
+        </label>
+
+        {/* Многострочный текст */}
+        <label className="field">
+          <div className="label">Текст</div>
+          <textarea
+            className="textarea"
+            placeholder={"Вставь текст сюда…\n\nПустая строка = следующий слайд"}
+            rows={8}
+            value={bulkText}
+            onChange={(e) => setTextField({ bulkText: e.target.value })}
+          />
+        </label>
       </div>
       <div className="sheet__footer">
-        <button className="btn" onClick={()=>{ if(active) updateSlide(active.id,{ body: val }); closeSheet(); }}>
-          Done
-        </button>
+        <button className="btn-soft" onClick={onDone}>Done</button>
       </div>
     </Sheet>
   );

--- a/apps/webapp/src/features/render/canvas.ts
+++ b/apps/webapp/src/features/render/canvas.ts
@@ -42,6 +42,14 @@ export async function renderSlideToPNG(slide: Slide): Promise<Blob> {
     lines.forEach(l => { ctx.fillText(l, 64, y); y += 56; });
   }
 
+  if (slide.nickname) {
+    ctx.font = '32px system-ui, -apple-system, Segoe UI, Roboto, Arial';
+    ctx.fillStyle = 'rgba(255,255,255,.8)';
+    ctx.shadowColor = 'rgba(0,0,0,.6)';
+    ctx.shadowBlur = 8;
+    ctx.fillText(slide.nickname, 64, CANVAS_H - 32);
+  }
+
   return await new Promise<Blob>((resolve, reject)=>{
     canvas.toBlob(b => b ? resolve(b) : reject(new Error('toBlob failed')),'image/png');
   });

--- a/apps/webapp/src/styles/text-sheet.css
+++ b/apps/webapp/src/styles/text-sheet.css
@@ -1,0 +1,24 @@
+.text-sheet .field{ margin:10px 12px; display:flex; flex-direction:column; gap:6px; }
+.text-sheet .label{ opacity:.7; font-size:13px; }
+.text-sheet .input, .text-sheet .textarea{
+  width:100%; padding:12px 14px; border-radius:12px; border:1px solid rgba(255,255,255,.12);
+  background: rgba(255,255,255,.06); color:#fff; outline:none;
+}
+.text-sheet .textarea{ resize:vertical; min-height:140px; }
+
+.btn-soft{
+  position:relative; z-index:1;
+  display:inline-flex; align-items:center; gap:8px;
+  padding:10px 14px;
+  border-radius:14px;
+  background:color-mix(in srgb, #ffffff 12%, transparent);
+  border:1px solid color-mix(in srgb, #ffffff 35%, transparent);
+  backdrop-filter:blur(6px);
+  box-shadow:0 2px 12px rgba(0,0,0,.18);
+  color:rgba(255,255,255,.92);
+  font-weight:600;
+  font-size:15px;
+  line-height:1;
+}
+.btn-soft:hover{ background:color-mix(in srgb, #ffffff 18%, transparent); }
+.btn-soft:active{ transform:translateY(1px); }


### PR DESCRIPTION
## Summary
- add top margin and text/nickname overlay styling to carousel
- introduce nickname + bulk text fields that auto-split text across slides
- render nickname on slides and in exported PNGs

## Testing
- ⚠️ `npm test` (missing script: test)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c705ecb1a08328bfe26c41d46424c7