### PR TITLE
Implement collage UX v2 improvements

### DIFF
--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -87,6 +87,22 @@
 .collage-slot.is-empty{ background:rgba(0,0,0,.08); color:rgba(255,255,255,.65); }
 .collage-slot__placeholder{ pointer-events:none; padding:12px; text-align:center; }
 .collage-divider{ position:absolute; left:0; width:100%; pointer-events:none; }
+.collage-tag{
+  position:absolute;
+  top:12px;
+  left:12px;
+  padding:6px 10px;
+  border-radius:999px;
+  background:color-mix(in srgb, #000 55%, transparent);
+  border:1px solid rgba(255,255,255,.28);
+  color:#fff;
+  font-size:12px;
+  font-weight:700;
+  letter-spacing:0.02em;
+  text-transform:uppercase;
+  pointer-events:none;
+  backdrop-filter:blur(6px);
+}
 
 .overlay{
   position:absolute; inset:auto 12px 12px 12px; display:flex; flex-direction:column; gap:8px;

--- a/apps/webapp/src/components/collage/CollageCropModal.tsx
+++ b/apps/webapp/src/components/collage/CollageCropModal.tsx
@@ -1,0 +1,426 @@
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useCallback,
+  useLayoutEffect,
+  type PointerEvent as ReactPointerEvent,
+  type MouseEvent as ReactMouseEvent,
+  type WheelEvent as ReactWheelEvent,
+} from 'react';
+import type { PhotoTransform } from '@/state/store';
+import { createDefaultTransform } from '@/state/store';
+import type { CollageBox } from '@/utils/collage';
+import { CollageSlotImage } from './CollageSlotImage';
+
+type Point = { x: number; y: number };
+
+const SCALE_MAX = 3;
+
+type Props = {
+  open: boolean;
+  slot: 'top' | 'bottom';
+  photoSrc: string;
+  transform: PhotoTransform;
+  box: CollageBox;
+  onClose: () => void;
+  onSave: (transform: PhotoTransform) => void;
+};
+
+type GestureState =
+  | { mode: 'none' }
+  | { mode: 'pan'; pointerId: number; start: Point; base: PhotoTransform }
+  | {
+      mode: 'pinch';
+      pointers: [number, number];
+      start: { center: Point; distance: number; base: PhotoTransform };
+    };
+
+export function CollageCropModal({
+  open,
+  slot,
+  photoSrc,
+  transform,
+  box,
+  onClose,
+  onSave,
+}: Props) {
+  const [current, setCurrent] = useState<PhotoTransform>(transform);
+  const transformRef = useRef(transform);
+  const [imageSize, setImageSize] = useState<{ width: number; height: number } | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const surfaceRef = useRef<HTMLDivElement>(null);
+  const pointerPositions = useRef(
+    new Map<number, { start: Point; point: Point }>(),
+  );
+  const gestureRef = useRef<GestureState>({ mode: 'none' });
+  const [surfaceScale, setSurfaceScale] = useState(1);
+
+  useEffect(() => {
+    if (open) {
+      setCurrent(transform);
+      transformRef.current = transform;
+    }
+  }, [open, transform]);
+
+  useEffect(() => {
+    setImageSize(null);
+  }, [photoSrc]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open, onClose]);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    const element = wrapperRef.current;
+    if (!element) return;
+    const updateScale = () => {
+      const rect = element.getBoundingClientRect();
+      if (!rect.width || !rect.height) return;
+      const scale = Math.min(rect.width / box.width, rect.height / box.height);
+      setSurfaceScale(scale > 0 ? scale : 1);
+    };
+    updateScale();
+    const observer = new ResizeObserver(updateScale);
+    observer.observe(element);
+    window.addEventListener('resize', updateScale);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateScale);
+    };
+  }, [open, box.width, box.height]);
+
+  const baseScale = useMemo(() => {
+    if (!imageSize) return 1;
+    return Math.max(box.width / imageSize.width, box.height / imageSize.height);
+  }, [imageSize, box.width, box.height]);
+
+  const clampScale = useCallback((value: number) => {
+    if (Number.isNaN(value)) return 1;
+    return Math.min(Math.max(value, 1), SCALE_MAX);
+  }, []);
+
+  const clampTransform = useCallback(
+    (value: PhotoTransform): PhotoTransform => {
+      if (!imageSize) {
+        return {
+          scale: clampScale(value.scale),
+          offsetX: value.offsetX,
+          offsetY: value.offsetY,
+        };
+      }
+      const scale = clampScale(value.scale);
+      const drawWidth = imageSize.width * baseScale * scale;
+      const drawHeight = imageSize.height * baseScale * scale;
+      const minX = box.width - drawWidth;
+      const minY = box.height - drawHeight;
+      return {
+        scale,
+        offsetX: Math.min(Math.max(value.offsetX, minX), 0),
+        offsetY: Math.min(Math.max(value.offsetY, minY), 0),
+      };
+    },
+    [baseScale, box.height, box.width, clampScale, imageSize],
+  );
+
+  const applyTransform = useCallback(
+    (value: PhotoTransform) => {
+      const next = clampTransform(value);
+      setCurrent(next);
+      transformRef.current = next;
+    },
+    [clampTransform],
+  );
+
+  const applyPan = useCallback(
+    (base: PhotoTransform, delta: Point) => {
+      applyTransform({
+        scale: base.scale,
+        offsetX: base.offsetX + delta.x,
+        offsetY: base.offsetY + delta.y,
+      });
+    },
+    [applyTransform],
+  );
+
+  const applyScaleFromBase = useCallback(
+    (base: PhotoTransform, targetScale: number, baseCenter: Point, nextCenter: Point) => {
+      const scale = clampScale(targetScale);
+      if (!imageSize) {
+        applyTransform({ ...base, scale });
+        return;
+      }
+
+      const baseAbsScale = baseScale * base.scale;
+      const newAbsScale = baseScale * scale;
+      const baseDrawWidth = imageSize.width * baseAbsScale;
+      const baseDrawHeight = imageSize.height * baseAbsScale;
+      const baseLeft = (box.width - baseDrawWidth) / 2 + base.offsetX;
+      const baseTop = (box.height - baseDrawHeight) / 2 + base.offsetY;
+      const imgX = (baseCenter.x - baseLeft) / baseAbsScale;
+      const imgY = (baseCenter.y - baseTop) / baseAbsScale;
+      const drawWidth = imageSize.width * newAbsScale;
+      const drawHeight = imageSize.height * newAbsScale;
+      const newLeft = nextCenter.x - imgX * newAbsScale;
+      const newTop = nextCenter.y - imgY * newAbsScale;
+      const offsetX = newLeft - (box.width - drawWidth) / 2;
+      const offsetY = newTop - (box.height - drawHeight) / 2;
+      applyTransform({ scale, offsetX, offsetY });
+    },
+    [applyTransform, baseScale, box.height, box.width, clampScale, imageSize],
+  );
+
+  const resetGesture = useCallback(() => {
+    pointerPositions.current.clear();
+    gestureRef.current = { mode: 'none' };
+  }, []);
+
+  const getLocalPoint = useCallback(
+    (clientX: number, clientY: number): Point | null => {
+      const surface = surfaceRef.current;
+      if (!surface) return null;
+      const rect = surface.getBoundingClientRect();
+      if (!rect.width || !rect.height) return null;
+      return {
+        x: (clientX - rect.left) / surfaceScale,
+        y: (clientY - rect.top) / surfaceScale,
+      };
+    },
+    [surfaceScale],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (!open) return;
+      const local = getLocalPoint(event.clientX, event.clientY);
+      if (!local) return;
+      surfaceRef.current?.setPointerCapture(event.pointerId);
+      pointerPositions.current.set(event.pointerId, { start: local, point: local });
+
+      if (pointerPositions.current.size === 1) {
+        gestureRef.current = {
+          mode: 'pan',
+          pointerId: event.pointerId,
+          start: local,
+          base: transformRef.current,
+        };
+      } else if (pointerPositions.current.size === 2) {
+        const entries = Array.from(pointerPositions.current.entries());
+        const [a, b] = entries;
+        const center: Point = {
+          x: (a[1].point.x + b[1].point.x) / 2,
+          y: (a[1].point.y + b[1].point.y) / 2,
+        };
+        const distance = Math.hypot(
+          a[1].point.x - b[1].point.x,
+          a[1].point.y - b[1].point.y,
+        );
+        gestureRef.current = {
+          mode: 'pinch',
+          pointers: [a[0], b[0]],
+          start: { center, distance, base: transformRef.current },
+        };
+      }
+    },
+    [getLocalPoint, open],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent<HTMLDivElement>) => {
+      if (gestureRef.current.mode === 'none') return;
+      const entry = pointerPositions.current.get(event.pointerId);
+      const local = getLocalPoint(event.clientX, event.clientY);
+      if (!entry || !local) return;
+      entry.point = local;
+
+      const gesture = gestureRef.current;
+      if (gesture.mode === 'pan' && gesture.pointerId === event.pointerId) {
+        const delta = {
+          x: local.x - gesture.start.x,
+          y: local.y - gesture.start.y,
+        };
+        applyPan(gesture.base, delta);
+      } else if (gesture.mode === 'pinch') {
+        const [idA, idB] = gesture.pointers;
+        const posA = pointerPositions.current.get(idA);
+        const posB = pointerPositions.current.get(idB);
+        if (!posA || !posB) return;
+        const center: Point = {
+          x: (posA.point.x + posB.point.x) / 2,
+          y: (posA.point.y + posB.point.y) / 2,
+        };
+        const distance = Math.hypot(
+          posA.point.x - posB.point.x,
+          posA.point.y - posB.point.y,
+        );
+        const factor = gesture.start.distance
+          ? distance / gesture.start.distance
+          : 1;
+        const targetScale = gesture.start.base.scale * factor;
+        applyScaleFromBase(gesture.start.base, targetScale, gesture.start.center, center);
+      }
+    },
+    [applyPan, applyScaleFromBase, getLocalPoint],
+  );
+
+  const handlePointerUp = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    pointerPositions.current.delete(event.pointerId);
+    if (gestureRef.current.mode === 'pan' && gestureRef.current.pointerId === event.pointerId) {
+      gestureRef.current = { mode: 'none' };
+    } else if (gestureRef.current.mode === 'pinch') {
+      const remaining = Array.from(pointerPositions.current.keys());
+      if (remaining.length === 1) {
+        const id = remaining[0];
+        const entry = pointerPositions.current.get(id);
+        if (entry) {
+          gestureRef.current = {
+            mode: 'pan',
+            pointerId: id,
+            start: entry.point,
+            base: transformRef.current,
+          };
+        } else {
+          gestureRef.current = { mode: 'none' };
+        }
+      } else if (remaining.length < 1) {
+        gestureRef.current = { mode: 'none' };
+      }
+    }
+  }, []);
+
+  const handlePointerCancel = useCallback(() => {
+    resetGesture();
+  }, [resetGesture]);
+
+  const handleWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const local = getLocalPoint(event.clientX, event.clientY);
+      if (!local) return;
+      const base = transformRef.current;
+      const delta = -event.deltaY / 400;
+      if (!delta) return;
+      const targetScale = base.scale * (1 + delta);
+      applyScaleFromBase(base, targetScale, local, local);
+    },
+    [applyScaleFromBase, getLocalPoint],
+  );
+
+  const handleDoubleClick = useCallback(
+    (event: ReactMouseEvent<HTMLDivElement>) => {
+      const local = getLocalPoint(event.clientX, event.clientY);
+      if (!local) return;
+      const base = transformRef.current;
+      const targetScale = Math.min(base.scale * 1.25, SCALE_MAX);
+      applyScaleFromBase(base, targetScale, local, local);
+    },
+    [applyScaleFromBase, getLocalPoint],
+  );
+
+  if (!open) return null;
+
+  const slotLabel = slot === 'top' ? 'Верхний слот' : 'Нижний слот';
+
+  return (
+    <div className="crop-modal">
+      <div
+        className="crop-modal__overlay"
+        onClick={() => {
+          onClose();
+          resetGesture();
+        }}
+      />
+      <div className="crop-modal__panel" role="dialog" aria-modal="true">
+        <div className="crop-modal__header">
+          <h3>Кадрирование — {slotLabel}</h3>
+          <button
+            type="button"
+            onClick={() => {
+              onClose();
+              resetGesture();
+            }}
+            aria-label="Close"
+            className="crop-modal__close"
+          >
+            ×
+          </button>
+        </div>
+        <div className="crop-modal__content">
+          <div className="crop-modal__canvas" ref={wrapperRef}>
+            <div
+              ref={surfaceRef}
+              className="crop-modal__surface"
+              style={{
+                width: box.width,
+                height: box.height,
+                transform: `translate(-50%, -50%) scale(${surfaceScale})`,
+              }}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+              onPointerLeave={handlePointerUp}
+              onWheel={handleWheel}
+              onDoubleClick={handleDoubleClick}
+            >
+              <CollageSlotImage
+                src={photoSrc}
+                box={{ width: box.width, height: box.height }}
+                transform={current}
+                onLoad={(size) => setImageSize(size)}
+              />
+            </div>
+          </div>
+          <div className="crop-modal__controls">
+            <button
+              type="button"
+              className="btn-soft"
+              onClick={() => {
+                applyTransform(createDefaultTransform());
+              }}
+            >
+              Reset
+            </button>
+          </div>
+        </div>
+        <div className="crop-modal__footer">
+          <button
+            type="button"
+            className="btn-soft"
+            onClick={() => {
+              onClose();
+              resetGesture();
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn-soft is-active"
+            onClick={() => {
+              onSave(current);
+              resetGesture();
+            }}
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/webapp/src/components/collage/CollageSlotImage.tsx
+++ b/apps/webapp/src/components/collage/CollageSlotImage.tsx
@@ -1,0 +1,74 @@
+import { useState, useMemo, useCallback, useEffect, type SyntheticEvent } from 'react';
+import type { PhotoTransform } from '@/state/store';
+
+type Box = { width: number; height: number };
+
+type Props = {
+  src: string;
+  box: Box;
+  transform: PhotoTransform;
+  className?: string;
+  onLoad?: (size: { width: number; height: number }) => void;
+};
+
+export function CollageSlotImage({ src, box, transform, className, onLoad }: Props) {
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    setSize(null);
+  }, [src]);
+
+  const handleLoad = useCallback((event: SyntheticEvent<HTMLImageElement>) => {
+    const img = event.currentTarget;
+    const width = img.naturalWidth || img.width;
+    const height = img.naturalHeight || img.height;
+    if (width && height) {
+      setSize({ width, height });
+      onLoad?.({ width, height });
+    }
+  }, [onLoad]);
+
+  const style = useMemo(() => {
+    if (!size) {
+      return {
+        position: 'absolute' as const,
+        left: 0,
+        top: 0,
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover' as const,
+        objectPosition: 'center' as const,
+      };
+    }
+
+    const scaleBase = Math.max(box.width / size.width, box.height / size.height);
+    const finalScale = scaleBase * transform.scale;
+    const drawWidth = size.width * finalScale;
+    const drawHeight = size.height * finalScale;
+    const dx = (box.width - drawWidth) / 2 + transform.offsetX;
+    const dy = (box.height - drawHeight) / 2 + transform.offsetY;
+
+    return {
+      position: 'absolute' as const,
+      left: `${dx}px`,
+      top: `${dy}px`,
+      width: `${drawWidth}px`,
+      height: `${drawHeight}px`,
+      objectFit: 'cover' as const,
+      objectPosition: 'center' as const,
+      transform: 'translate3d(0,0,0)',
+    };
+  }, [box.height, box.width, size, transform.offsetX, transform.offsetY, transform.scale]);
+
+  return (
+    <img
+      src={src}
+      alt=""
+      draggable={false}
+      className={className}
+      onLoad={handleLoad}
+      style={style}
+    />
+  );
+}
+

--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -1,15 +1,47 @@
-import { useState, useEffect, useMemo, MouseEvent } from 'react';
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+  useLayoutEffect,
+  type PointerEvent as ReactPointerEvent,
+  type MouseEvent as ReactMouseEvent,
+} from 'react';
 import {
   photosActions,
   usePhotos,
+  Photo,
   PhotoId,
+  PhotoTransform,
   useCarouselStore,
   slidesActions,
-  DEFAULT_COLLAGE_50,
+  normalizeCollage,
 } from '@/state/store';
-import { ArrowLeftIcon, ArrowRightIcon, TrashIcon } from '@/ui/icons';
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  TrashIcon,
+  CheckIcon,
+  PencilIcon,
+  SwapIcon,
+} from '@/ui/icons';
 import { resolvePhotoSource } from '@/utils/photos';
+import { computeCollageBoxes } from '@/utils/collage';
+import { CollageSlotImage } from '@/components/collage/CollageSlotImage';
+import { CollageCropModal } from '@/components/collage/CollageCropModal';
 import '@/styles/photos-sheet.css';
+
+type MenuState = {
+  photo: Photo;
+  anchor: { x: number; y: number };
+};
+
+type CropState = {
+  slot: 'top' | 'bottom';
+  photoId: string;
+  photoSrc: string;
+};
 
 const impact = (style: 'light' | 'medium' = 'light') => {
   try {
@@ -20,149 +52,326 @@ const impact = (style: 'light' | 'medium' = 'light') => {
   } catch {}
 };
 
+type SlotPreviewProps = {
+  label: string;
+  box: { width: number; height: number };
+  src?: string;
+  transform: { scale: number; offsetX: number; offsetY: number };
+  active: boolean;
+  onSelect: () => void;
+  onEdit: () => void;
+  canEdit: boolean;
+};
+
+function SlotPreview({ label, box, src, transform, active, onSelect, onEdit, canEdit }: SlotPreviewProps) {
+  const frameRef = useRef<HTMLDivElement>(null);
+  const [frameWidth, setFrameWidth] = useState(0);
+
+  useLayoutEffect(() => {
+    const element = frameRef.current;
+    if (!element) return;
+    const update = () => setFrameWidth(element.clientWidth);
+    update();
+    if (typeof ResizeObserver !== 'undefined') {
+      const observer = new ResizeObserver(update);
+      observer.observe(element);
+      return () => observer.disconnect();
+    }
+    return () => {};
+  }, []);
+
+  const scale = frameWidth > 0 ? frameWidth / box.width : 1;
+  const scaledBox = useMemo(
+    () => ({ width: box.width * scale, height: box.height * scale }),
+    [box.height, box.width, scale],
+  );
+  const scaledTransform = useMemo(
+    () => ({
+      scale: transform.scale,
+      offsetX: transform.offsetX * scale,
+      offsetY: transform.offsetY * scale,
+    }),
+    [scale, transform.offsetX, transform.offsetY, transform.scale],
+  );
+
+  return (
+    <div className={`slot-preview${active ? ' is-active' : ''}`}>
+      <div className="slot-preview__header">
+        <span>{label}</span>
+        <button
+          type="button"
+          className="slot-preview__edit"
+          onClick={onEdit}
+          disabled={!canEdit}
+          aria-label="Edit crop"
+        >
+          <PencilIcon />
+        </button>
+      </div>
+      <div
+        ref={frameRef}
+        className="slot-preview__frame"
+        style={{ aspectRatio: `${box.width} / ${box.height}` }}
+        onClick={onSelect}
+      >
+        <div className="slot-preview__surface">
+          {src ? (
+            <CollageSlotImage src={src} box={scaledBox} transform={scaledTransform} />
+          ) : (
+            <div className="slot-preview__placeholder">Добавьте фото</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatBadges(badges: string[] | undefined) {
+  if (!badges || badges.length === 0) return undefined;
+  return badges.join(', ');
+}
+
 export default function PhotosSheet() {
+  const panelRef = useRef<HTMLDivElement>(null);
   const { items } = usePhotos();
   const [selected, setSelected] = useState<PhotoId[]>([]);
   const [activeSlot, setActiveSlot] = useState<'top' | 'bottom'>('top');
-  const onClose = useCarouselStore((s) => s.closeSheet);
-  const activeSlide = useCarouselStore((s) => s.slides[s.activeIndex]);
-  const updateSlide = useCarouselStore((s) => s.updateSlide);
+  const [menu, setMenu] = useState<MenuState | null>(null);
+  const [crop, setCrop] = useState<CropState | null>(null);
+  const holdRef = useRef<{ timer: number; photo: Photo; target: HTMLElement | null } | null>(null);
 
-  const collageConfig = useMemo(
-    () => ({ ...DEFAULT_COLLAGE_50, ...(activeSlide?.collage50 ?? {}) }),
+  const closeSheet = useCarouselStore((s) => s.closeSheet);
+  const slides = useCarouselStore((s) => s.slides);
+  const activeIndex = useCarouselStore((s) => s.activeIndex);
+  const setCollageSlot = useCarouselStore((s) => s.setCollageSlot);
+  const swapCollage = useCarouselStore((s) => s.swapCollage);
+  const setCollageTransform = useCarouselStore((s) => s.setCollageTransform);
+  const applyCollageTemplateToAll = useCarouselStore((s) => s.applyCollageTemplateToAll);
+  const autoFillCollage = useCarouselStore((s) => s.autoFillCollage);
+
+  const activeSlide = slides[activeIndex];
+  const isCollage = activeSlide?.template === 'collage-50';
+  const collage = useMemo(
+    () => normalizeCollage(activeSlide?.collage50),
     [activeSlide?.collage50],
   );
-  const isCollage = activeSlide?.template === 'collage-50';
+  const collageBoxes = useMemo(() => computeCollageBoxes(collage.dividerPx), [collage.dividerPx]);
+
   const topPreview = useMemo(
-    () => (isCollage ? resolvePhotoSource(collageConfig.topPhoto, items) : undefined),
-    [collageConfig.topPhoto, isCollage, items],
+    () => (isCollage ? resolvePhotoSource(collage.top.photoId, items) : undefined),
+    [collage.top.photoId, isCollage, items],
   );
   const bottomPreview = useMemo(
-    () => (isCollage ? resolvePhotoSource(collageConfig.bottomPhoto, items) : undefined),
-    [collageConfig.bottomPhoto, isCollage, items],
+    () => (isCollage ? resolvePhotoSource(collage.bottom.photoId, items) : undefined),
+    [collage.bottom.photoId, isCollage, items],
   );
 
   useEffect(() => {
-    const onEsc = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose();
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeSheet();
     };
-    window.addEventListener('keydown', onEsc);
-    return () => window.removeEventListener('keydown', onEsc);
-  }, [onClose]);
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [closeSheet]);
+
+  useEffect(() => {
+    setSelected((prev) => prev.filter((id) => items.some((p) => p.id === id)));
+  }, [items]);
 
   useEffect(() => {
     if (!isCollage) {
-      setSelected([]);
       setActiveSlot('top');
       return;
     }
-    if (!collageConfig.topPhoto) {
+    if (!collage.top.photoId) {
       setActiveSlot('top');
-    } else if (!collageConfig.bottomPhoto) {
+    } else if (!collage.bottom.photoId) {
       setActiveSlot('bottom');
     }
-  }, [isCollage, collageConfig.topPhoto, collageConfig.bottomPhoto]);
+  }, [isCollage, collage.top.photoId, collage.bottom.photoId]);
 
-  const onAdd = (files: FileList | null) => {
-    if (!files) return;
-    photosActions.addFiles(Array.from(files));
-  };
-
-  const assignCollagePhoto = (slot: 'top' | 'bottom', id: PhotoId) => {
-    if (!activeSlide) return;
-    updateSlide(activeSlide.id, {
-      collage50: {
-        ...collageConfig,
-        [slot === 'top' ? 'topPhoto' : 'bottomPhoto']: id,
-      },
+  const assignments = useMemo(() => {
+    const map = new Map<string, string[]>();
+    slides.forEach((slide, index) => {
+      if (slide.template !== 'collage-50') return;
+      const cfg = normalizeCollage(slide.collage50);
+      if (cfg.top.photoId) {
+        const key = cfg.top.photoId;
+        const list = map.get(key) ?? [];
+        list.push(`T${index + 1}`);
+        map.set(key, list);
+      }
+      if (cfg.bottom.photoId) {
+        const key = cfg.bottom.photoId;
+        const list = map.get(key) ?? [];
+        list.push(`B${index + 1}`);
+        map.set(key, list);
+      }
     });
-  };
+    return map;
+  }, [slides]);
 
-  const swapCollagePhotos = () => {
-    if (!activeSlide) return;
-    updateSlide(activeSlide.id, {
-      collage50: {
-        ...collageConfig,
-        topPhoto: collageConfig.bottomPhoto,
-        bottomPhoto: collageConfig.topPhoto,
-      },
-    });
+  const toggleSelect = useCallback((id: PhotoId) => {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+    impact('light');
+  }, []);
+
+  const handleAutoFill = () => {
+    if (selected.length === 0) return;
+    autoFillCollage(selected);
     impact('medium');
   };
 
-  const toggleSelect = (id: PhotoId) => {
+  const handleApplyTemplate = () => {
+    applyCollageTemplateToAll();
+    impact('medium');
+  };
+
+  const handleSwap = () => {
+    if (!isCollage) return;
+    swapCollage(activeIndex);
+    impact('medium');
+  };
+
+  const openMenu = (photo: Photo, element: HTMLElement) => {
+    const panel = panelRef.current;
+    if (!panel) return;
+    const rect = element.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    setMenu({
+      photo,
+      anchor: {
+        x: rect.left - panelRect.left + rect.width / 2,
+        y: rect.top - panelRect.top + rect.height + 8,
+      },
+    });
+  };
+
+  const closeMenu = () => setMenu(null);
+
+  const startHold = (photo: Photo, element: HTMLElement) => {
+    const timer = window.setTimeout(() => {
+      const state = holdRef.current;
+      if (!state) return;
+      holdRef.current = null;
+      if (!activeSlide || !isCollage) return;
+      const topEmpty = !collage.top.photoId;
+      const bottomEmpty = !collage.bottom.photoId;
+      if (topEmpty) {
+        setCollageSlot(activeIndex, 'top', photo.id);
+        setActiveSlot('bottom');
+        impact('light');
+      } else if (bottomEmpty) {
+        setCollageSlot(activeIndex, 'bottom', photo.id);
+        setActiveSlot('top');
+        impact('light');
+      } else {
+        openMenu(photo, element);
+      }
+    }, 350);
+    holdRef.current = { timer, photo, target: element };
+  };
+
+  const cancelHold = () => {
+    if (holdRef.current) {
+      clearTimeout(holdRef.current.timer);
+      holdRef.current = null;
+    }
+  };
+
+  const handleThumbPointerDown = (photo: Photo, event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!isCollage) return;
+    startHold(photo, event.currentTarget);
+  };
+
+  const handleThumbPointerUp = (photo: Photo, event: ReactPointerEvent<HTMLDivElement>) => {
+    if (!isCollage) return;
+    if (!holdRef.current) return;
+    const state = holdRef.current;
+    cancelHold();
+    openMenu(photo, state?.target ?? event.currentTarget);
+  };
+
+  const handleThumbClick = (photo: Photo, event: ReactMouseEvent<HTMLDivElement>) => {
     if (isCollage) {
-      assignCollagePhoto(activeSlot, id);
-      setActiveSlot((prev) => (prev === 'top' ? 'bottom' : 'top'));
-      impact('light');
+      event.preventDefault();
+      event.stopPropagation();
       return;
     }
-    setSelected((s) => (s.includes(id) ? s.filter((i) => i !== id) : [...s, id]));
+    toggleSelect(photo.id);
+  };
+
+  const handleMenuAction = (slot: 'top' | 'bottom', photo: Photo) => {
+    if (!activeSlide || !isCollage) return;
+    setCollageSlot(activeIndex, slot, photo.id);
+    setActiveSlot(slot === 'top' ? 'bottom' : 'top');
+    closeMenu();
     impact('light');
+  };
+
+  const openCrop = (slot: 'top' | 'bottom') => {
+    if (!isCollage) return;
+    const photoId = collage[slot].photoId;
+    if (!photoId) return;
+    const src = resolvePhotoSource(photoId, items);
+    if (!src) return;
+    setCrop({ slot, photoId, photoSrc: src });
+  };
+
+  const handleSaveCrop = (next: PhotoTransform) => {
+    if (!crop) return;
+    setCollageTransform(activeIndex, crop.slot, next);
+    setCrop(null);
+    impact('light');
+  };
+
+  const handleRemove = (id: PhotoId) => {
+    photosActions.remove(id);
+  };
+
+  const handleDone = (event: ReactMouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (!isCollage) {
+      slidesActions.replaceWithPhotos(items);
+    }
+    closeSheet();
   };
 
   const moveLeft = (id: PhotoId) => photosActions.move(id, 'left');
   const moveRight = (id: PhotoId) => photosActions.move(id, 'right');
 
-  const removeOne = (id: PhotoId) => {
-    photosActions.remove(id);
-    if (isCollage && activeSlide) {
-      const next = { ...collageConfig };
-      let changed = false;
-      if (next.topPhoto === id) {
-        next.topPhoto = undefined;
-        changed = true;
-      }
-      if (next.bottomPhoto === id) {
-        next.bottomPhoto = undefined;
-        changed = true;
-      }
-      if (changed) {
-        updateSlide(activeSlide.id, { collage50: next });
-      }
-    }
-  };
-
-  const onDone = (e: MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (isCollage) {
-      onClose();
-      return;
-    }
-    slidesActions.replaceWithPhotos(items);
-    onClose();
-  };
-
-  const inputId = 'photos-file-input';
-  const canSwap = Boolean(collageConfig.topPhoto || collageConfig.bottomPhoto);
-
   return (
-    <div className="sheet" aria-open="true" onClick={onClose}>
+    <div className="sheet" aria-open="true" onClick={closeSheet}>
       <div className="sheet__overlay" />
-      <div className="sheet__panel" onClick={(e) => e.stopPropagation()}>
+      <div className="sheet__panel" ref={panelRef} onClick={(e) => e.stopPropagation()}>
         <div className="actions-row">
           <input
-            id={inputId}
+            id="photos-file-input"
             type="file"
             accept="image/*"
             multiple
             hidden
-            onChange={(e) => onAdd(e.target.files)}
+            onChange={(event) => photosActions.addFiles(event.target.files ? Array.from(event.target.files) : [])}
           />
-          <label className="btn-soft add-btn" htmlFor={inputId}>
+          <label className="btn-soft add-btn" htmlFor="photos-file-input">
             <svg width="18" height="18" viewBox="0 0 24 24">
-              <path
-                d="M12 5v14M5 12h14"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-              />
+              <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
             </svg>
             <span>Add photo</span>
           </label>
-
-          <button type="button" className="btn-soft" onClick={onDone}>
+          <button
+            type="button"
+            className={`btn-soft${selected.length === 0 ? ' is-disabled' : ''}`}
+            onClick={handleAutoFill}
+            disabled={selected.length === 0}
+          >
+            Auto-fill Collage
+          </button>
+          <button type="button" className="btn-soft" onClick={handleApplyTemplate}>
+            Apply template to all slides
+          </button>
+          <button type="button" className="btn-soft" onClick={handleDone}>
             Done
           </button>
         </div>
@@ -173,103 +382,104 @@ export default function PhotosSheet() {
             ) : (
               <>
                 {isCollage && (
-                  <div className="collage-slot-preview">
-                    <div
-                      className={`collage-slot-preview__item${activeSlot === 'top' ? ' is-active' : ''}`}
-                      onClick={() => setActiveSlot('top')}
-                    >
-                      <div className="collage-slot-preview__label">Верхнее фото</div>
-                      <div className="collage-slot-preview__frame">
-                        {topPreview ? (
-                          <img src={topPreview} alt="" />
-                        ) : (
-                          <div className="collage-slot-preview__placeholder">Добавьте фото</div>
-                        )}
-                      </div>
-                    </div>
+                  <div className="collage-overview">
+                    <SlotPreview
+                      label="Верхний слот"
+                      box={{ width: collageBoxes.top.width, height: collageBoxes.top.height }}
+                      src={topPreview}
+                      transform={collage.top.transform}
+                      active={activeSlot === 'top'}
+                      onSelect={() => setActiveSlot('top')}
+                      onEdit={() => openCrop('top')}
+                      canEdit={Boolean(collage.top.photoId)}
+                    />
                     <button
                       type="button"
                       className="btn-soft swap-btn"
-                      onClick={swapCollagePhotos}
-                      disabled={!canSwap}
+                      onClick={handleSwap}
+                      disabled={!collage.top.photoId && !collage.bottom.photoId}
                     >
-                      Swap
+                      <SwapIcon />
+                      <span>Swap</span>
                     </button>
-                    <div
-                      className={`collage-slot-preview__item${activeSlot === 'bottom' ? ' is-active' : ''}`}
-                      onClick={() => setActiveSlot('bottom')}
-                    >
-                      <div className="collage-slot-preview__label">Нижнее фото</div>
-                      <div className="collage-slot-preview__frame">
-                        {bottomPreview ? (
-                          <img src={bottomPreview} alt="" />
-                        ) : (
-                          <div className="collage-slot-preview__placeholder">Добавьте фото</div>
-                        )}
-                      </div>
-                    </div>
+                    <SlotPreview
+                      label="Нижний слот"
+                      box={{ width: collageBoxes.bottom.width, height: collageBoxes.bottom.height }}
+                      src={bottomPreview}
+                      transform={collage.bottom.transform}
+                      active={activeSlot === 'bottom'}
+                      onSelect={() => setActiveSlot('bottom')}
+                      onEdit={() => openCrop('bottom')}
+                      canEdit={Boolean(collage.bottom.photoId)}
+                    />
                   </div>
                 )}
                 <div className="photoGrid">
-                  {items.map((p, idx) => {
-                    const isAssignedTop = isCollage && collageConfig.topPhoto === p.id;
-                    const isAssignedBottom = isCollage && collageConfig.bottomPhoto === p.id;
-                    const isActive = isCollage ? isAssignedTop || isAssignedBottom : selected.includes(p.id);
-                    const order = selected.indexOf(p.id);
-                    const badgeContent = isCollage
-                      ? isAssignedTop
-                        ? 'Top'
-                        : isAssignedBottom
-                        ? 'Bottom'
-                        : null
-                      : order >= 0
-                      ? String(order + 1)
-                      : null;
-                    const controlsDisabled = !isCollage && !isActive;
+                  {items.map((photo, index) => {
+                    const badges = assignments.get(photo.id);
+                    const badgeContent = formatBadges(badges);
+                    const isSelected = selected.includes(photo.id);
+                    const isTop = isCollage && collage.top.photoId === photo.id;
+                    const isBottom = isCollage && collage.bottom.photoId === photo.id;
                     return (
                       <div
-                        key={p.id}
-                        className={
-                          'thumb' +
-                          (isActive ? ' is-active' : '') +
-                          (isAssignedTop ? ' is-top' : '') +
-                          (isAssignedBottom ? ' is-bottom' : '')
-                        }
-                        onClick={() => toggleSelect(p.id)}
+                        key={photo.id}
+                        className={`thumb${isSelected ? ' is-selected' : ''}${isTop ? ' is-top' : ''}${
+                          isBottom ? ' is-bottom' : ''
+                        }`}
+                        onPointerDown={(event) => handleThumbPointerDown(photo, event)}
+                        onPointerUp={(event) => handleThumbPointerUp(photo, event)}
+                        onPointerLeave={cancelHold}
+                        onPointerCancel={cancelHold}
+                        onClick={(event) => handleThumbClick(photo, event)}
                       >
-                        <img src={p.src} alt={p.fileName ?? 'photo'} loading="lazy" />
+                        <img src={photo.src} alt={photo.fileName ?? 'photo'} loading="lazy" />
+                        <button
+                          type="button"
+                          className={`thumb__selector${isSelected ? ' is-active' : ''}`}
+                          onPointerDown={(event) => event.stopPropagation()}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            toggleSelect(photo.id);
+                          }}
+                          aria-label={isSelected ? 'Deselect photo' : 'Select photo'}
+                        >
+                          <CheckIcon />
+                        </button>
                         {badgeContent && <div className="badge">{badgeContent}</div>}
                         <div className="controls">
                           <button
                             className="btn-circle-soft"
-                            aria-label="Left"
-                            disabled={controlsDisabled || idx === 0}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              moveLeft(p.id);
+                            aria-label="Move left"
+                            disabled={index === 0}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              moveLeft(photo.id);
                             }}
+                            onPointerDown={(event) => event.stopPropagation()}
                           >
                             <ArrowLeftIcon />
                           </button>
                           <button
                             className="btn-circle-soft"
                             aria-label="Delete"
-                            disabled={controlsDisabled}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              removeOne(p.id);
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              handleRemove(photo.id);
                             }}
+                            onPointerDown={(event) => event.stopPropagation()}
                           >
                             <TrashIcon />
                           </button>
                           <button
                             className="btn-circle-soft"
-                            aria-label="Right"
-                            disabled={controlsDisabled || idx === items.length - 1}
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              moveRight(p.id);
+                            aria-label="Move right"
+                            disabled={index === items.length - 1}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              moveRight(photo.id);
                             }}
+                            onPointerDown={(event) => event.stopPropagation()}
                           >
                             <ArrowRightIcon />
                           </button>
@@ -282,7 +492,31 @@ export default function PhotosSheet() {
             )}
           </div>
         </div>
+        {menu && isCollage && (
+          <div className="collage-menu" style={{ left: menu.anchor.x, top: menu.anchor.y }}>
+            <button type="button" onClick={() => handleMenuAction('top', menu.photo)}>
+              {collage.top.photoId ? 'Replace Top' : 'Set as Top'}
+            </button>
+            <button type="button" onClick={() => handleMenuAction('bottom', menu.photo)}>
+              {collage.bottom.photoId ? 'Replace Bottom' : 'Set as Bottom'}
+            </button>
+            <button type="button" className="collage-menu__close" onClick={closeMenu}>
+              Cancel
+            </button>
+          </div>
+        )}
       </div>
+      {crop && (
+        <CollageCropModal
+          open
+          slot={crop.slot}
+          photoSrc={crop.photoSrc}
+          transform={collage[crop.slot].transform}
+          box={crop.slot === 'top' ? collageBoxes.top : collageBoxes.bottom}
+          onClose={() => setCrop(null)}
+          onSave={handleSaveCrop}
+        />
+      )}
     </div>
   );
 }

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -2,15 +2,15 @@
 .empty { margin:16px 0; color:rgba(255,255,255,.5); }
 .photoGrid {
   display:grid;
-  grid-template-columns:repeat(auto-fill, minmax(88px,1fr));
-  gap:10px;
+  grid-template-columns:repeat(auto-fill, minmax(72px,1fr));
+  gap:8px;
   margin-top:12px;
 }
 
 /* ряд с кнопками наверху шита */
 .actions-row{
   position:relative; z-index:2;
-  display:flex; align-items:center; gap:10px;
+  display:flex; align-items:center; gap:10px; flex-wrap:wrap;
   padding:8px 12px 4px;
 }
 
@@ -31,6 +31,11 @@
 }
 .btn-soft:hover{ background:color-mix(in srgb, #ffffff 18%, transparent); }
 .btn-soft:active{ transform:translateY(1px); }
+.btn-soft.is-disabled,
+.btn-soft:disabled{
+  opacity:.45;
+  pointer-events:none;
+}
 .btn-soft.is-active{
   background: color-mix(in srgb, #ffffff 18%, transparent);
   border-color: color-mix(in srgb, #ffffff 45%, transparent);
@@ -57,8 +62,37 @@
 .add-btn{ margin-left: 0; pointer-events:auto; }
 
 /* миниатюры */
-.thumb{ position:relative; border-radius:14px; overflow:hidden; }
+.thumb{ position:relative; border-radius:14px; overflow:hidden; min-height:72px; }
 .thumb img{ width:100%; height:100%; object-fit:cover; display:block; }
+.thumb.is-top{ outline:2px solid rgba(59,130,246,.75); }
+.thumb.is-bottom{ outline:2px solid rgba(16,185,129,.75); }
+.thumb.is-top.is-bottom{ outline:2px solid rgba(236,72,153,.75); }
+.thumb.is-selected::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:color-mix(in srgb, #ffffff 8%, transparent);
+}
+
+.thumb__selector{
+  position:absolute;
+  top:6px;
+  right:6px;
+  width:26px;
+  height:26px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.5);
+  background:rgba(0,0,0,.45);
+  color:#fff;
+  display:grid;
+  place-items:center;
+  backdrop-filter:blur(4px);
+}
+.thumb__selector svg{ width:16px; height:16px; }
+.thumb__selector.is-active{
+  background:rgba(16,185,129,.85);
+  border-color:rgba(255,255,255,.8);
+}
 
 /* панель кнопок на миниатюре */
 .thumb .controls{
@@ -67,7 +101,7 @@
   opacity:0; transform:translateY(4px);
   transition:opacity .15s ease, transform .15s ease;
 }
-.thumb.is-active .controls,
+.thumb.is-selected .controls,
 .thumb:hover .controls{
   opacity:1; transform:translateY(0);
 }
@@ -82,39 +116,37 @@
   background:color-mix(in srgb, #000 45%, transparent);
   border:1px solid rgba(255,255,255,.25);
   backdrop-filter:blur(4px);
-  opacity:0; transform:translateY(-4px);
-  transition:opacity .15s, transform .15s;
 }
-.thumb.is-active .badge{ opacity:1; transform:translateY(0); }
+.thumb .badge{ opacity:1; }
 
-.collage-slot-preview{ display:flex; flex-direction:column; gap:12px; margin-bottom:16px; }
-.collage-slot-preview__item{
-  border:1px solid var(--border);
-  border-radius:16px;
-  padding:12px;
-  background:var(--bg-section);
-  cursor:pointer;
-  transition:border-color .15s ease, box-shadow .15s ease;
-}
-.collage-slot-preview__item.is-active{
-  border-color:var(--outline);
-  box-shadow:0 0 0 1px color-mix(in srgb, #ffffff 18%, transparent);
-}
-.collage-slot-preview__label{ font-weight:600; font-size:14px; color:var(--text-muted); margin-bottom:8px; }
-.collage-slot-preview__frame{
-  position:relative;
-  width:100%;
-  aspect-ratio:4/5;
-  border-radius:12px;
-  overflow:hidden;
-  background:rgba(0,0,0,.08);
-  display:flex;
-  align-items:center;
-  justify-content:center;
-  color:rgba(255,255,255,.65);
-  font-weight:600;
-}
-.collage-slot-preview__frame img{ width:100%; height:100%; object-fit:cover; object-position:center; display:block; }
-.collage-slot-preview__placeholder{ padding:16px; text-align:center; }
-.swap-btn{ align-self:center; }
+.collage-overview{ display:flex; flex-direction:column; gap:16px; margin-bottom:16px; }
+.collage-overview .swap-btn{ align-self:center; display:flex; align-items:center; gap:6px; }
+
+.slot-preview{ border:1px solid rgba(255,255,255,.18); border-radius:16px; padding:12px; background:rgba(0,0,0,.18); backdrop-filter:blur(8px); transition:border-color .15s ease, box-shadow .15s ease; }
+.slot-preview.is-active{ border-color:color-mix(in srgb, #ffffff 45%, transparent); box-shadow:0 0 0 1px rgba(255,255,255,.2); }
+.slot-preview__header{ display:flex; align-items:center; justify-content:space-between; font-weight:600; font-size:14px; color:rgba(255,255,255,.72); margin-bottom:8px; }
+.slot-preview__edit{ display:grid; place-items:center; width:30px; height:30px; border-radius:999px; border:1px solid rgba(255,255,255,.25); background:rgba(0,0,0,.45); color:#fff; }
+.slot-preview__edit:disabled{ opacity:.4; pointer-events:none; }
+.slot-preview__frame{ position:relative; width:100%; border-radius:12px; overflow:hidden; background:rgba(0,0,0,.25); cursor:pointer; }
+.slot-preview__surface{ position:relative; width:100%; height:100%; }
+.slot-preview__placeholder{ display:flex; align-items:center; justify-content:center; height:100%; padding:16px; color:rgba(255,255,255,.65); font-weight:600; text-align:center; }
+
+.collage-menu{ position:absolute; z-index:10; display:flex; flex-direction:column; background:rgba(20,20,24,.95); border:1px solid rgba(255,255,255,.14); border-radius:12px; padding:8px; gap:4px; min-width:160px; box-shadow:0 10px 30px rgba(0,0,0,.35); transform:translate(-50%, 0); }
+.collage-menu button{ width:100%; padding:8px 10px; text-align:left; border:0; background:transparent; color:#fff; font-size:14px; border-radius:8px; }
+.collage-menu button:hover{ background:rgba(255,255,255,.08); }
+.collage-menu__close{ color:rgba(255,255,255,.75); text-align:center !important; }
+
+.collage-overview .btn-soft{ align-self:center; }
+
+.crop-modal{ position:fixed; inset:0; z-index:120; display:flex; align-items:center; justify-content:center; }
+.crop-modal__overlay{ position:absolute; inset:0; background:rgba(0,0,0,.65); }
+.crop-modal__panel{ position:relative; z-index:121; width:min(92vw, 600px); max-height:90vh; background:rgba(15,15,18,.96); color:#fff; border-radius:18px; padding:20px; display:flex; flex-direction:column; gap:18px; box-shadow:0 20px 60px rgba(0,0,0,.45); }
+.crop-modal__header{ display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.crop-modal__header h3{ margin:0; font-size:18px; font-weight:600; }
+.crop-modal__close{ border:0; background:transparent; color:#fff; font-size:26px; line-height:1; padding:0 4px; cursor:pointer; }
+.crop-modal__content{ display:flex; flex-direction:column; gap:12px; }
+.crop-modal__canvas{ position:relative; width:100%; height:min(60vh, 460px); background:#000; border-radius:16px; overflow:hidden; }
+.crop-modal__surface{ position:absolute; top:50%; left:50%; transform-origin:top left; border-radius:12px; overflow:hidden; background:#000; box-shadow:0 12px 24px rgba(0,0,0,.35); touch-action:none; cursor:grab; }
+.crop-modal__controls{ display:flex; gap:12px; }
+.crop-modal__footer{ display:flex; justify-content:flex-end; gap:12px; }
 

--- a/apps/webapp/src/ui/icons.tsx
+++ b/apps/webapp/src/ui/icons.tsx
@@ -68,3 +68,56 @@ export const PlusIcon = () => (
     <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round"/>
   </svg>
 );
+
+export const CheckIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M5 12.5l4.5 4L19 7"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const PencilIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M4 17.5V20h2.5L18.374 8.126 15.874 5.626 4 17.5z"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+    <path
+      d="M19.5 6.999l-2.5-2.5"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export const SwapIcon = () => (
+  <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
+    <path
+      d="M7 10l-3 3 3 3"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M17 7l3 3-3 3"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M4 13h14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+    <path d="M6 10h14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
+  </svg>
+);

--- a/apps/webapp/src/utils/collage.ts
+++ b/apps/webapp/src/utils/collage.ts
@@ -1,0 +1,25 @@
+import { BASE_FRAME } from '@/features/render/constants';
+
+export type CollageBox = { x: number; y: number; width: number; height: number };
+
+export type CollageBoxes = {
+  top: CollageBox;
+  bottom: CollageBox;
+  divider: { y: number; height: number };
+};
+
+export function computeCollageBoxes(dividerPx: number): CollageBoxes {
+  const thickness = Math.max(0, dividerPx);
+  const half = Math.floor(BASE_FRAME.height / 2);
+  const halfLine = thickness / 2;
+  const topHeight = Math.max(0, half - halfLine);
+  const bottomY = half + halfLine;
+  const bottomHeight = Math.max(0, BASE_FRAME.height - bottomY);
+
+  return {
+    top: { x: 0, y: 0, width: BASE_FRAME.width, height: topHeight },
+    bottom: { x: 0, y: bottomY, width: BASE_FRAME.width, height: bottomHeight },
+    divider: { y: half - halfLine, height: thickness },
+  };
+}
+

--- a/apps/webapp/src/utils/drawImageCover.ts
+++ b/apps/webapp/src/utils/drawImageCover.ts
@@ -1,9 +1,12 @@
+import type { PhotoTransform } from '@/state/store';
+
 export type Rect = { x: number; y: number; width: number; height: number };
 
 export function drawImageCover(
   ctx: CanvasRenderingContext2D,
   img: HTMLImageElement,
   rect: Rect,
+  transform?: PhotoTransform,
 ) {
   const imageWidth = img.naturalWidth || img.width;
   const imageHeight = img.naturalHeight || img.height;
@@ -12,11 +15,14 @@ export function drawImageCover(
   const { x, y, width, height } = rect;
   if (width <= 0 || height <= 0) return;
 
-  const scale = Math.max(width / imageWidth, height / imageHeight);
+  const baseScale = Math.max(width / imageWidth, height / imageHeight);
+  const scale = baseScale * (transform?.scale ?? 1);
   const drawWidth = imageWidth * scale;
   const drawHeight = imageHeight * scale;
-  const dx = x + (width - drawWidth) / 2;
-  const dy = y + (height - drawHeight) / 2;
+  const offsetX = transform?.offsetX ?? 0;
+  const offsetY = transform?.offsetY ?? 0;
+  const dx = x + (width - drawWidth) / 2 + offsetX;
+  const dy = y + (height - drawHeight) / 2 + offsetY;
 
   ctx.save();
   ctx.beginPath();


### PR DESCRIPTION
## Summary
- refactor collage state to track top/bottom slots with transforms plus new actions for assignment, swapping, auto-fill, and template application
- redesign the Photos sheet with miniature thumbnails, slot previews, context menu, auto-fill/apply buttons, and integrate a pan/zoom cropping modal
- update collage rendering across slide preview and export, add shared slot drawing utilities, new icons, and refresh styles and template management for the new structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9f85aa5a08328b8cfc6073186a57f