### PR TITLE
Update template sheet styling and heading accent handling

### DIFF
--- a/apps/webapp/src/components/Carousel/SlideCard.tsx
+++ b/apps/webapp/src/components/Carousel/SlideCard.tsx
@@ -1,4 +1,11 @@
-import { Slide, TemplateStyle, LayoutStyle, useCarouselStore } from '@/state/store';
+import {
+  Slide,
+  TemplateConfig,
+  LayoutStyle,
+  useCarouselStore,
+  getBaseTextColor,
+  getHeadingColor,
+} from '@/state/store';
 
 function splitTextEditorial(text: string): { title: string; body: string } {
   const trimmed = text.trim();
@@ -30,24 +37,29 @@ export function SlideCard({
 }) {
   const globalTemplate = useCarouselStore((s) => s.style.template);
   const globalLayout = useCarouselStore((s) => s.style.layout);
-  const template: TemplateStyle = slide.overrides?.template || globalTemplate;
+  const { textColorMode, headingAccent } = useCarouselStore((s) => s.typography);
+  const template: TemplateConfig = slide.overrides?.template || globalTemplate;
   const layout: LayoutStyle = slide.overrides?.layout || globalLayout;
   const h = Math.min(Math.max(template.bottomGradient, 0), 60);
   const tone = template.footerStyle;
+
+  const bgTone: 'dark' | 'light' =
+    slide.runtime?.bgTone ?? (textColorMode === 'black' ? 'light' : 'dark');
+  const baseTextColor = getBaseTextColor(bgTone, textColorMode);
+  const titleColor = getHeadingColor(bgTone, textColorMode, headingAccent);
 
   const { title, body } = splitTextEditorial(slide.body || '');
   const titleSize = Math.round(layout.fontSize * 1.35);
   const bodySize = Math.round(layout.fontSize * 0.9);
   const titleLine = (layout.lineHeight * 1.2) / 1.3;
   const bodyLine = (layout.lineHeight * 1.35) / 1.3;
-  const fontMap: Record<TemplateStyle['font'], string> = {
+  const fontMap: Record<TemplateConfig['font'], string> = {
     system: 'var(--font-system)',
     inter: 'var(--font-inter, var(--font-system))',
     playfair: 'var(--font-playfair, var(--font-system))',
     bodoni: 'var(--font-bodoni, var(--font-system))',
     dmsans: 'var(--font-dmsans, var(--font-system))',
   };
-  const color = template.textColorMode === 'black' ? '#000' : '#fff';
   return (
     <div className="ig-frame" style={{ aspectRatio: aspect }}>
       {slide.image ? (
@@ -80,7 +92,7 @@ export function SlideCard({
                     fontSize: titleSize,
                     lineHeight: titleLine,
                     fontFamily: fontMap[template.font],
-                    color,
+                    color: titleColor,
                   }}
                 >
                   {title}
@@ -94,7 +106,8 @@ export function SlideCard({
                     fontSize: bodySize,
                     lineHeight: bodyLine,
                     fontFamily: fontMap[template.font],
-                    color,
+                    color: baseTextColor,
+                    opacity: 0.92,
                   }}
                 >
                   {body}

--- a/apps/webapp/src/components/Sheet/Sheet.css
+++ b/apps/webapp/src/components/Sheet/Sheet.css
@@ -26,3 +26,41 @@
   padding:12px;
   resize:vertical;
 }
+
+.template-sheet__quick{ display:flex; flex-direction:column; gap:10px; margin-bottom:16px; }
+.template-sheet__quick-row{ display:flex; flex-wrap:wrap; gap:8px; }
+
+.soft-pill{
+  padding:10px 14px;
+  border-radius:16px;
+  border:1px solid rgba(255,255,255,.14);
+  background:rgba(255,255,255,.04);
+  backdrop-filter:blur(6px);
+  -webkit-backdrop-filter:blur(6px);
+  transition:.15s ease;
+  color:inherit;
+}
+.soft-pill:hover{ background:rgba(255,255,255,.07); }
+.soft-pill.is-active{
+  background:rgba(255,255,255,.1);
+  border-color:rgba(255,255,255,.22);
+  box-shadow:0 1px 0 rgba(255,255,255,.08) inset;
+}
+
+.swatches{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.swatch{
+  width:28px;
+  height:28px;
+  border-radius:9px;
+  border:1px solid rgba(255,255,255,.18);
+}
+.swatch.is-active{ outline:2px solid rgba(255,255,255,.8); outline-offset:2px; }
+.swatch.reset{
+  width:auto;
+  padding:0 10px;
+  background:transparent;
+  color:inherit;
+  border:1px dashed rgba(255,255,255,.25);
+}
+
+.hint{ margin-top:6px; font-size:12px; color:rgba(255,255,255,.6); }

--- a/apps/webapp/src/components/sheets/TemplateSheet.tsx
+++ b/apps/webapp/src/components/sheets/TemplateSheet.tsx
@@ -1,14 +1,36 @@
 import Sheet from '../Sheet/Sheet';
 import { useCarouselStore } from '@/state/store';
+import type { TemplateStyle } from '@/state/store';
 import '@/styles/photos-sheet.css';
+
+const SOFT_CLASSES = 'soft-pill';
+const ACCENTS = ['#FFFFFF', '#000000', '#3B82F6', '#22C55E', '#F59E0B', '#EF4444', '#8B5CF6', '#F97316'];
+const QUICK_STYLE_GROUPS: [TemplateStyle, string][][] = [
+  [
+    ['original', 'Original'],
+    ['darkFooter', 'Dark footer'],
+    ['lightFooter', 'Light footer'],
+  ],
+  [
+    ['editorial', 'Editorial'],
+    ['minimal', 'Minimal'],
+    ['light', 'Light'],
+    ['focus', 'Focus'],
+    ['quote', 'Quote'],
+  ],
+];
 
 export default function TemplateSheet() {
   const template = useCarouselStore((s) => s.style.template);
+  const templateStyle = useCarouselStore((s) => s.templateStyle);
   const scope = useCarouselStore((s) => s.style.templateScope);
   const setScope = useCarouselStore((s) => s.setTemplateScope);
-  const setPreset = useCarouselStore((s) => s.setTemplatePreset);
+  const setTemplateStyle = useCarouselStore((s) => s.setTemplateStyle);
   const setTemplate = useCarouselStore((s) => s.setTemplate);
-  const setFooterStyle = useCarouselStore((s) => s.setFooterStyle);
+  const textColorMode = useCarouselStore((s) => s.typography.textColorMode);
+  const headingAccent = useCarouselStore((s) => s.typography.headingAccent);
+  const setHeadingAccent = useCarouselStore((s) => s.setHeadingAccent);
+  const setTextColorMode = useCarouselStore((s) => s.setTextColorMode);
   const reset = useCarouselStore((s) => s.resetTemplate);
   const apply = useCarouselStore((s) => s.applyTemplate);
   const close = useCarouselStore((s) => s.closeSheet);
@@ -18,47 +40,23 @@ export default function TemplateSheet() {
     close();
   };
 
-  const presetItems: { key: Exclude<typeof template.preset, 'custom'>; label: string }[] = [
-    { key: 'editorial', label: 'Editorial' },
-    { key: 'minimal', label: 'Minimal' },
-    { key: 'light', label: 'Light' },
-    { key: 'focus', label: 'Focus' },
-    { key: 'quote', label: 'Quote' },
-  ];
-
   return (
     <Sheet title="Template">
       <div className="template-sheet">
-        <div className="actions-row">
-          <button
-            className={`btn-soft${template.footerStyle === 'none' ? ' is-active' : ''}`}
-            onClick={() => setFooterStyle('none', scope)}
-          >
-            Original
-          </button>
-          <button
-            className={`btn-soft${template.footerStyle === 'dark' ? ' is-active' : ''}`}
-            onClick={() => setFooterStyle('dark', scope)}
-          >
-            Dark footer
-          </button>
-          <button
-            className={`btn-soft${template.footerStyle === 'light' ? ' is-active' : ''}`}
-            onClick={() => setFooterStyle('light', scope)}
-          >
-            Light footer
-          </button>
-        </div>
-
-        <div className="section presets">
-          {presetItems.map((p) => (
-            <button
-              key={p.key}
-              className={`preset${template.preset === p.key ? ' is-active' : ''}`}
-              onClick={() => setPreset(p.key)}
-            >
-              {p.label}
-            </button>
+        <div className="template-sheet__quick">
+          {QUICK_STYLE_GROUPS.map((group, idx) => (
+            <div key={idx} className="template-sheet__quick-row">
+              {group.map(([key, label]) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={`${SOFT_CLASSES}${templateStyle === key ? ' is-active' : ''}`}
+                  onClick={() => setTemplateStyle(key)}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
           ))}
         </div>
 
@@ -70,8 +68,8 @@ export default function TemplateSheet() {
                 type="radio"
                 name="textColorMode"
                 value={c}
-                checked={template.textColorMode === c}
-                onChange={() => setTemplate({ textColorMode: c as any })}
+                checked={textColorMode === c}
+                onChange={() => setTextColorMode(c as 'auto' | 'white' | 'black')}
               />
               {c.charAt(0).toUpperCase() + c.slice(1)}
             </label>
@@ -79,20 +77,24 @@ export default function TemplateSheet() {
         </div>
 
         <div className="section">
-          <div>Accent color:</div>
-          <div className="palette">
-            {['#FFFFFF', '#000000', '#2D6CFF', '#FF6B00', '#22C55E', '#E11D48'].map((color) => (
+          <div>Heading color:</div>
+          <div className="swatches">
+            {ACCENTS.map((hex) => (
               <button
-                key={color}
-                style={{ background: color, width: 24, height: 24, borderRadius: 4, marginRight: 4 }}
-                onClick={() => setTemplate({ accent: color })}
+                key={hex}
+                type="button"
+                className={`swatch${headingAccent === hex ? ' is-active' : ''}`}
+                style={{ background: hex }}
+                onClick={() => setHeadingAccent(hex)}
+                aria-label={`Accent ${hex}`}
               />
             ))}
-            <input
-              type="color"
-              value={template.accent}
-              onChange={(e) => setTemplate({ accent: e.target.value })}
-            />
+            <button type="button" className="swatch reset" onClick={() => setHeadingAccent(null)}>
+              Auto
+            </button>
+          </div>
+          <div className="hint">
+            По умолчанию заголовок = цвету текста. Выбор акцента меняет только заголовок.
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- restyle quick template selection as soft pill buttons and add heading accent swatches with reset support
- extend the store with typography settings, template style tracking, and color helper utilities
- update slide card rendering to honor the new heading accent while keeping body text on the base color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c881f57f34832883cdd6af7f44db74