### PR TITLE
feat: add footer gradient modes

### DIFF
--- a/apps/webapp/src/components/Carousel/SlideCard.tsx
+++ b/apps/webapp/src/components/Carousel/SlideCard.tsx
@@ -32,6 +32,8 @@ export function SlideCard({
   const globalLayout = useCarouselStore((s) => s.style.layout);
   const template: TemplateStyle = slide.overrides?.template || globalTemplate;
   const layout: LayoutStyle = slide.overrides?.layout || globalLayout;
+  const h = Math.min(Math.max(template.bottomGradient, 0), 60);
+  const tone = template.footerStyle;
 
   const { title, body } = splitTextEditorial(slide.body || '');
   const titleSize = Math.round(layout.fontSize * 1.35);
@@ -52,6 +54,17 @@ export function SlideCard({
         <img src={slide.image} alt="" draggable={false} />
       ) : (
         <div className="ig-placeholder" />
+      )}
+      {tone !== 'none' && (
+        <div
+          className="footer-gradient"
+          style={{
+            background:
+              tone === 'dark'
+                ? `linear-gradient(to top, rgba(0,0,0,.68) 0%, rgba(0,0,0,0) ${h}%)`
+                : `linear-gradient(to top, rgba(255,255,255,.85) 0%, rgba(255,255,255,0) ${h}%)`,
+          }}
+        />
       )}
       {(title || body || slide.nickname) && (
         <div className="overlay editorial">

--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -40,6 +40,12 @@
   background: #000;
 }
 
+.footer-gradient{
+  position:absolute; left:0; right:0; bottom:0;
+  height:60%;
+  pointer-events:none;
+}
+
 /* Фото внутри — как в IG */
 .ig-frame > img{
   width: 100%;

--- a/apps/webapp/src/components/sheets/TemplateSheet.tsx
+++ b/apps/webapp/src/components/sheets/TemplateSheet.tsx
@@ -8,6 +8,7 @@ export default function TemplateSheet() {
   const setScope = useCarouselStore((s) => s.setTemplateScope);
   const setPreset = useCarouselStore((s) => s.setTemplatePreset);
   const setTemplate = useCarouselStore((s) => s.setTemplate);
+  const setFooterStyle = useCarouselStore((s) => s.setFooterStyle);
   const reset = useCarouselStore((s) => s.resetTemplate);
   const apply = useCarouselStore((s) => s.applyTemplate);
   const close = useCarouselStore((s) => s.closeSheet);
@@ -28,6 +29,27 @@ export default function TemplateSheet() {
   return (
     <Sheet title="Template">
       <div className="template-sheet">
+        <div className="actions-row">
+          <button
+            className={`btn-soft${template.footerStyle === 'none' ? ' is-active' : ''}`}
+            onClick={() => setFooterStyle('none', scope)}
+          >
+            Original
+          </button>
+          <button
+            className={`btn-soft${template.footerStyle === 'dark' ? ' is-active' : ''}`}
+            onClick={() => setFooterStyle('dark', scope)}
+          >
+            Dark footer
+          </button>
+          <button
+            className={`btn-soft${template.footerStyle === 'light' ? ' is-active' : ''}`}
+            onClick={() => setFooterStyle('light', scope)}
+          >
+            Light footer
+          </button>
+        </div>
+
         <div className="section presets">
           {presetItems.map((p) => (
             <button
@@ -80,11 +102,13 @@ export default function TemplateSheet() {
             <input
               type="range"
               min={0}
-              max={100}
+              max={60}
               step={1}
-              value={template.gradient}
-              onChange={(e) => setTemplate({ gradient: Number(e.target.value) })}
+              value={template.bottomGradient}
+              onChange={(e) => setTemplate({ bottomGradient: Number(e.target.value) })}
+              disabled={template.footerStyle === 'none'}
             />
+            <small>Height</small>
           </label>
           <label>
             Dim photo
@@ -93,8 +117,8 @@ export default function TemplateSheet() {
               min={0}
               max={30}
               step={1}
-              value={template.dim}
-              onChange={(e) => setTemplate({ dim: Number(e.target.value) })}
+              value={template.dimPhoto}
+              onChange={(e) => setTemplate({ dimPhoto: Number(e.target.value) })}
             />
           </label>
         </div>

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -31,6 +31,10 @@
 }
 .btn-soft:hover{ background:color-mix(in srgb, #ffffff 18%, transparent); }
 .btn-soft:active{ transform:translateY(1px); }
+.btn-soft.is-active{
+  background: color-mix(in srgb, #ffffff 18%, transparent);
+  border-color: color-mix(in srgb, #ffffff 45%, transparent);
+}
 
 /* ↓ Уменьшаем круглые кнопки на миниатюрах на ~15% */
 .btn-circle-soft{


### PR DESCRIPTION
## Summary
- add footerStyle, bottomGradient, and dimPhoto to template style with dark mode default
- provide quick Original/Dark/Light footer buttons and adjustable height slider in template sheet
- render footer gradient overlay on slides and style active soft buttons

## Testing
- `npm test` (fails: Missing script)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c7f6e6516083288bee19a732082efd