### PR TITLE
Trim empty slides before export and streamline carousel state

### DIFF
--- a/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
+++ b/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
@@ -1,10 +1,13 @@
+import { useMemo } from 'react';
 import { Slide, useCarouselStore, useLayoutSelector } from '@/state/store';
 import { resolveSlideDesign } from '@/styles/theme';
 import { SlideCard } from './SlideCard';
+import { getExportSlides } from '@/utils/getExportSlides';
 
 export function PreviewCarousel({ slides }: { slides: Slide[] }) {
   const baseTemplate = useCarouselStore((s) => s.style.template);
   const typographySettings = useCarouselStore((s) => s.typography);
+  const activeIndex = useCarouselStore((s) => s.activeIndex);
   const layout = useLayoutSelector((state) => ({
     vertical: state.vertical,
     vOffset: state.vOffset,
@@ -23,9 +26,19 @@ export function PreviewCarousel({ slides }: { slides: Slide[] }) {
     gradientIntensity: state.gradientIntensity,
   }));
 
+  const visibleSlides = useMemo(() => {
+    const trimmed = getExportSlides(slides);
+    if (slides.length === 0) {
+      return trimmed;
+    }
+    const maxLength = Math.max(trimmed.length, activeIndex + 1);
+    const safeLength = Math.min(slides.length, maxLength);
+    return slides.slice(0, safeLength);
+  }, [slides, activeIndex]);
+
   return (
     <div className="carousel">
-      {slides.map((s, i) => (
+      {visibleSlides.map((s, i) => (
         <div className="slide" key={s.id ?? i}>
           <SlideCard
             slide={s}

--- a/apps/webapp/src/features/export/share.ts
+++ b/apps/webapp/src/features/export/share.ts
@@ -1,12 +1,14 @@
 import { Slide } from '@/state/store';
 import { renderSlideToPNG } from '../render/canvas';
+import { getExportSlides } from '@/utils/getExportSlides';
 
 export async function shareAllSlides(slides: Slide[]) {
-  if (!slides?.length) { alert('Добавьте текст или фото.'); return; }
+  const slidesForRender = getExportSlides(slides ?? []);
+  if (slidesForRender.length === 0) { alert('Добавьте текст или фото.'); return; }
 
   // Рендерим PNG
   const blobs: Blob[] = [];
-  for (const s of slides) blobs.push(await renderSlideToPNG(s));
+  for (const s of slidesForRender) blobs.push(await renderSlideToPNG(s));
 
   // Пытаемся через Web Share API (iOS 16+)
   const files = blobs.map((b,i)=> new File([b], `slide-${String(i+1).padStart(2,'0')}.png`, { type: 'image/png' }));

--- a/apps/webapp/src/utils/getExportSlides.ts
+++ b/apps/webapp/src/utils/getExportSlides.ts
@@ -1,0 +1,21 @@
+import type { Slide } from '@/state/store';
+import { slideIsEmpty } from '@/utils/slideIsEmpty';
+
+export function getExportSlides(slides: Slide[]): Slide[] {
+  if (!Array.isArray(slides) || slides.length === 0) {
+    return [];
+  }
+
+  let lastNonEmptyIndex = -1;
+  slides.forEach((slide, index) => {
+    if (!slideIsEmpty(slide)) {
+      lastNonEmptyIndex = index;
+    }
+  });
+
+  if (lastNonEmptyIndex >= 0) {
+    return slides.slice(0, lastNonEmptyIndex + 1);
+  }
+
+  return slides.slice(0, 1);
+}

--- a/apps/webapp/src/utils/slideIsEmpty.ts
+++ b/apps/webapp/src/utils/slideIsEmpty.ts
@@ -1,0 +1,25 @@
+import type { Slide } from '@/state/store';
+
+function hasNonEmptyText(slide: Slide): boolean {
+  const candidate = slide.text?.title ?? slide.text?.body ?? slide.body;
+  if (typeof candidate === 'string') {
+    return candidate.trim().length > 0;
+  }
+  if (!candidate) return false;
+  const maybeTrim = (candidate as unknown as { trim?: () => string }).trim;
+  return typeof maybeTrim === 'function' ? maybeTrim.call(candidate).length > 0 : false;
+}
+
+export function slideIsEmpty(slide: Slide): boolean {
+  const hasText = hasNonEmptyText(slide);
+  if (slide.template === 'collage-50') {
+    const hasTop = Boolean(slide.collage50?.top.photoId);
+    const hasBottom = Boolean(slide.collage50?.bottom.photoId);
+    return !hasText && !hasTop && !hasBottom;
+  }
+
+  const singleSlot = slide.single as unknown as { photoId?: string } | undefined;
+  const singlePhotoId = singleSlot?.photoId ?? slide.photoId ?? slide.image;
+  const hasPhoto = Boolean(singlePhotoId);
+  return !hasText && !hasPhoto;
+}


### PR DESCRIPTION
## Summary
- add utility helpers to detect empty slides and compute the exportable subset
- trim exported and previewed slides to the last non-empty entry and keep users on active slides
- initialize the carousel with a single empty slide, trim persisted tails on rehydrate, and update slide management helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb25fe8ce08328885817c9b13c8aec