### PR TITLE
Persist and apply crop transforms

### DIFF
--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -83,7 +83,7 @@
   font-weight:600;
   font-size:22px;
 }
-.collage-slot img{ width:100%; height:100%; object-fit:cover; object-position:center; display:block; }
+.collage-slot img{ display:block; -webkit-user-drag:none; }
 .collage-slot.is-empty{ background:rgba(0,0,0,.08); color:rgba(255,255,255,.65); }
 .collage-slot.is-dimmed{ filter:brightness(0.45); }
 .collage-slot.is-active{ box-shadow:inset 0 0 0 2px rgba(255,255,255,.8); }

--- a/apps/webapp/src/components/collage/CollageSlotImage.tsx
+++ b/apps/webapp/src/components/collage/CollageSlotImage.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo, useCallback, useEffect, type SyntheticEvent } from 'react';
 import type { PhotoTransform } from '@/state/store';
-import { computeCoverScale } from '@/utils/collage';
+import { placeImage } from '@/utils/placeImage';
 
 type Box = { width: number; height: number };
 
@@ -37,26 +37,23 @@ export function CollageSlotImage({ src, box, transform, className, onLoad }: Pro
         top: 0,
         width: '100%',
         height: '100%',
-        objectFit: 'cover' as const,
-        objectPosition: 'center' as const,
+        visibility: 'hidden' as const,
       };
     }
 
-    const scaleBase = computeCoverScale(size.width, size.height, box.width, box.height);
-    const finalScale = scaleBase * transform.scale;
-    const drawWidth = size.width * finalScale;
-    const drawHeight = size.height * finalScale;
-    const dx = (box.width - drawWidth) / 2 + transform.offsetX;
-    const dy = (box.height - drawHeight) / 2 + transform.offsetY;
+    const placement = placeImage(
+      { x: 0, y: 0, width: box.width, height: box.height },
+      size.width,
+      size.height,
+      transform,
+    );
 
     return {
       position: 'absolute' as const,
-      left: `${dx}px`,
-      top: `${dy}px`,
-      width: `${drawWidth}px`,
-      height: `${drawHeight}px`,
-      objectFit: 'cover' as const,
-      objectPosition: 'center' as const,
+      left: `${placement.left}px`,
+      top: `${placement.top}px`,
+      width: `${placement.width}px`,
+      height: `${placement.height}px`,
       transform: 'translate3d(0,0,0)',
     };
   }, [box.height, box.width, size, transform.offsetX, transform.offsetY, transform.scale]);

--- a/apps/webapp/src/features/render/canvas.ts
+++ b/apps/webapp/src/features/render/canvas.ts
@@ -14,6 +14,7 @@ import { composeTextLines } from '@/utils/textLayout';
 import { resolveBlockPosition, resolveBlockWidth } from '@/utils/layoutGeometry';
 import { resolvePhotoFromStore } from '@/utils/photos';
 import { computeCollageBoxes } from '@/utils/collage';
+import { placeImage } from '@/utils/placeImage';
 import { applyOpacityToColor } from '@/utils/color';
 
 export const CANVAS_W = BASE_FRAME.width;
@@ -31,18 +32,13 @@ function drawImageWithTransform(
   const imageHeight = img.naturalHeight || img.height;
   if (!imageWidth || !imageHeight) return;
 
-  const baseScale = Math.max(box.width / imageWidth, box.height / imageHeight);
-  const scale = baseScale * (transform?.scale ?? 1);
-  const drawWidth = imageWidth * scale;
-  const drawHeight = imageHeight * scale;
-  const dx = box.x + (box.width - drawWidth) / 2 + (transform?.offsetX ?? 0);
-  const dy = box.y + (box.height - drawHeight) / 2 + (transform?.offsetY ?? 0);
+  const placement = placeImage(box, imageWidth, imageHeight, transform);
 
   ctx.save();
   ctx.beginPath();
   ctx.rect(box.x, box.y, box.width, box.height);
   ctx.clip();
-  ctx.drawImage(img, dx, dy, drawWidth, drawHeight);
+  ctx.drawImage(img, placement.left, placement.top, placement.width, placement.height);
   ctx.restore();
 }
 

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -921,16 +921,12 @@ export const useCarouselStore = create<State>()(
         const slide = state.slides[slideIndex];
         if (!slide) return {};
         const collage = normalizeCollage(slide.collage50);
-        const slotsEqual =
-          collage.top.photoId === collage.bottom.photoId &&
-          collage.top.transform.scale === collage.bottom.transform.scale &&
-          collage.top.transform.offsetX === collage.bottom.transform.offsetX &&
-          collage.top.transform.offsetY === collage.bottom.transform.offsetY;
+        const slotsEqual = collage.top.photoId === collage.bottom.photoId;
         if (slotsEqual) return {};
         const nextCollage: Collage50 = {
           ...collage,
-          top: { photoId: collage.bottom.photoId, transform: { ...collage.bottom.transform } },
-          bottom: { photoId: collage.top.photoId, transform: { ...collage.top.transform } },
+          top: { ...collage.top, photoId: collage.bottom.photoId },
+          bottom: { ...collage.bottom, photoId: collage.top.photoId },
         };
         const slides = [...state.slides];
         slides[slideIndex] = {

--- a/apps/webapp/src/utils/placeImage.ts
+++ b/apps/webapp/src/utils/placeImage.ts
@@ -1,0 +1,35 @@
+import type { PhotoTransform } from '@/state/store';
+
+export type PlacementBox = { x: number; y: number; width: number; height: number };
+
+export type PlacedImage = { left: number; top: number; width: number; height: number };
+
+const DEFAULT_TRANSFORM: PhotoTransform = { scale: 1, offsetX: 0, offsetY: 0 };
+
+export function placeImage(
+  box: PlacementBox,
+  imageWidth: number,
+  imageHeight: number,
+  transform?: PhotoTransform | null,
+): PlacedImage {
+  const boxWidth = Math.max(0, box.width);
+  const boxHeight = Math.max(0, box.height);
+  const sourceWidth = Math.max(0, imageWidth);
+  const sourceHeight = Math.max(0, imageHeight);
+
+  if (!boxWidth || !boxHeight || !sourceWidth || !sourceHeight) {
+    return { left: box.x, top: box.y, width: boxWidth, height: boxHeight };
+  }
+
+  const t = transform ?? DEFAULT_TRANSFORM;
+  const baseScale = Math.max(boxWidth / sourceWidth, boxHeight / sourceHeight);
+  const scale = baseScale * (t.scale ?? DEFAULT_TRANSFORM.scale);
+  const width = sourceWidth * scale;
+  const height = sourceHeight * scale;
+  const offsetX = t.offsetX ?? DEFAULT_TRANSFORM.offsetX;
+  const offsetY = t.offsetY ?? DEFAULT_TRANSFORM.offsetY;
+  const left = box.x + (boxWidth - width) / 2 + offsetX;
+  const top = box.y + (boxHeight - height) / 2 + offsetY;
+
+  return { left, top, width, height };
+}


### PR DESCRIPTION
## Summary
- add a shared `placeImage` helper so preview and export use the same cover + crop placement math
- render collage and single images through the helper to respect saved transforms without relying on `object-fit`
- keep slot transforms when swapping collage photos and clean up related styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb1a90b8bc832893fe28264b50b473