### PR TITLE
feat: live layout preview with shared engine

### DIFF
--- a/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
+++ b/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
@@ -1,11 +1,27 @@
-import { Slide, useCarouselStore } from '@/state/store';
+import { Slide, useCarouselStore, useLayoutSelector } from '@/state/store';
 import { resolveSlideDesign } from '@/styles/theme';
 import { SlideCard } from './SlideCard';
 
 export function PreviewCarousel({ slides }: { slides: Slide[] }) {
   const baseTemplate = useCarouselStore((s) => s.style.template);
-  const baseLayout = useCarouselStore((s) => s.style.layout);
   const typographySettings = useCarouselStore((s) => s.typography);
+  const layout = useLayoutSelector((state) => ({
+    vertical: state.vertical,
+    vOffset: state.vOffset,
+    horizontal: state.horizontal,
+    useSafeArea: state.useSafeArea,
+    blockWidth: state.blockWidth,
+    padding: state.padding,
+    maxLines: state.maxLines,
+    overflow: state.overflow,
+    paragraphGap: state.paragraphGap,
+    cornerRadius: state.cornerRadius,
+    fontSize: state.fontSize,
+    lineHeight: state.lineHeight,
+    nickname: state.nickname,
+    textShadow: state.textShadow,
+    gradientIntensity: state.gradientIntensity,
+  }));
 
   return (
     <div className="carousel">
@@ -16,9 +32,10 @@ export function PreviewCarousel({ slides }: { slides: Slide[] }) {
             design={resolveSlideDesign({
               slide: s,
               baseTemplate,
-              baseLayout,
+              baseLayout: layout,
               typographySettings,
             })}
+            safeAreaEnabled={layout.useSafeArea}
           />
         </div>
       ))}

--- a/apps/webapp/src/styles/typography.ts
+++ b/apps/webapp/src/styles/typography.ts
@@ -1,4 +1,4 @@
-import type { LayoutStyle, TemplateConfig } from '@/state/store';
+import type { LayoutConfig, TemplateConfig } from '@/state/store';
 
 export type Typography = {
   title: {
@@ -48,7 +48,7 @@ function normalizeLineHeight(value: number): number {
   return value > 0 ? value : BODY_LINE_HEIGHT_BASE;
 }
 
-function computeTitleSize(layout: LayoutStyle): { fontSize: number; lineHeight: number } {
+function computeTitleSize(layout: LayoutConfig): { fontSize: number; lineHeight: number } {
   const bodyFontSize = normalizeFontSize(layout.fontSize);
   const bodyLineHeight = normalizeLineHeight(layout.lineHeight);
   const fontSize = Number((bodyFontSize * TITLE_FONT_SCALE).toFixed(3));
@@ -56,13 +56,13 @@ function computeTitleSize(layout: LayoutStyle): { fontSize: number; lineHeight: 
   return { fontSize, lineHeight };
 }
 
-function computeBodySize(layout: LayoutStyle): { fontSize: number; lineHeight: number } {
+function computeBodySize(layout: LayoutConfig): { fontSize: number; lineHeight: number } {
   const fontSize = Number(normalizeFontSize(layout.fontSize).toFixed(3));
   const lineHeight = Number(normalizeLineHeight(layout.lineHeight).toFixed(3));
   return { fontSize, lineHeight };
 }
 
-export function createTypography(template: TemplateConfig, layout: LayoutStyle): Typography {
+export function createTypography(template: TemplateConfig, layout: LayoutConfig): Typography {
   const family = getFontFamily(template.font);
   const titleSize = computeTitleSize(layout);
   const bodySize = computeBodySize(layout);

--- a/apps/webapp/src/utils/debounce.ts
+++ b/apps/webapp/src/utils/debounce.ts
@@ -1,0 +1,13 @@
+export function debounce<T extends (...args: any[]) => void>(fn: T, wait = 16) {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
+  return (...args: Parameters<T>) => {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+    timeout = setTimeout(() => {
+      timeout = undefined;
+      fn(...args);
+    }, wait);
+  };
+}

--- a/apps/webapp/src/utils/layoutGeometry.ts
+++ b/apps/webapp/src/utils/layoutGeometry.ts
@@ -1,0 +1,53 @@
+import type { LayoutConfig } from '@/state/store';
+
+export function resolveBlockWidth(
+  containerWidth: number,
+  layout: LayoutConfig,
+): { blockWidth: number; textWidth: number } {
+  const raw = layout.blockWidth > 0 ? layout.blockWidth : containerWidth;
+  const clamped = Math.min(Math.max(raw, 0), containerWidth);
+  const blockWidth = Math.max(clamped, layout.padding * 2);
+  const textWidth = Math.max(0, blockWidth - layout.padding * 2);
+  return { blockWidth, textWidth };
+}
+
+export function resolveBlockPosition(
+  containerWidth: number,
+  containerHeight: number,
+  layout: LayoutConfig,
+  blockWidth: number,
+  blockHeight: number,
+): { x: number; y: number } {
+  let x: number;
+  switch (layout.horizontal) {
+    case 'center':
+      x = (containerWidth - blockWidth) / 2;
+      break;
+    case 'right':
+      x = containerWidth - blockWidth;
+      break;
+    default:
+      x = 0;
+      break;
+  }
+
+  let y: number;
+  switch (layout.vertical) {
+    case 'top':
+      y = layout.vOffset;
+      break;
+    case 'middle':
+      y = (containerHeight - blockHeight) / 2 + layout.vOffset;
+      break;
+    default:
+      y = containerHeight - blockHeight + layout.vOffset;
+      break;
+  }
+
+  const maxX = containerWidth - blockWidth;
+  const maxY = containerHeight - blockHeight;
+  return {
+    x: Math.max(0, Math.min(x, maxX)),
+    y: Math.max(0, Math.min(y, maxY)),
+  };
+}

--- a/apps/webapp/src/utils/textLayout.ts
+++ b/apps/webapp/src/utils/textLayout.ts
@@ -1,3 +1,6 @@
+import type { Typography } from '@/styles/typography';
+import { typographyToCanvasFont } from '@/styles/typography';
+
 export type CanvasTextContext = Pick<CanvasRenderingContext2D, 'measureText'>;
 
 export function measureWithLetterSpacing(
@@ -124,4 +127,171 @@ export function applyEllipsis(
   }
 
   return ellipsis;
+}
+
+export type LineMetrics = {
+  ascent: number;
+  descent: number;
+  lineHeight: number;
+  baselineOffset: number;
+};
+
+const METRIC_SAMPLE = 'Mg';
+
+const metricsCache = new WeakMap<Typography['title'] | Typography['body'], LineMetrics>();
+
+export function lineHeightPx(style: Typography['title'] | Typography['body']) {
+  return style.fontSize * style.lineHeight;
+}
+
+export function getLineMetrics(
+  ctx: CanvasRenderingContext2D,
+  style: Typography['title'] | Typography['body'],
+): LineMetrics {
+  const cached = metricsCache.get(style);
+  if (cached) return cached;
+
+  const previousFont = ctx.font;
+  ctx.font = typographyToCanvasFont(style);
+  const measurement = ctx.measureText(METRIC_SAMPLE);
+  ctx.font = previousFont;
+
+  const ascent = measurement.actualBoundingBoxAscent ?? style.fontSize * 0.8;
+  const descent = measurement.actualBoundingBoxDescent ?? style.fontSize * 0.2;
+  const naturalHeight = ascent + descent;
+  const fullLineHeight = lineHeightPx(style);
+  const leading = Math.max(0, fullLineHeight - naturalHeight);
+  const baselineOffset = leading / 2 + ascent;
+
+  const metrics: LineMetrics = {
+    ascent,
+    descent,
+    lineHeight: fullLineHeight,
+    baselineOffset,
+  };
+
+  metricsCache.set(style, metrics);
+  return metrics;
+}
+
+export type ComposedLine = {
+  text: string;
+  type: 'title' | 'body';
+  style: Typography['title'] | Typography['body'];
+  color: string;
+  letterSpacing: number;
+  gapBefore: number;
+  metrics: LineMetrics;
+};
+
+export type TextComposition = {
+  lines: ComposedLine[];
+  contentHeight: number;
+  truncated: boolean;
+  fadeMaskStart?: number;
+};
+
+export function composeTextLines(params: {
+  ctx: CanvasRenderingContext2D;
+  maxWidth: number;
+  title: string;
+  body: string;
+  typography: Typography;
+  colors: { title: string; body: string };
+  paragraphGap: number;
+  overflow: 'wrap' | 'fade';
+  maxLines: number;
+}): TextComposition {
+  const {
+    ctx,
+    maxWidth,
+    title,
+    body,
+    typography,
+    colors,
+    paragraphGap,
+    overflow,
+    maxLines,
+  } = params;
+
+  const lines: Array<{
+    text: string;
+    type: 'title' | 'body';
+    style: Typography['title'] | Typography['body'];
+    color: string;
+    letterSpacing: number;
+    gapBefore: number;
+  }> = [];
+
+  if (title) {
+    ctx.font = typographyToCanvasFont(typography.title);
+    const titleLines = layoutParagraph(
+      ctx,
+      title,
+      maxWidth,
+      typography.title.lineHeight,
+      typography.title.letterSpacing,
+    );
+    for (const text of titleLines) {
+      lines.push({
+        text,
+        type: 'title',
+        style: typography.title,
+        color: colors.title,
+        letterSpacing: typography.title.letterSpacing,
+        gapBefore: 0,
+      });
+    }
+  }
+
+  if (body) {
+    ctx.font = typographyToCanvasFont(typography.body);
+    const bodyLines = layoutParagraph(
+      ctx,
+      body,
+      maxWidth,
+      typography.body.lineHeight,
+      typography.body.letterSpacing,
+    );
+    bodyLines.forEach((text, index) => {
+      lines.push({
+        text,
+        type: 'body',
+        style: typography.body,
+        color: colors.body,
+        letterSpacing: typography.body.letterSpacing,
+        gapBefore: index === 0 && lines.length ? paragraphGap : 0,
+      });
+    });
+  }
+
+  if (!lines.length) {
+    return { lines: [], contentHeight: 0, truncated: false };
+  }
+
+  const limit = maxLines > 0 ? Math.max(0, Math.min(maxLines, lines.length)) : lines.length;
+  const truncated = lines.length > limit;
+  const visible = lines.slice(0, limit);
+
+  if (truncated && overflow === 'wrap' && visible.length) {
+    const last = visible[visible.length - 1];
+    ctx.font = typographyToCanvasFont(last.style);
+    last.text = applyEllipsis(ctx, last.text, maxWidth, last.letterSpacing);
+  }
+
+  let contentHeight = 0;
+  const composed: ComposedLine[] = visible.map((line) => {
+    const metrics = getLineMetrics(ctx, line.style);
+    contentHeight += line.gapBefore + metrics.lineHeight;
+    return { ...line, metrics };
+  });
+
+  let fadeMaskStart: number | undefined;
+  if (truncated && overflow === 'fade' && composed.length && contentHeight > 0) {
+    const last = composed[composed.length - 1];
+    const fadeHeight = Math.min(last.metrics.lineHeight * 1.4, contentHeight);
+    fadeMaskStart = Math.max(0, (contentHeight - fadeHeight) / contentHeight);
+  }
+
+  return { lines: composed, contentHeight, truncated, fadeMaskStart };
 }


### PR DESCRIPTION
## Summary
- add a persisted layout store slice with normalized config, selectors and reset utilities
- rebuild the layout sheet UI to read/write the new store with debounced sliders, live safe-area toggle, and nickname controls
- refactor preview rendering to use shared text composition helpers, safe-area guides, and layout geometry so carousel cards update instantly
- update the canvas exporter and theme/typography helpers to consume the shared layout config for 1:1 export and preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9cb5a4afc83289c4d73ddb649585f