### PR TITLE
Align preview and export rendering

### DIFF
--- a/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
+++ b/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
@@ -1,14 +1,28 @@
-import { Slide } from '@/state/store';
+import { Slide, useCarouselStore } from '@/state/store';
+import { resolveSlideDesign } from '@/styles/theme';
 import { SlideCard } from './SlideCard';
 
 const TARGET_AR = 0.8; // 4:5 — единый для всех
 
 export function PreviewCarousel({ slides }: { slides: Slide[] }) {
+  const baseTemplate = useCarouselStore((s) => s.style.template);
+  const baseLayout = useCarouselStore((s) => s.style.layout);
+  const typographySettings = useCarouselStore((s) => s.typography);
+
   return (
     <div className="carousel">
       {slides.map((s, i) => (
         <div className="slide" key={s.id ?? i}>
-          <SlideCard slide={s} aspect={TARGET_AR} />
+          <SlideCard
+            slide={s}
+            aspect={TARGET_AR}
+            design={resolveSlideDesign({
+              slide: s,
+              baseTemplate,
+              baseLayout,
+              typographySettings,
+            })}
+          />
         </div>
       ))}
     </div>

--- a/apps/webapp/src/features/render/canvas.ts
+++ b/apps/webapp/src/features/render/canvas.ts
@@ -1,67 +1,387 @@
-import { Slide } from '@/state/store';
+import type { LayoutStyle, TemplateConfig } from '@/state/store';
+import { Slide, useCarouselStore } from '@/state/store';
+import { resolveSlideDesign, Theme } from '@/styles/theme';
+import { Typography, typographyToCanvasFont } from '@/styles/typography';
+import { splitEditorialText } from '@/utils/text';
+import { applyEllipsis, layoutParagraph } from '@/utils/textLayout';
 
 export const CANVAS_W = 1080;
 export const CANVAS_H = 1350;
 
-function drawCover(ctx:CanvasRenderingContext2D, img: HTMLImageElement){
-  const cw = CANVAS_W, ch = CANVAS_H;
-  const ir = img.naturalWidth / img.naturalHeight;
-  const cr = cw / ch;
-  let w=0,h=0,x=0,y=0;
-  if (ir > cr) { // слишком широкий
-    h = ch; w = h * ir; x = (cw - w)/2; y = 0;
-  } else {
-    w = cw; h = w / ir; x = 0; y = (ch - h)/2;
-  }
-  ctx.drawImage(img, x, y, w, h);
+type TextLine = {
+  text: string;
+  style: Typography['title'] | Typography['body'];
+  color: string;
+  letterSpacing: number;
+  gapBefore: number;
+};
+
+function roundedRectPath(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  radius: number,
+) {
+  const r = Math.max(0, Math.min(radius, Math.min(width, height) / 2));
+  ctx.beginPath();
+  ctx.moveTo(x + r, y);
+  ctx.lineTo(x + width - r, y);
+  ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+  ctx.lineTo(x + width, y + height - r);
+  ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+  ctx.lineTo(x + r, y + height);
+  ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+  ctx.lineTo(x, y + r);
+  ctx.quadraticCurveTo(x, y, x + r, y);
+  ctx.closePath();
 }
 
-export async function renderSlideToPNG(slide: Slide): Promise<Blob> {
-  const canvas = document.createElement('canvas');
-  canvas.width = CANVAS_W; canvas.height = CANVAS_H;
-  const ctx = canvas.getContext('2d')!;
-  ctx.fillStyle = '#000'; ctx.fillRect(0,0,CANVAS_W,CANVAS_H);
+function drawCover(ctx: CanvasRenderingContext2D, img: HTMLImageElement) {
+  const imageRatio = img.naturalWidth / img.naturalHeight || 1;
+  const canvasRatio = CANVAS_W / CANVAS_H;
 
-  if (slide.image) {
-    await new Promise<void>((res, rej)=>{
-      const img = new Image();
-      img.onload = ()=>{ drawCover(ctx, img); res(); };
-      img.onerror = rej;
-      img.crossOrigin = 'anonymous';
-      img.src = slide.image!;
+  let drawWidth = CANVAS_W;
+  let drawHeight = CANVAS_H;
+  let offsetX = 0;
+  let offsetY = 0;
+
+  if (imageRatio > canvasRatio) {
+    drawHeight = CANVAS_H;
+    drawWidth = drawHeight * imageRatio;
+    offsetX = (CANVAS_W - drawWidth) / 2;
+  } else {
+    drawWidth = CANVAS_W;
+    drawHeight = drawWidth / imageRatio;
+    offsetY = (CANVAS_H - drawHeight) / 2;
+  }
+
+  ctx.drawImage(img, offsetX, offsetY, drawWidth, drawHeight);
+}
+
+function drawFooterGradient(ctx: CanvasRenderingContext2D, theme: Theme) {
+  if (theme.gradient === 'original') return;
+  const heightPct = Math.max(0, Math.min(theme.gradientStops.heightPct, 1));
+  if (!heightPct) return;
+
+  const gradientHeight = CANVAS_H * heightPct;
+  const gradient = ctx.createLinearGradient(0, CANVAS_H, 0, CANVAS_H - gradientHeight);
+  gradient.addColorStop(0, theme.gradientStops.to);
+  gradient.addColorStop(1, theme.gradientStops.from);
+
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, CANVAS_H - gradientHeight, CANVAS_W, gradientHeight);
+}
+
+function drawLine(
+  ctx: CanvasRenderingContext2D,
+  text: string,
+  x: number,
+  y: number,
+  letterSpacing: number,
+) {
+  if (!text) return;
+  if (!letterSpacing) {
+    ctx.fillText(text, x, y);
+    return;
+  }
+
+  const chars = Array.from(text);
+  let cursor = x;
+  for (let i = 0; i < chars.length; i += 1) {
+    const ch = chars[i];
+    ctx.fillText(ch, cursor, y);
+    const advance = ctx.measureText(ch).width;
+    if (i < chars.length - 1) {
+      cursor += advance + letterSpacing;
+    }
+  }
+}
+
+function lineHeightPx(style: Typography['title'] | Typography['body']) {
+  return style.fontSize * style.lineHeight;
+}
+
+function totalHeight(lines: TextLine[]): number {
+  return lines.reduce((sum, line) => sum + line.gapBefore + lineHeightPx(line.style), 0);
+}
+
+function trimLinesToHeight(
+  ctx: CanvasRenderingContext2D,
+  lines: TextLine[],
+  availableHeight: number,
+  maxWidth: number,
+) {
+  let trimmed = false;
+  let height = totalHeight(lines);
+  while (lines.length && height > availableHeight) {
+    lines.pop();
+    trimmed = true;
+    height = totalHeight(lines);
+  }
+
+  if (!lines.length) return;
+
+  if (trimmed) {
+    const last = lines[lines.length - 1];
+    ctx.font = typographyToCanvasFont(last.style);
+    last.text = applyEllipsis(ctx, last.text, maxWidth, last.letterSpacing);
+  }
+}
+
+async function ensureFontsLoaded(typography: Typography) {
+  if (typeof document === 'undefined' || !document.fonts) return;
+  const toLoad = new Set<string>([
+    typographyToCanvasFont(typography.title),
+    typographyToCanvasFont(typography.body),
+  ]);
+
+  const loaders = Array.from(toLoad).map((font) => document.fonts.load(font));
+  await Promise.all(loaders);
+  await document.fonts.ready;
+}
+
+async function loadImage(src: string): Promise<HTMLImageElement> {
+  return await new Promise((resolve, reject) => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(img);
+    img.onerror = reject;
+    img.src = src;
+  });
+}
+
+function drawOverlay(
+  ctx: CanvasRenderingContext2D,
+  slide: Slide,
+  typography: Typography,
+  theme: Theme,
+  layout: LayoutStyle,
+  template: TemplateConfig,
+) {
+  const { title, body } = splitEditorialText(slide.body ?? '');
+
+  const overlayInset = Math.max(theme.padding.x - layout.padding, 0);
+  const overlayWidth = CANVAS_W - overlayInset * 2;
+  const blockWidth = Math.max(0, Math.min(layout.blockWidth, 100));
+  const blockPx = (overlayWidth * blockWidth) / 100;
+  const maxWidth = Math.max(blockPx - layout.padding * 2, 0);
+
+  const contentTop = theme.padding.y;
+  const contentBottom = CANVAS_H - theme.padding.y;
+  const availableHeight = Math.max(contentBottom - contentTop, 0);
+  const canLayout = maxWidth > 0 && availableHeight > 0;
+  const lines: TextLine[] = [];
+
+  if (canLayout && title) {
+    ctx.font = typographyToCanvasFont(typography.title);
+    const titleLines = layoutParagraph(
+      ctx,
+      title,
+      maxWidth,
+      typography.title.lineHeight,
+      typography.title.letterSpacing,
+    );
+    for (const line of titleLines) {
+      lines.push({
+        text: line,
+        style: typography.title,
+        color: theme.titleColor ?? theme.textColor,
+        letterSpacing: typography.title.letterSpacing,
+        gapBefore: 0,
+      });
+    }
+  }
+
+  if (canLayout && body) {
+    ctx.font = typographyToCanvasFont(typography.body);
+    const bodyLines = layoutParagraph(
+      ctx,
+      body,
+      maxWidth,
+      typography.body.lineHeight,
+      typography.body.letterSpacing,
+    );
+    bodyLines.forEach((line, index) => {
+      lines.push({
+        text: line,
+        style: typography.body,
+        color: theme.textColor,
+        letterSpacing: typography.body.letterSpacing,
+        gapBefore: index === 0 && lines.length ? layout.paraGap : 0,
+      });
     });
   }
 
-  if (slide.body) {
-    ctx.font = '48px system-ui, -apple-system, Segoe UI, Roboto, Arial';
-    ctx.fillStyle = '#fff';
-    ctx.shadowColor = 'rgba(0,0,0,.6)';
-    ctx.shadowBlur = 12;
-    const lines = wrap(slide.body, 28);
-    let y = CANVAS_H - 80 - lines.length * 56;
-    lines.forEach(l => { ctx.fillText(l, 64, y); y += 56; });
+  let usedHeight = 0;
+  if (canLayout && lines.length) {
+    trimLinesToHeight(ctx, lines, availableHeight, maxWidth);
+    usedHeight = totalHeight(lines);
+
+    let cursorY = contentBottom - usedHeight;
+    if (cursorY < contentTop) cursorY = contentTop;
+    const textX = theme.padding.x;
+
+    ctx.save();
+    ctx.textAlign = 'left';
+    ctx.textBaseline = 'top';
+    if (theme.shadow) {
+      ctx.shadowColor = theme.shadow.color;
+      ctx.shadowBlur = theme.shadow.blur;
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = theme.shadow.y;
+    } else {
+      ctx.shadowColor = 'transparent';
+      ctx.shadowBlur = 0;
+      ctx.shadowOffsetX = 0;
+      ctx.shadowOffsetY = 0;
+    }
+
+    for (const line of lines) {
+      cursorY += line.gapBefore;
+      ctx.font = typographyToCanvasFont(line.style);
+      ctx.fillStyle = line.color;
+      drawLine(ctx, line.text, textX, cursorY, line.letterSpacing);
+      cursorY += lineHeightPx(line.style);
+    }
+
+    ctx.restore();
   }
 
-  if (slide.nickname) {
-    ctx.font = '32px system-ui, -apple-system, Segoe UI, Roboto, Arial';
-    ctx.fillStyle = 'rgba(255,255,255,.8)';
-    ctx.shadowColor = 'rgba(0,0,0,.6)';
-    ctx.shadowBlur = 8;
-    ctx.fillText(slide.nickname, 64, CANVAS_H - 32);
+  if (slide.nickname && template.showNickname) {
+    drawNickname(
+      ctx,
+      slide.nickname,
+      typography,
+      theme,
+      layout,
+      contentBottom,
+    );
   }
-
-  return await new Promise<Blob>((resolve, reject)=>{
-    canvas.toBlob(b => b ? resolve(b) : reject(new Error('toBlob failed')),'image/png');
-  });
 }
 
-function wrap(text:string, max:number){
-  const w = text.split(/\s+/); const out:string[] = [];
-  let cur:string[] = [];
-  w.forEach(word=>{
-    if ((cur.join(' ').length + word.length + 1) <= max) cur.push(word);
-    else { out.push(cur.join(' ')); cur=[word]; }
+const NICK_FONT_SIZE: Record<LayoutStyle['nickSize'], number> = {
+  s: 12,
+  m: 14,
+  l: 16,
+};
+
+function drawNickname(
+  ctx: CanvasRenderingContext2D,
+  nickname: string,
+  typography: Typography,
+  theme: Theme,
+  layout: LayoutStyle,
+  textBottom: number,
+) {
+  if (!nickname) return;
+
+  const fontSize = NICK_FONT_SIZE[layout.nickSize] ?? 12;
+  const paddingX = fontSize <= 12 ? 12 : 14;
+  const paddingY = 6;
+  const font = `600 ${fontSize}px ${typography.body.fontFamily}`;
+
+  ctx.save();
+  ctx.font = font;
+  ctx.textAlign = 'left';
+  ctx.textBaseline = 'middle';
+
+  const textWidth = ctx.measureText(nickname).width;
+  const width = textWidth + paddingX * 2;
+  const height = fontSize + paddingY * 2;
+
+  const overlayInset = Math.max(theme.padding.x - layout.padding, 0);
+  const overlayWidth = CANVAS_W - overlayInset * 2;
+
+  let x: number;
+  switch (layout.nickPos) {
+    case 'center':
+      x = overlayInset + (overlayWidth - width) / 2;
+      break;
+    case 'right':
+      x = CANVAS_W - overlayInset - width;
+      break;
+    default:
+      x = theme.padding.x;
+      break;
+  }
+  x = Math.max(overlayInset, Math.min(x, CANVAS_W - overlayInset - width));
+
+  const overlayBottom = Math.max(theme.padding.y - layout.padding, 0);
+  const baseY = textBottom + layout.nickOffset;
+  const maxY = CANVAS_H - overlayBottom - height;
+  const y = Math.min(baseY, maxY);
+
+  const opacity = Math.max(0, Math.min(layout.nickOpacity ?? 100, 100)) / 100;
+  const normalizedColor = theme.textColor.trim().toLowerCase();
+  const isDarkText =
+    normalizedColor === '#000000' ||
+    normalizedColor === 'black' ||
+    normalizedColor === 'rgb(0,0,0)';
+  const backgroundAlpha = (isDarkText ? 0.85 : 0.45) * opacity;
+  const strokeAlpha = (isDarkText ? 0.2 : 0.18) * opacity;
+  const background = isDarkText
+    ? `rgba(255,255,255,${backgroundAlpha.toFixed(3)})`
+    : `rgba(0,0,0,${backgroundAlpha.toFixed(3)})`;
+  const stroke = isDarkText
+    ? `rgba(0,0,0,${strokeAlpha.toFixed(3)})`
+    : `rgba(255,255,255,${strokeAlpha.toFixed(3)})`;
+  const radius = Math.min(layout.nickRadius ?? height / 2, height / 2);
+
+  ctx.shadowColor = 'transparent';
+  ctx.lineWidth = 1;
+  ctx.fillStyle = background;
+  ctx.strokeStyle = stroke;
+
+  roundedRectPath(ctx, x, y, width, height, radius);
+  ctx.fill();
+  if (strokeAlpha > 0) ctx.stroke();
+
+  ctx.fillStyle = theme.textColor;
+  ctx.fillText(nickname, x + paddingX, y + height / 2);
+
+  ctx.restore();
+}
+
+export async function renderSlideToPNG(slide: Slide): Promise<Blob> {
+  const state = useCarouselStore.getState();
+  const design = resolveSlideDesign({
+    slide,
+    baseTemplate: state.style.template,
+    baseLayout: state.style.layout,
+    typographySettings: state.typography,
   });
-  if (cur.length) out.push(cur.join(' '));
-  return out.slice(0, 10);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = CANVAS_W;
+  canvas.height = CANVAS_H;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('Canvas 2D context not available');
+
+  const imagePromise = slide.image ? loadImage(slide.image) : Promise.resolve<HTMLImageElement | null>(null);
+  await ensureFontsLoaded(design.typography);
+  const image = await imagePromise;
+
+  ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+  ctx.save();
+  roundedRectPath(ctx, 0, 0, CANVAS_W, CANVAS_H, design.theme.radius);
+  ctx.clip();
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  if (image) {
+    drawCover(ctx, image);
+  }
+
+  drawFooterGradient(ctx, design.theme);
+  drawOverlay(ctx, slide, design.typography, design.theme, design.layout, design.template);
+  ctx.restore();
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error('Canvas toBlob failed'));
+    }, 'image/png');
+  });
 }

--- a/apps/webapp/src/styles/theme.ts
+++ b/apps/webapp/src/styles/theme.ts
@@ -1,0 +1,105 @@
+import type {
+  LayoutStyle,
+  Slide,
+  TemplateConfig,
+  TypographySettings,
+} from '@/state/store';
+import { getBaseTextColor, getHeadingColor } from '@/state/store';
+import { createTypography, Typography } from './typography';
+
+export type Theme = {
+  textColor: string;
+  titleColor?: string | null;
+  padding: { x: number; y: number };
+  radius: number;
+  gradient: 'original' | 'darkFooter' | 'lightFooter';
+  gradientStops: { from: string; to: string; heightPct: number };
+  shadow?: { blur: number; color: string; y: number };
+};
+
+export type SlideDesign = {
+  template: TemplateConfig;
+  layout: LayoutStyle;
+  typography: Typography;
+  theme: Theme;
+};
+
+const DEFAULT_RADIUS = 16;
+const OVERLAY_GUTTER = 12;
+
+const TEXT_SHADOW_MAP: Record<number, Theme['shadow'] | undefined> = {
+  0: undefined,
+  1: { blur: 12, color: 'rgba(0,0,0,0.45)', y: 2 },
+  2: { blur: 18, color: 'rgba(0,0,0,0.55)', y: 4 },
+  3: { blur: 24, color: 'rgba(0,0,0,0.65)', y: 6 },
+};
+
+const GRADIENT_COLORS: Record<Theme['gradient'], { from: string; to: string }> = {
+  original: { from: 'rgba(0,0,0,0)', to: 'rgba(0,0,0,0)' },
+  darkFooter: { from: 'rgba(0,0,0,0)', to: 'rgba(0,0,0,0.7)' },
+  lightFooter: { from: 'rgba(255,255,255,0)', to: 'rgba(255,255,255,0.7)' },
+};
+
+function clampHeight(value: number) {
+  return Math.max(0, Math.min(value, 100)) / 100;
+}
+
+export function createTheme(
+  slide: Slide,
+  template: TemplateConfig,
+  layout: LayoutStyle,
+  typographySettings: TypographySettings,
+): Theme {
+  const mode = typographySettings.textColorMode ?? template.textColorMode;
+  const bgTone =
+    slide.runtime?.bgTone ?? (mode === 'black' ? 'light' : mode === 'white' ? 'dark' : 'dark');
+  const baseColor = getBaseTextColor(bgTone, mode);
+  const headingAccent = typographySettings.headingAccent;
+  const gradient: Theme['gradient'] =
+    template.footerStyle === 'dark'
+      ? 'darkFooter'
+      : template.footerStyle === 'light'
+      ? 'lightFooter'
+      : 'original';
+  const gradientStops = GRADIENT_COLORS[gradient];
+  const heightPct = gradient === 'original' ? 0 : clampHeight(template.bottomGradient);
+
+  return {
+    textColor: baseColor,
+    titleColor: headingAccent ? getHeadingColor(bgTone, mode, headingAccent) : null,
+    padding: {
+      x: OVERLAY_GUTTER + layout.padding,
+      y: OVERLAY_GUTTER + layout.padding,
+    },
+    radius: DEFAULT_RADIUS,
+    gradient,
+    gradientStops: {
+      from: gradientStops.from,
+      to: gradientStops.to,
+      heightPct,
+    },
+    shadow: TEXT_SHADOW_MAP[template.textShadow] ?? undefined,
+  };
+}
+
+function mergeTemplate(base: TemplateConfig, override?: TemplateConfig): TemplateConfig {
+  return override ? { ...base, ...override } : { ...base };
+}
+
+function mergeLayout(base: LayoutStyle, override?: LayoutStyle): LayoutStyle {
+  return override ? { ...base, ...override } : { ...base };
+}
+
+export function resolveSlideDesign(params: {
+  slide: Slide;
+  baseTemplate: TemplateConfig;
+  baseLayout: LayoutStyle;
+  typographySettings: TypographySettings;
+}): SlideDesign {
+  const template = mergeTemplate(params.baseTemplate, params.slide.overrides?.template);
+  const layout = mergeLayout(params.baseLayout, params.slide.overrides?.layout);
+  const typography = createTypography(template, layout);
+  const theme = createTheme(params.slide, template, layout, params.typographySettings);
+
+  return { template, layout, typography, theme };
+}

--- a/apps/webapp/src/styles/typography.ts
+++ b/apps/webapp/src/styles/typography.ts
@@ -1,0 +1,72 @@
+import type { LayoutStyle, TemplateConfig } from '@/state/store';
+
+export type Typography = {
+  title: {
+    fontFamily: string;
+    fontWeight: number;
+    fontSize: number;
+    lineHeight: number;
+    letterSpacing: number;
+  };
+  body: {
+    fontFamily: string;
+    fontWeight: number;
+    fontSize: number;
+    lineHeight: number;
+    letterSpacing: number;
+  };
+};
+
+const FALLBACK_STACK = '"Inter", "SF Pro Text", Arial, sans-serif';
+
+const FONT_STACK: Record<TemplateConfig['font'], string> = {
+  system: `-apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Inter, Arial, sans-serif`,
+  inter: `"Inter", "SF Pro Text", Arial, sans-serif`,
+  playfair: `"Playfair Display", "Times New Roman", Times, serif, ${FALLBACK_STACK}`,
+  bodoni: `"Bodoni Moda", "Didot", "Bodoni 72", serif, ${FALLBACK_STACK}`,
+  dmsans: `"DM Sans", ${FALLBACK_STACK}`,
+};
+
+function getFontFamily(font: TemplateConfig['font']): string {
+  const stack = FONT_STACK[font];
+  return stack ?? FALLBACK_STACK;
+}
+
+function computeTitleSize(layout: LayoutStyle): { fontSize: number; lineHeight: number } {
+  const fontSize = Math.round(layout.fontSize * 1.35);
+  const lineHeight = (layout.lineHeight * 1.2) / 1.3;
+  return { fontSize, lineHeight };
+}
+
+function computeBodySize(layout: LayoutStyle): { fontSize: number; lineHeight: number } {
+  const fontSize = Math.round(layout.fontSize * 0.9);
+  const lineHeight = (layout.lineHeight * 1.35) / 1.3;
+  return { fontSize, lineHeight };
+}
+
+export function createTypography(template: TemplateConfig, layout: LayoutStyle): Typography {
+  const family = getFontFamily(template.font);
+  const titleSize = computeTitleSize(layout);
+  const bodySize = computeBodySize(layout);
+
+  return {
+    title: {
+      fontFamily: family,
+      fontWeight: 700,
+      fontSize: titleSize.fontSize,
+      lineHeight: Number(titleSize.lineHeight.toFixed(3)),
+      letterSpacing: 0,
+    },
+    body: {
+      fontFamily: family,
+      fontWeight: 400,
+      fontSize: bodySize.fontSize,
+      lineHeight: Number(bodySize.lineHeight.toFixed(3)),
+      letterSpacing: 0,
+    },
+  };
+}
+
+export function typographyToCanvasFont(style: Typography['title'] | Typography['body']): string {
+  return `${style.fontWeight} ${style.fontSize}px ${style.fontFamily}`;
+}

--- a/apps/webapp/src/utils/text.ts
+++ b/apps/webapp/src/utils/text.ts
@@ -1,0 +1,23 @@
+export function splitEditorialText(text: string): { title: string; body: string } {
+  const trimmed = text.trim();
+  if (!trimmed) return { title: '', body: '' };
+
+  const sentenceMatch = trimmed.match(/[.!?…](?:\s|\n)/);
+  if (sentenceMatch && sentenceMatch.index !== undefined) {
+    const idx = sentenceMatch.index + 1;
+    return {
+      title: trimmed.slice(0, idx).trim(),
+      body: trimmed.slice(idx).trim(),
+    };
+  }
+
+  const newlineIndex = trimmed.indexOf('\n');
+  if (newlineIndex !== -1) {
+    return {
+      title: trimmed.slice(0, newlineIndex).trim(),
+      body: trimmed.slice(newlineIndex + 1).trim(),
+    };
+  }
+
+  return { title: trimmed, body: '' };
+}

--- a/apps/webapp/src/utils/textLayout.ts
+++ b/apps/webapp/src/utils/textLayout.ts
@@ -1,0 +1,127 @@
+export type CanvasTextContext = Pick<CanvasRenderingContext2D, 'measureText'>;
+
+export function measureWithLetterSpacing(
+  ctx: CanvasTextContext,
+  text: string,
+  letterSpacing: number,
+): number {
+  if (!text) return 0;
+  const base = ctx.measureText(text).width;
+  const extra = letterSpacing * Math.max(0, text.length - 1);
+  return base + extra;
+}
+
+function breakLongWord(
+  ctx: CanvasTextContext,
+  word: string,
+  maxWidth: number,
+  letterSpacing: number,
+  hyphenation: boolean,
+): string[] {
+  if (!word.length || maxWidth <= 0) return [];
+  const segments: string[] = [];
+  let current = '';
+  const chars = Array.from(word);
+
+  for (let i = 0; i < chars.length; i += 1) {
+    const ch = chars[i];
+    const next = current + ch;
+    if (measureWithLetterSpacing(ctx, next, letterSpacing) <= maxWidth) {
+      current = next;
+      continue;
+    }
+
+    if (current) {
+      if (hyphenation && measureWithLetterSpacing(ctx, `${current}-`, letterSpacing) <= maxWidth) {
+        segments.push(`${current}-`);
+      } else {
+        segments.push(current);
+      }
+      current = ch;
+    } else {
+      segments.push(ch);
+      current = '';
+    }
+  }
+
+  if (current) segments.push(current);
+
+  if (hyphenation && segments.length > 1) {
+    const lastIndex = segments.length - 1;
+    return segments.map((segment, index) =>
+      index === lastIndex || segment.endsWith('-') ? segment : `${segment}-`,
+    );
+  }
+
+  return segments;
+}
+
+export function layoutParagraph(
+  ctx: CanvasTextContext,
+  text: string,
+  maxWidth: number,
+  _lineHeight: number,
+  letterSpacing: number,
+  hyphenation = false,
+): string[] {
+  if (!text || maxWidth <= 0) return [];
+  const clean = text.replace(/\r/g, '').trim();
+  if (!clean) return [];
+
+  const words = clean.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word;
+    if (measureWithLetterSpacing(ctx, candidate, letterSpacing) <= maxWidth) {
+      current = candidate;
+      continue;
+    }
+
+    if (current) {
+      lines.push(current);
+      current = '';
+    }
+
+    if (measureWithLetterSpacing(ctx, word, letterSpacing) <= maxWidth) {
+      current = word;
+    } else {
+      const parts = breakLongWord(ctx, word, maxWidth, letterSpacing, hyphenation);
+      if (parts.length) {
+        const last = parts.pop()!;
+        lines.push(...parts);
+        current = last;
+      } else {
+        current = word;
+      }
+    }
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+export function applyEllipsis(
+  ctx: CanvasTextContext,
+  text: string,
+  maxWidth: number,
+  letterSpacing: number,
+): string {
+  const ellipsis = '…';
+  if (!text) return ellipsis;
+  if (measureWithLetterSpacing(ctx, `${text}${ellipsis}`, letterSpacing) <= maxWidth) {
+    return `${text}${ellipsis}`;
+  }
+
+  const chars = Array.from(text);
+  for (let i = chars.length - 1; i >= 0; i -= 1) {
+    const candidate = chars.slice(0, i).join('');
+    if (!candidate) break;
+    if (measureWithLetterSpacing(ctx, `${candidate}${ellipsis}`, letterSpacing) <= maxWidth) {
+      return `${candidate}${ellipsis}`;
+    }
+  }
+
+  return ellipsis;
+}


### PR DESCRIPTION
## Summary
- add shared typography and theme modules so preview and export share style tokens
- update the preview carousel to pass resolved slide design into slide cards
- rewrite the canvas renderer to load fonts, mirror layout, gradients, and nickname styling from the shared theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c893ca8678832896b3e7d28be2a673