### PR TITLE
Fix collage crop modal rendering and thumbnail overlays

### DIFF
--- a/apps/webapp/src/components/collage/CollageSlotImage.tsx
+++ b/apps/webapp/src/components/collage/CollageSlotImage.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, type SyntheticEvent } from 'react';
 import type { PhotoTransform } from '@/state/store';
+import { computeCoverScale } from '@/utils/collage';
 
 type Box = { width: number; height: number };
 
@@ -41,7 +42,7 @@ export function CollageSlotImage({ src, box, transform, className, onLoad }: Pro
       };
     }
 
-    const scaleBase = Math.max(box.width / size.width, box.height / size.height);
+    const scaleBase = computeCoverScale(size.width, size.height, box.width, box.height);
     const finalScale = scaleBase * transform.scale;
     const drawWidth = size.width * finalScale;
     const drawHeight = size.height * finalScale;

--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -572,70 +572,77 @@ export default function PhotosSheet() {
                         onClick={(event) => handleThumbClick(photo, event)}
                       >
                         <img src={photo.src} alt={photo.fileName ?? 'photo'} loading="lazy" />
-                        {(isTop || isBottom) && (
+                        <div className="ov-top-left">
                           <button
                             type="button"
-                            className="edit"
-                            onPointerDown={(event) => event.stopPropagation()}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              handleThumbEdit(photo, event.currentTarget as HTMLElement);
-                            }}
-                            aria-label="Edit crop"
-                          >
-                            <PencilIcon />
-                          </button>
-                        )}
-                        <button
-                          type="button"
-                          className={`thumb__selector${isSelected ? ' is-active' : ''}`}
-                          onPointerDown={(event) => event.stopPropagation()}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            toggleSelect(photo.id);
-                          }}
-                          aria-label={isSelected ? 'Deselect photo' : 'Select photo'}
-                        >
-                          <CheckIcon />
-                        </button>
-                        {badgeContent && <div className="badge">{badgeContent}</div>}
-                        <div className="controls">
-                          <button
-                            className="btn-circle-soft"
+                            className="btn-icon"
                             aria-label="Move left"
                             disabled={index === 0}
+                            onPointerDown={(event) => event.stopPropagation()}
                             onClick={(event) => {
                               event.stopPropagation();
                               moveLeft(photo.id);
                             }}
-                            onPointerDown={(event) => event.stopPropagation()}
                           >
                             <ArrowLeftIcon />
                           </button>
                           <button
-                            className="btn-circle-soft"
+                            type="button"
+                            className="btn-icon"
                             aria-label="Delete"
+                            onPointerDown={(event) => event.stopPropagation()}
                             onClick={(event) => {
                               event.stopPropagation();
                               handleRemove(photo.id);
                             }}
-                            onPointerDown={(event) => event.stopPropagation()}
                           >
                             <TrashIcon />
                           </button>
                           <button
-                            className="btn-circle-soft"
+                            type="button"
+                            className="btn-icon"
                             aria-label="Move right"
                             disabled={index === items.length - 1}
+                            onPointerDown={(event) => event.stopPropagation()}
                             onClick={(event) => {
                               event.stopPropagation();
                               moveRight(photo.id);
                             }}
-                            onPointerDown={(event) => event.stopPropagation()}
                           >
                             <ArrowRightIcon />
                           </button>
                         </div>
+                        <div className="ov-top-right">
+                          <button
+                            type="button"
+                            className={`check${isSelected ? ' is-active' : ''}`}
+                            onPointerDown={(event) => event.stopPropagation()}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              toggleSelect(photo.id);
+                            }}
+                            aria-label={isSelected ? 'Deselect photo' : 'Select photo'}
+                          >
+                            <CheckIcon />
+                          </button>
+                        </div>
+                        {(isTop || isBottom) && (
+                          <div className="ov-bot-right">
+                            <button
+                              type="button"
+                              className="btn-icon edit"
+                              onPointerDown={(event) => event.stopPropagation()}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                handleThumbEdit(photo, event.currentTarget as HTMLElement);
+                              }}
+                              aria-label="Edit crop"
+                            >
+                              <PencilIcon />
+                            </button>
+                          </div>
+                        )}
+                        {badgeContent && <div className="badge">{badgeContent}</div>}
                       </div>
                     );
                   })}

--- a/apps/webapp/src/styles/photos-sheet.css
+++ b/apps/webapp/src/styles/photos-sheet.css
@@ -40,22 +40,21 @@
   border-color: color-mix(in srgb, #ffffff 45%, transparent);
 }
 
-/* ↓ Уменьшаем круглые кнопки на миниатюрах на ~15% */
-.btn-circle-soft{
+/* компактные кнопки-иконки для миниатюр */
+.btn-icon{
   display:inline-grid; place-items:center;
-  width:30px;
-  height:30px;
-  border-radius:999px;
+  width:26px;
+  height:26px;
+  border-radius:8px;
   border:1px solid rgba(255,255,255,.35);
   background:color-mix(in srgb, #ffffff 12%, transparent);
-  backdrop-filter:blur(6px);
-  box-shadow:0 2px 10px rgba(0,0,0,.25);
   color:#fff;
+  backdrop-filter:blur(8px);
+  box-shadow:0 2px 10px rgba(0,0,0,.25);
 }
-.btn-circle-soft:hover{ background:color-mix(in srgb, #ffffff 18%, transparent); }
-.btn-circle-soft:disabled{ opacity:.45; box-shadow:none; }
-/* если внутри SVG, слегка уменьшим и его */
-.btn-circle-soft svg{ width:16px; height:16px; }
+.btn-icon:hover{ background:color-mix(in srgb, #ffffff 18%, transparent); }
+.btn-icon:disabled{ opacity:.45; box-shadow:none; }
+.btn-icon svg{ width:14px; height:14px; }
 
 /* блок «Add photo» */
 .add-btn{ margin-left: 0; pointer-events:auto; }
@@ -73,28 +72,38 @@
   background:color-mix(in srgb, #ffffff 8%, transparent);
 }
 
-.thumb__selector{
+
+.thumb .ov-top-left,
+.thumb .ov-top-right,
+.thumb .ov-bot-right{
   position:absolute;
-  bottom:6px;
-  right:6px;
-  width:26px;
-  height:26px;
+  display:flex;
+  gap:6px;
+  z-index:2;
+}
+.thumb .ov-top-left{ top:6px; left:6px; }
+.thumb .ov-top-right{ top:6px; right:6px; z-index:3; }
+.thumb .ov-bot-right{ bottom:6px; right:6px; }
+
+.thumb .check{
+  width:24px;
+  height:24px;
   border-radius:999px;
   border:1px solid rgba(255,255,255,.5);
   background:rgba(0,0,0,.45);
   color:#fff;
   display:grid;
   place-items:center;
-  backdrop-filter:blur(4px);
+  backdrop-filter:blur(6px);
+  transition:background .15s ease, border-color .15s ease;
 }
-.thumb__selector svg{ width:16px; height:16px; }
-.thumb__selector.is-active{
+.thumb .check svg{ width:14px; height:14px; }
+.thumb .check.is-active{
   background:rgba(16,185,129,.85);
   border-color:rgba(255,255,255,.8);
 }
 
-/* быстрый кроп */
-.thumb .edit,
+/* быстрый кроп в превью слотов */
 .slot-thumb .edit{
   position:absolute;
   top:6px;
@@ -109,20 +118,8 @@
   place-items:center;
   backdrop-filter:blur(4px);
 }
-.thumb .edit svg,
 .slot-thumb .edit svg{ width:14px; height:14px; }
 
-/* панель кнопок на миниатюре */
-.thumb .controls{
-  position:absolute; left:6px; right:40px; bottom:6px;
-  display:flex; justify-content:space-between; gap:6px;
-  opacity:0; transform:translateY(4px);
-  transition:opacity .15s ease, transform .15s ease;
-}
-.thumb.is-selected .controls,
-.thumb:hover .controls{
-  opacity:1; transform:translateY(0);
-}
 
 /* Нумерация в кружке — тоже мягче */
 .thumb .badge,
@@ -136,7 +133,8 @@
   border:1px solid rgba(255,255,255,.25);
   backdrop-filter:blur(4px);
 }
-.thumb .badge{ opacity:1; }
+.thumb .badge{ top:auto; bottom:6px; opacity:1; }
+.slot-thumb .badge{ top:6px; bottom:auto; }
 
 .collage-slots{ display:flex; align-items:flex-start; gap:12px; margin-bottom:16px; }
 .collage-slots .swap-btn{ align-self:center; display:inline-flex; align-items:center; gap:6px; }

--- a/apps/webapp/src/utils/collage.ts
+++ b/apps/webapp/src/utils/collage.ts
@@ -23,3 +23,15 @@ export function computeCollageBoxes(dividerPx: number): CollageBoxes {
   };
 }
 
+export function computeCoverScale(
+  imageWidth: number,
+  imageHeight: number,
+  boxWidth: number,
+  boxHeight: number,
+): number {
+  if (!imageWidth || !imageHeight || !boxWidth || !boxHeight) {
+    return 1;
+  }
+  return Math.max(boxWidth / imageWidth, boxHeight / imageHeight);
+}
+


### PR DESCRIPTION
## Summary
- ensure the collage crop modal waits for decoded images, resizes the canvas after layout, and clamps transforms using the measured viewport
- add a shared cover-scale helper and reuse it for crop rendering and collage thumbnails
- redesign collage photo thumbnail overlays so navigation buttons move to the top-left, the crop control sits bottom-right, and the checkmark stays unobstructed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cab42c32f48328bf4227534bd08626