### PR TITLE
feat: disable zoom and refine global styles

### DIFF
--- a/apps/webapp/index.html
+++ b/apps/webapp/index.html
@@ -2,7 +2,10 @@
 <html lang="ru">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
+    />
     <title>Carousel MVP</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -1,12 +1,12 @@
 /* Трек карусели */
 .carousel{
-  --side-pad: 10px;   /* можно 8px, если хочешь ещё больше */
-  --gap: 10px;
-  --peek: 0px;        /* 0 = не «подглядываем» соседний слайд */
+    --side-pad: 10px;   /* можно 8px, если хочешь ещё больше */
+    --gap: 10px;
+    --peek: 0px;        /* 0 = не «подглядываем» соседний слайд */
 
-  margin-top: 8px;
-  padding-inline: var(--side-pad);
-  display: flex;
+    margin-top: 10px;
+    padding-inline: var(--side-pad);
+    display: flex;
   gap: var(--gap);
   overflow-x: auto;
   scroll-snap-type: x mandatory;

--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -2,3 +2,12 @@
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; }
 body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; background: #0d0d0f; color: #fff; }
+
+/* iOS зумит инпуты < 16px — не даём повода */
+input, textarea, select, button { font-size: 16px; }
+
+/* не увеличивай текст «по своему» */
+html { -webkit-text-size-adjust: 100%; }
+
+/* кликабельным элементам отключаем double-tap zoom */
+a, button, [role="button"], .btn-soft { touch-action: manipulation; }

--- a/apps/webapp/src/main.tsx
+++ b/apps/webapp/src/main.tsx
@@ -6,6 +6,39 @@ import './styles/bottom-bar.css';
 import './components/Sheet/Sheet.css';
 import './components/Carousel/carousel.css';
 
+// Блок pinch-zoom (iOS gesturestart) и ctrl+wheel (desktop)
+document.addEventListener('gesturestart', (e) => e.preventDefault(), { passive: false });
+document.addEventListener(
+  'wheel',
+  (e) => {
+    if ((e as WheelEvent).ctrlKey) e.preventDefault();
+  },
+  { passive: false }
+);
+
+// Блок двойного тапа -> zoom
+let lastTouchEnd = 0;
+document.addEventListener(
+  'touchend',
+  (e) => {
+    const now = Date.now();
+    if (now - lastTouchEnd <= 300) {
+      e.preventDefault(); // отменяем double-tap zoom
+    }
+    lastTouchEnd = now;
+  },
+  { passive: false }
+);
+
+// Резерв: две пальца = попытка zoom -> гасим
+document.addEventListener(
+  'touchmove',
+  (e) => {
+    if (e.touches && e.touches.length > 1) e.preventDefault();
+  },
+  { passive: false }
+);
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <App />


### PR DESCRIPTION
## Summary
- block page zoom via viewport meta tag
- add global CSS to prevent auto-zoom and double-tap zoom
- stop pinch and double-tap zoom with JS listeners
- tweak carousel spacing

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c713eade048328baadd337acd793dd