### PR TITLE
feat: add template and layout sheets

### DIFF
--- a/apps/webapp/src/components/Carousel/SlideCard.tsx
+++ b/apps/webapp/src/components/Carousel/SlideCard.tsx
@@ -14,12 +14,15 @@ export function SlideCard({
       ) : (
         <div className="ig-placeholder" />
       )}
-      {(slide.body || slide.nickname) && (
-        <div className="overlay">
-          {slide.body && <div className="caption">{slide.body}</div>}
-          {slide.nickname && <div className="nick">{slide.nickname}</div>}
-        </div>
-      )}
-    </div>
-  );
-}
+        {(slide.body || slide.nickname) && (
+          <div className="overlay">
+            {slide.body && <div className="caption">{slide.body}</div>}
+            {slide.nickname &&
+              (slide.overrides?.template?.showNickname ?? true) && (
+                <div className="nick">{slide.nickname}</div>
+              )}
+          </div>
+        )}
+      </div>
+    );
+  }

--- a/apps/webapp/src/components/sheets/LayoutSheet.tsx
+++ b/apps/webapp/src/components/sheets/LayoutSheet.tsx
@@ -1,17 +1,283 @@
+import { useState } from 'react';
 import Sheet from '../Sheet/Sheet';
 import { useCarouselStore } from '@/state/store';
+import '@/styles/photos-sheet.css';
 
-export default function LayoutSheet(){
-  const close = useCarouselStore(s=>s.closeSheet);
+export default function LayoutSheet() {
+  const layout = useCarouselStore((s) => s.style.layout);
+  const scope = useCarouselStore((s) => s.style.layoutScope);
+  const setScope = useCarouselStore((s) => s.setLayoutScope);
+  const setLayout = useCarouselStore((s) => s.setLayout);
+  const reset = useCarouselStore((s) => s.resetLayout);
+  const apply = useCarouselStore((s) => s.applyLayout);
+  const close = useCarouselStore((s) => s.closeSheet);
+  const showNickname = useCarouselStore((s) => s.style.template.showNickname);
+  const [safeArea, setSafeArea] = useState(false);
+
+  const onDone = () => {
+    apply();
+    close();
+  };
+
   return (
     <Sheet title="Layout">
-      <p>
-        Сюда переехали настройки: размер текста, межстрочный интервал,
-        позиция (top/bottom). Штатные контролы можно добавить позже.
-      </p>
+      <div className="layout-sheet">
+        <div className="section">
+          <div>Vertical:</div>
+          {['top', 'middle', 'bottom'].map((p) => (
+            <label key={p}>
+              <input
+                type="radio"
+                name="vPos"
+                value={p}
+                checked={layout.vPos === p}
+                onChange={() => setLayout({ vPos: p as any })}
+              />
+              {p.charAt(0).toUpperCase() + p.slice(1)}
+            </label>
+          ))}
+          <label>
+            Vertical offset
+            <input
+              type="range"
+              min={-40}
+              max={40}
+              step={1}
+              value={layout.vOffset}
+              onChange={(e) => setLayout({ vOffset: Number(e.target.value) })}
+            />
+          </label>
+          <div>Horizontal:</div>
+          {['left', 'center', 'right'].map((p) => (
+            <label key={p}>
+              <input
+                type="radio"
+                name="hAlign"
+                value={p}
+                checked={layout.hAlign === p}
+                onChange={() => setLayout({ hAlign: p as any })}
+              />
+              {p.charAt(0).toUpperCase() + p.slice(1)}
+            </label>
+          ))}
+          <label>
+            <input
+              type="checkbox"
+              checked={safeArea}
+              onChange={(e) => setSafeArea(e.target.checked)}
+            />
+            Safe area guides
+          </label>
+        </div>
+
+        <div className="section">
+          <label>
+            Font size
+            <input
+              type="range"
+              min={14}
+              max={26}
+              step={1}
+              value={layout.fontSize}
+              onChange={(e) => setLayout({ fontSize: Number(e.target.value) })}
+            />
+          </label>
+          <label>
+            Line height
+            <input
+              type="range"
+              min={1}
+              max={1.6}
+              step={0.05}
+              value={layout.lineHeight}
+              onChange={(e) => setLayout({ lineHeight: Number(e.target.value) })}
+            />
+          </label>
+          <label>
+            Block width
+            <input
+              type="range"
+              min={60}
+              max={100}
+              step={1}
+              value={layout.blockWidth}
+              onChange={(e) => setLayout({ blockWidth: Number(e.target.value) })}
+            />
+          </label>
+          <label>
+            Padding
+            <input
+              type="range"
+              min={0}
+              max={16}
+              step={1}
+              value={layout.padding}
+              onChange={(e) => setLayout({ padding: Number(e.target.value) })}
+            />
+          </label>
+        </div>
+
+        <div className="section">
+          <label>
+            Max lines
+            <input
+              type="number"
+              min={1}
+              max={8}
+              value={layout.maxLines}
+              onChange={(e) => setLayout({ maxLines: Number(e.target.value) })}
+            />
+          </label>
+          <label>
+            Paragraph gap
+            <input
+              type="range"
+              min={0}
+              max={16}
+              step={1}
+              value={layout.paraGap}
+              onChange={(e) => setLayout({ paraGap: Number(e.target.value) })}
+            />
+          </label>
+          <div>
+            Overflow:
+            {['wrap', 'fade'].map((o) => (
+              <label key={o}>
+                <input
+                  type="radio"
+                  name="overflow"
+                  value={o}
+                  checked={layout.overflow === o}
+                  onChange={() => setLayout({ overflow: o as any })}
+                />
+                {o === 'wrap' ? 'Wrap' : 'Fade'}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="section" aria-disabled={!showNickname}>
+          <div>Nickname</div>
+          <div>
+            Position:
+            {['left', 'center', 'right'].map((p) => (
+              <label key={p}>
+                <input
+                  type="radio"
+                  name="nickPos"
+                  value={p}
+                  checked={layout.nickPos === p}
+                  onChange={() => setLayout({ nickPos: p as any })}
+                  disabled={!showNickname}
+                />
+                {p.charAt(0).toUpperCase() + p.slice(1)}
+              </label>
+            ))}
+          </div>
+          <label>
+            Offset
+            <input
+              type="range"
+              min={0}
+              max={16}
+              step={1}
+              value={layout.nickOffset}
+              onChange={(e) => setLayout({ nickOffset: Number(e.target.value) })}
+              disabled={!showNickname}
+            />
+          </label>
+          <div>
+            Size:
+            {['s', 'm', 'l'].map((s) => (
+              <label key={s}>
+                <input
+                  type="radio"
+                  name="nickSize"
+                  value={s}
+                  checked={layout.nickSize === s}
+                  onChange={() => setLayout({ nickSize: s as any })}
+                  disabled={!showNickname}
+                />
+                {s.toUpperCase()}
+              </label>
+            ))}
+          </div>
+          <label>
+            Opacity
+            <input
+              type="range"
+              min={30}
+              max={100}
+              step={1}
+              value={layout.nickOpacity}
+              onChange={(e) => setLayout({ nickOpacity: Number(e.target.value) })}
+              disabled={!showNickname}
+            />
+          </label>
+          <label>
+            Corner radius
+            <input
+              type="range"
+              min={8}
+              max={999}
+              step={1}
+              value={layout.nickRadius}
+              onChange={(e) => setLayout({ nickRadius: Number(e.target.value) })}
+              disabled={!showNickname}
+            />
+          </label>
+        </div>
+
+        <div className="section">
+          <div>
+            Text shadow:
+            {[0, 1, 2, 3].map((n) => (
+              <label key={n}>
+                <input
+                  type="radio"
+                  name="layoutTextShadow"
+                  value={n}
+                  checked={layout.textShadow === n}
+                  onChange={() => setLayout({ textShadow: n as any })}
+                />
+                {n}
+              </label>
+            ))}
+          </div>
+          <label>
+            Gradient intensity
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={layout.gradient}
+              onChange={(e) => setLayout({ gradient: Number(e.target.value) })}
+            />
+          </label>
+        </div>
+
+        <div className="section">
+          Apply to:
+          {['all', 'current'].map((sc) => (
+            <label key={sc}>
+              <input
+                type="radio"
+                name="applyScopeLayout"
+                value={sc}
+                checked={scope === sc}
+                onChange={() => setScope(sc as any)}
+              />
+              {sc === 'all' ? 'All slides' : 'Current slide'}
+            </label>
+          ))}
+        </div>
+      </div>
       <div className="sheet__footer">
-        <button className="btn" onClick={close}>Close</button>
+        <button className="btn" onClick={reset}>Reset layout</button>
+        <button className="btn-soft" onClick={onDone}>Done</button>
       </div>
     </Sheet>
   );
 }
+

--- a/apps/webapp/src/components/sheets/TemplateSheet.tsx
+++ b/apps/webapp/src/components/sheets/TemplateSheet.tsx
@@ -1,14 +1,181 @@
 import Sheet from '../Sheet/Sheet';
 import { useCarouselStore } from '@/state/store';
+import '@/styles/photos-sheet.css';
 
-export default function TemplateSheet(){
-  const close = useCarouselStore(s=>s.closeSheet);
+export default function TemplateSheet() {
+  const template = useCarouselStore((s) => s.style.template);
+  const scope = useCarouselStore((s) => s.style.templateScope);
+  const setScope = useCarouselStore((s) => s.setTemplateScope);
+  const setPreset = useCarouselStore((s) => s.setTemplatePreset);
+  const setTemplate = useCarouselStore((s) => s.setTemplate);
+  const reset = useCarouselStore((s) => s.resetTemplate);
+  const apply = useCarouselStore((s) => s.applyTemplate);
+  const close = useCarouselStore((s) => s.closeSheet);
+
+  const onDone = () => {
+    apply();
+    close();
+  };
+
+  const presetItems: { key: Exclude<typeof template.preset, 'custom'>; label: string }[] = [
+    { key: 'minimal', label: 'Minimal' },
+    { key: 'light', label: 'Light' },
+    { key: 'focus', label: 'Focus' },
+    { key: 'quote', label: 'Quote' },
+  ];
+
   return (
     <Sheet title="Template">
-      <p>Здесь позже добавим пресеты (Minimal/Light/Focus/Quote).</p>
+      <div className="template-sheet">
+        <div className="section presets">
+          {presetItems.map((p) => (
+            <button
+              key={p.key}
+              className={`preset${template.preset === p.key ? ' is-active' : ''}`}
+              onClick={() => setPreset(p.key)}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="section">
+          <div>Text color:</div>
+          {['auto', 'white', 'black'].map((c) => (
+            <label key={c}>
+              <input
+                type="radio"
+                name="textColorMode"
+                value={c}
+                checked={template.textColorMode === c}
+                onChange={() => setTemplate({ textColorMode: c as any })}
+              />
+              {c.charAt(0).toUpperCase() + c.slice(1)}
+            </label>
+          ))}
+        </div>
+
+        <div className="section">
+          <div>Accent color:</div>
+          <div className="palette">
+            {['#FFFFFF', '#000000', '#2D6CFF', '#FF6B00', '#22C55E', '#E11D48'].map((color) => (
+              <button
+                key={color}
+                style={{ background: color, width: 24, height: 24, borderRadius: 4, marginRight: 4 }}
+                onClick={() => setTemplate({ accent: color })}
+              />
+            ))}
+            <input
+              type="color"
+              value={template.accent}
+              onChange={(e) => setTemplate({ accent: e.target.value })}
+            />
+          </div>
+        </div>
+
+        <div className="section">
+          <label>
+            Bottom gradient
+            <input
+              type="range"
+              min={0}
+              max={100}
+              step={1}
+              value={template.gradient}
+              onChange={(e) => setTemplate({ gradient: Number(e.target.value) })}
+            />
+          </label>
+          <label>
+            Dim photo
+            <input
+              type="range"
+              min={0}
+              max={30}
+              step={1}
+              value={template.dim}
+              onChange={(e) => setTemplate({ dim: Number(e.target.value) })}
+            />
+          </label>
+        </div>
+
+        <div className="section">
+          <label>
+            <input
+              type="checkbox"
+              checked={template.showNickname}
+              onChange={(e) => setTemplate({ showNickname: e.target.checked })}
+            />
+            Show nickname
+          </label>
+          <div>
+            Text shadow:
+            {[0, 1, 2, 3].map((n) => (
+              <label key={n}>
+                <input
+                  type="radio"
+                  name="textShadow"
+                  value={n}
+                  checked={template.textShadow === n}
+                  onChange={() => setTemplate({ textShadow: n as any })}
+                />
+                {n}
+              </label>
+            ))}
+          </div>
+          <div>
+            Nickname style:
+            {['pill', 'tag'].map((n) => (
+              <label key={n}>
+                <input
+                  type="radio"
+                  name="nicknameStyle"
+                  value={n}
+                  checked={template.nicknameStyle === n}
+                  onChange={() => setTemplate({ nicknameStyle: n as any })}
+                />
+                {n === 'pill' ? 'Pill' : 'Tag'}
+              </label>
+            ))}
+          </div>
+        </div>
+
+        <div className="section">
+          Font:
+          {['system', 'sf', 'inter'].map((f) => (
+            <label key={f}>
+              <input
+                type="radio"
+                name="font"
+                value={f}
+                checked={template.font === f}
+                onChange={() => setTemplate({ font: f as any })}
+              />
+              {f === 'sf' ? 'SF Display' : f === 'inter' ? 'Inter' : 'System'}
+            </label>
+          ))}
+        </div>
+
+        <div className="section">
+          Apply to:
+          {['all', 'current'].map((sc) => (
+            <label key={sc}>
+              <input
+                type="radio"
+                name="applyScopeTemplate"
+                value={sc}
+                checked={scope === sc}
+                onChange={() => setScope(sc as any)}
+              />
+              {sc === 'all' ? 'All slides' : 'Current slide'}
+            </label>
+          ))}
+        </div>
+      </div>
       <div className="sheet__footer">
-        <button className="btn" onClick={close}>Close</button>
+          <button className="btn" onClick={reset}>Reset preset</button>
+          <button className="btn-soft" onClick={onDone}>Done</button>
       </div>
     </Sheet>
   );
 }
+


### PR DESCRIPTION
## Summary
- scaffold template sheet with presets, color and nickname controls
- add layout sheet for positioning, text box, behavior, nickname and effects
- extend store with template/layout style state and slide overrides

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c7158925c8832885e70091f3814550