### PR TITLE
Fix collage crop rendering and streamline photo sheet actions

### DIFF
--- a/apps/webapp/src/components/sheets/PhotosSheet.tsx
+++ b/apps/webapp/src/components/sheets/PhotosSheet.tsx
@@ -168,7 +168,6 @@ export default function PhotosSheet() {
   const setCollageSlot = useCarouselStore((s) => s.setCollageSlot);
   const swapCollage = useCarouselStore((s) => s.swapCollage);
   const setCollageTransform = useCarouselStore((s) => s.setCollageTransform);
-  const applyCollageTemplateToAll = useCarouselStore((s) => s.applyCollageTemplateToAll);
   const autoFillCollage = useCarouselStore((s) => s.autoFillCollage);
 
   const activeSlide = slides[activeIndex];
@@ -242,13 +241,26 @@ export default function PhotosSheet() {
   }, []);
 
   const handleAutoFill = () => {
-    if (selected.length === 0) return;
-    autoFillCollage(selected);
-    impact('medium');
-  };
-
-  const handleApplyTemplate = () => {
-    applyCollageTemplateToAll();
+    if (!isCollage) return;
+    let queue: string[] = [];
+    if (selected.length === 0) {
+      alert('Выдели фото для автозаполнения');
+      if (items.length === 0) {
+        impact('light');
+        return;
+      }
+      impact('light');
+      queue = items.map((photo) => photo.id);
+    } else {
+      const selectedSet = new Set(selected);
+      queue = items.filter((photo) => selectedSet.has(photo.id)).map((photo) => photo.id);
+      if (queue.length === 0) {
+        alert('Выбранные фото недоступны для автозаполнения');
+        impact('light');
+        return;
+      }
+    }
+    autoFillCollage(queue);
     impact('medium');
   };
 
@@ -542,17 +554,11 @@ export default function PhotosSheet() {
             </svg>
             <span>Add photo</span>
           </label>
-          <button
-            type="button"
-            className={`btn-soft${selected.length === 0 ? ' is-disabled' : ''}`}
-            onClick={handleAutoFill}
-            disabled={selected.length === 0}
-          >
-            Auto-fill Collage
-          </button>
-          <button type="button" className="btn-soft" onClick={handleApplyTemplate}>
-            Apply template to all slides
-          </button>
+          {isCollage && (
+            <button type="button" className="btn-soft" onClick={handleAutoFill}>
+              Auto-fill
+            </button>
+          )}
           <button type="button" className="btn-soft" onClick={handleDone}>
             Done
           </button>

--- a/apps/webapp/src/components/sheets/TemplateSheet.tsx
+++ b/apps/webapp/src/components/sheets/TemplateSheet.tsx
@@ -50,6 +50,7 @@ export default function TemplateSheet() {
   const close = useCarouselStore((s) => s.closeSheet);
   const activeSlide = useCarouselStore((s) => s.slides[s.activeIndex]);
   const updateSlide = useCarouselStore((s) => s.updateSlide);
+  const applyCollageTemplateToAll = useCarouselStore((s) => s.applyCollageTemplateToAll);
 
   const collageConfig = useMemo(
     () => normalizeCollage(activeSlide?.collage50),
@@ -176,6 +177,13 @@ export default function TemplateSheet() {
                   </button>
                 ))}
               </div>
+              <button
+                type="button"
+                className="btn-soft"
+                onClick={applyCollageTemplateToAll}
+              >
+                Apply template to all slides
+              </button>
             </div>
           )}
         </div>

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -965,10 +965,12 @@ export const useCarouselStore = create<State>((set, get) => ({
   autoFillCollage: (photoIds) =>
     set((state) => {
       if (photoIds.length === 0) return {};
+      const maxSlides = Math.min(state.slides.length, 10);
+      if (maxSlides === 0) return {};
       let changed = false;
-      const limit = state.slides.length * 2;
-      const queue = photoIds.slice(0, limit);
+      const queue = photoIds.slice(0, maxSlides * 2);
       const slides = state.slides.map((slide, index) => {
+        if (index >= maxSlides) return slide;
         const collage = normalizeCollage(slide.collage50);
         const topId = queue[index * 2];
         const bottomId = queue[index * 2 + 1];
@@ -980,7 +982,7 @@ export const useCarouselStore = create<State>((set, get) => ({
                   ? { ...collage.top.transform }
                   : createDefaultTransform(),
             }
-          : { photoId: undefined, transform: createDefaultTransform() };
+          : createDefaultCollageSlot();
         const nextBottom: CollageSlot = bottomId
           ? {
               photoId: bottomId,
@@ -989,7 +991,7 @@ export const useCarouselStore = create<State>((set, get) => ({
                   ? { ...collage.bottom.transform }
                   : createDefaultTransform(),
             }
-          : { photoId: undefined, transform: createDefaultTransform() };
+          : createDefaultCollageSlot();
         const sameTop =
           collage.top.photoId === nextTop.photoId &&
           collage.top.transform.scale === nextTop.transform.scale &&


### PR DESCRIPTION
## Summary
- ensure the collage crop modal reliably decodes images, resizes its canvas via ResizeObserver, and responds to viewport changes without drawing black frames
- simplify the Photos sheet controls by keeping a single collage auto-fill button with sensible fallbacks and move the "apply template to all" action to the Template sheet
- update collage auto-fill logic to limit filling to the first 10 slides, preserve existing transforms when reusing images, and keep empty slots reset when no photo is provided

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cac85576f883289e52796d5387bac5