### PR TITLE
Replace demo slides with uploaded photos

### DIFF
--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -51,7 +51,7 @@ export default function PhotosSheet() {
   const onDone = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     e.stopPropagation();
-    slidesActions.syncWithPhotos(items);
+    slidesActions.replaceWithPhotos(items);
     onClose(); // закрыть щит
   };
 

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -98,6 +98,8 @@ export type Slide = {
     template?: TemplateStyle;
     layout?: LayoutStyle;
   };
+  kind?: 'demo' | 'photo';
+  isDemo?: boolean;
 };
 
 export type UISheet = null | 'template' | 'layout' | 'photos' | 'text';
@@ -220,8 +222,10 @@ const defaultLayout: LayoutStyle = {
 
 // дефолтный сет мотивации (5 слайдов)
 const initial: Slide[] = Array.from({ length: 5 }).map((_, i) => ({
-  id: `s${i + 1}`,
+  id: `demo-${i + 1}`,
   body: `Текст ${i + 1} ...`,
+  kind: 'demo',
+  isDemo: true,
 }));
 
 export const useCarouselStore = create<State>((set, get) => ({
@@ -344,21 +348,18 @@ export const useCarouselStore = create<State>((set, get) => ({
 const uid = () => crypto.randomUUID();
 
 export const slidesActions = {
-  syncWithPhotos(photos: Photo[]) {
+  replaceWithPhotos(photos: Photo[]) {
     useCarouselStore.setState((state) => {
-      const prev = state.slides;
-      const photoSlides = prev.filter((s) => s.photoId);
-      const otherSlides = prev.filter((s) => !s.photoId);
-      const byPhotoId = new Map(photoSlides.map((s) => [s.photoId!, s]));
+      const next: Slide[] = photos.map((p) => ({
+        id: uid(),
+        image: p.src,
+        photoId: p.id,
+        body: '',
+        nickname: state.text?.nickname ?? '',
+        kind: 'photo',
+      }));
 
-      const nextPhotoSlides: Slide[] = photos.map((p) => {
-        const keep = byPhotoId.get(p.id);
-        return keep
-          ? { ...keep, image: p.src }
-          : { id: uid(), image: p.src, photoId: p.id };
-      });
-
-      return { slides: [...nextPhotoSlides, ...otherSlides] };
+      return { slides: next, activeIndex: 0 };
     });
   },
 };


### PR DESCRIPTION
## Summary
- add `replaceWithPhotos` action that rebuilds slides from selected photos and resets the active index
- mark initial slides as demo to ensure placeholders disappear when photos are added
- call the new action from the Photos sheet to fully replace slides on Done

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c72a24062083288ad1ae3a58f33696