### PR TITLE
Restore large typography tokens and container scaling

### DIFF
--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -98,8 +98,8 @@
 .overlay.editorial .title{
   font-family: var(--font-inter, var(--font-system));
   font-weight: 700;
-  font-size: 24px;
-  line-height: 1.2;
+  font-size: 48px;
+  line-height: 1.15;
   letter-spacing: 0;
   color:#fff;
   text-shadow: 0 1px 2px rgba(0,0,0,.48);
@@ -109,8 +109,8 @@
   margin-top: 6px;
   font-family: var(--font-inter, var(--font-system));
   font-weight: 400;
-  font-size: 16px;
-  line-height: 1.35;
+  font-size: 28px;
+  line-height: 1.25;
   color:#fff;
   text-shadow: 0 1px 2px rgba(0,0,0,.48);
 }

--- a/apps/webapp/src/components/sheets/LayoutSheet.tsx
+++ b/apps/webapp/src/components/sheets/LayoutSheet.tsx
@@ -75,8 +75,8 @@ export default function LayoutSheet() {
             Font size
             <input
               type="range"
-              min={14}
-              max={26}
+              min={20}
+              max={40}
               step={1}
               value={layout.fontSize}
               onChange={(e) => setLayout({ fontSize: Number(e.target.value) })}

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -298,8 +298,8 @@ const defaultLayout: LayoutStyle = {
   vPos: 'bottom',
   vOffset: 0,
   hAlign: 'left',
-  fontSize: 18,
-  lineHeight: 1.3,
+  fontSize: 28,
+  lineHeight: 1.25,
   blockWidth: 88,
   padding: 10,
 

--- a/apps/webapp/src/styles/typography.ts
+++ b/apps/webapp/src/styles/typography.ts
@@ -27,20 +27,38 @@ const FONT_STACK: Record<TemplateConfig['font'], string> = {
   dmsans: `"DM Sans", ${FALLBACK_STACK}`,
 };
 
+const BODY_FONT_SIZE_BASE = 28;
+const BODY_LINE_HEIGHT_BASE = 1.25;
+const TITLE_FONT_SIZE_BASE = 48;
+const TITLE_LINE_HEIGHT_BASE = 1.15;
+
+const TITLE_FONT_SCALE = TITLE_FONT_SIZE_BASE / BODY_FONT_SIZE_BASE;
+const TITLE_LINE_SCALE = TITLE_LINE_HEIGHT_BASE / BODY_LINE_HEIGHT_BASE;
+
 function getFontFamily(font: TemplateConfig['font']): string {
   const stack = FONT_STACK[font];
   return stack ?? FALLBACK_STACK;
 }
 
+function normalizeFontSize(value: number): number {
+  return value > 0 ? value : BODY_FONT_SIZE_BASE;
+}
+
+function normalizeLineHeight(value: number): number {
+  return value > 0 ? value : BODY_LINE_HEIGHT_BASE;
+}
+
 function computeTitleSize(layout: LayoutStyle): { fontSize: number; lineHeight: number } {
-  const fontSize = Math.round(layout.fontSize * 1.35);
-  const lineHeight = (layout.lineHeight * 1.2) / 1.3;
+  const bodyFontSize = normalizeFontSize(layout.fontSize);
+  const bodyLineHeight = normalizeLineHeight(layout.lineHeight);
+  const fontSize = Number((bodyFontSize * TITLE_FONT_SCALE).toFixed(3));
+  const lineHeight = Number((bodyLineHeight * TITLE_LINE_SCALE).toFixed(3));
   return { fontSize, lineHeight };
 }
 
 function computeBodySize(layout: LayoutStyle): { fontSize: number; lineHeight: number } {
-  const fontSize = Math.round(layout.fontSize * 0.9);
-  const lineHeight = (layout.lineHeight * 1.35) / 1.3;
+  const fontSize = Number(normalizeFontSize(layout.fontSize).toFixed(3));
+  const lineHeight = Number(normalizeLineHeight(layout.lineHeight).toFixed(3));
   return { fontSize, lineHeight };
 }
 
@@ -54,14 +72,14 @@ export function createTypography(template: TemplateConfig, layout: LayoutStyle):
       fontFamily: family,
       fontWeight: 700,
       fontSize: titleSize.fontSize,
-      lineHeight: Number(titleSize.lineHeight.toFixed(3)),
+      lineHeight: titleSize.lineHeight,
       letterSpacing: 0,
     },
     body: {
       fontFamily: family,
       fontWeight: 400,
       fontSize: bodySize.fontSize,
-      lineHeight: Number(bodySize.lineHeight.toFixed(3)),
+      lineHeight: bodySize.lineHeight,
       letterSpacing: 0,
     },
   };


### PR DESCRIPTION
## Summary
- restore the typography token generator to use the large base sizes (48px title / 28px body) so preview and export share the same values
- bump the default layout font metrics and editor slider range to align with the new token scale
- update the carousel fallback CSS to mirror the refreshed typography tokens

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9351713a48328b23483b228927a88