### PR TITLE
Enhance toolbar interactions and smooth crop preview

### DIFF
--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -178,32 +178,80 @@
   right:12px;
   display:flex;
   flex-direction:column;
+  align-items:flex-end;
   gap:8px;
   z-index:15;
 }
 
-.slide-tools__button{
-  display:flex;
-  align-items:center;
-  gap:6px;
-  padding:6px 12px;
-  border-radius:999px;
-  border:0;
-  background:color-mix(in srgb, rgba(0,0,0,.78) 70%, transparent);
+.slide-tools__menu-trigger{
+  width:48px;
+  height:48px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,.18);
+  background:color-mix(in srgb, rgba(0,0,0,.75) 75%, transparent);
   color:#fff;
-  font-size:12px;
+  display:grid;
+  place-items:center;
+  cursor:pointer;
+  transition:background .15s ease, transform .15s ease, border-color .15s ease;
+  backdrop-filter:blur(8px);
+}
+
+.slide-tools__menu-trigger.is-open{
+  background:color-mix(in srgb, rgba(0,0,0,.9) 85%, transparent);
+  border-color:rgba(255,255,255,.26);
+}
+
+.slide-tools__menu-trigger svg{
+  width:22px;
+  height:22px;
+}
+
+.slide-tools__menu-trigger:active{
+  transform:scale(.96);
+}
+
+.slide-tools__menu{
+  min-width:168px;
+  padding:8px 0;
+  border-radius:16px;
+  background:color-mix(in srgb, rgba(0,0,0,.85) 80%, transparent);
+  border:1px solid rgba(255,255,255,.16);
+  box-shadow:0 18px 38px rgba(0,0,0,.3);
+  backdrop-filter:blur(8px);
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+}
+
+.slide-tools__menu-item{
+  min-height:44px;
+  padding:0 16px;
+  border:0;
+  background:transparent;
+  color:#fff;
+  font-size:14px;
   font-weight:600;
   letter-spacing:0.01em;
+  display:flex;
+  align-items:center;
+  justify-content:flex-start;
   cursor:pointer;
-  transition:opacity .15s ease;
+  text-align:left;
+  transition:background .15s ease, color .15s ease;
 }
 
-.slide-tools__button svg{
-  width:16px;
-  height:16px;
+.slide-tools__menu-item + .slide-tools__menu-item{
+  border-top:1px solid rgba(255,255,255,.12);
 }
 
-.slide-tools__button:disabled{
+.slide-tools__menu-item:is(:hover,:focus-visible){
+  background:rgba(255,255,255,.08);
+  outline:none;
+}
+
+.slide-tools__menu-item.is-disabled,
+.slide-tools__menu-item:disabled{
   opacity:.45;
   cursor:default;
 }
@@ -238,10 +286,16 @@
   cursor:grabbing;
 }
 
-.slide-crop-overlay__surface canvas{
-  width:100%;
-  height:100%;
+.slide-crop-overlay__image{
+  position:absolute;
+  left:0;
+  top:0;
   display:block;
+  pointer-events:none;
+  user-select:none;
+  touch-action:none;
+  will-change:transform;
+  transform-origin:center center;
 }
 
 .slide-crop-overlay__grid{

--- a/apps/webapp/src/ui/icons.tsx
+++ b/apps/webapp/src/ui/icons.tsx
@@ -121,3 +121,11 @@ export const SwapIcon = () => (
     <path d="M6 10h14" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" />
   </svg>
 );
+
+export const MoreIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+    <circle cx="5" cy="12" r="1.8" fill="currentColor" />
+    <circle cx="12" cy="12" r="1.8" fill="currentColor" />
+    <circle cx="19" cy="12" r="1.8" fill="currentColor" />
+  </svg>
+);

--- a/apps/webapp/src/utils/haptics.ts
+++ b/apps/webapp/src/utils/haptics.ts
@@ -1,0 +1,13 @@
+export function haptic(type: 'light' | 'medium' | 'heavy' | 'selection' | 'success' = 'light') {
+  const tg = (window as any).Telegram?.WebApp?.HapticFeedback;
+  if (tg) {
+    if (type === 'selection') tg.selectionChanged();
+    else if (type === 'success') tg.notificationOccurred('success');
+    else tg.impactOccurred(type);
+    return;
+  }
+  if (navigator.vibrate) {
+    const ms = { light: 10, selection: 10, medium: 30, heavy: 50, success: 20 }[type];
+    navigator.vibrate(ms);
+  }
+}


### PR DESCRIPTION
## Summary
- replace the slide tools chip buttons with a larger overflow menu that triggers haptic feedback when opened or selecting an action
- add a reusable haptic utility and use it for medium and success feedback during crop interactions
- render the crop preview with CSS transforms and requestAnimationFrame updates for smoother pan/zoom behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf5902e6c83288d473a74bb16929c