### PR TITLE
Hide slot base image during cropping

### DIFF
--- a/apps/webapp/src/components/Carousel/SlideCard.tsx
+++ b/apps/webapp/src/components/Carousel/SlideCard.tsx
@@ -77,6 +77,9 @@ export function SlideCard({ slide, design, safeAreaEnabled, slideIndex }: Props)
   const cropActive = crop.active;
   const cropping = cropActive && crop.slideId === slide.id;
   const cropSlot = cropping ? crop.slot : null;
+  const isCroppingTop = cropping && cropSlot === 'top';
+  const isCroppingBottom = cropping && cropSlot === 'bottom';
+  const isCroppingSingle = cropping && cropSlot === 'single';
   const [menuOpen, setMenuOpen] = useState(false);
   const menuTriggerRef = useRef<HTMLButtonElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -540,6 +543,8 @@ export function SlideCard({ slide, design, safeAreaEnabled, slideIndex }: Props)
                     src={collageImages.top}
                     box={{ width: collageBoxes.top.width, height: collageBoxes.top.height }}
                     transform={collage.top.transform}
+                    className="collage-slot__image"
+                    hidden={isCroppingTop}
                   />
                 ) : (
                   <span className="collage-slot__placeholder">Добавьте фото</span>
@@ -563,6 +568,8 @@ export function SlideCard({ slide, design, safeAreaEnabled, slideIndex }: Props)
                     src={collageImages.bottom}
                     box={{ width: collageBoxes.bottom.width, height: collageBoxes.bottom.height }}
                     transform={collage.bottom.transform}
+                    className="collage-slot__image"
+                    hidden={isCroppingBottom}
                   />
                 ) : (
                   <span className="collage-slot__placeholder">Добавьте фото</span>
@@ -587,6 +594,8 @@ export function SlideCard({ slide, design, safeAreaEnabled, slideIndex }: Props)
                 src={singleImage}
                 box={{ width: BASE_FRAME.width, height: BASE_FRAME.height }}
                 transform={singleConfig.transform}
+                className="single-slot__image"
+                hidden={isCroppingSingle}
               />
             </div>
           ) : (

--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -84,6 +84,12 @@
   font-size:22px;
 }
 .collage-slot img{ display:block; -webkit-user-drag:none; }
+.collage-slot__image.is-hidden,
+.single-slot__image.is-hidden{
+  opacity:0;
+  visibility:hidden;
+  pointer-events:none;
+}
 .collage-slot.is-empty{ background:rgba(0,0,0,.08); color:rgba(255,255,255,.65); }
 .collage-slot.is-dimmed{ filter:brightness(0.45); }
 .collage-slot.is-active{ box-shadow:inset 0 0 0 2px rgba(255,255,255,.8); }

--- a/apps/webapp/src/components/collage/CollageSlotImage.tsx
+++ b/apps/webapp/src/components/collage/CollageSlotImage.tsx
@@ -9,10 +9,11 @@ type Props = {
   box: Box;
   transform: PhotoTransform;
   className?: string;
+  hidden?: boolean;
   onLoad?: (size: { width: number; height: number }) => void;
 };
 
-export function CollageSlotImage({ src, box, transform, className, onLoad }: Props) {
+export function CollageSlotImage({ src, box, transform, className, hidden, onLoad }: Props) {
   const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
   useEffect(() => {
@@ -58,12 +59,17 @@ export function CollageSlotImage({ src, box, transform, className, onLoad }: Pro
     };
   }, [box.height, box.width, size, transform.offsetX, transform.offsetY, transform.scale]);
 
+  const resolvedClassName = useMemo(() => {
+    const classes = [className, hidden ? 'is-hidden' : null].filter(Boolean);
+    return classes.length > 0 ? classes.join(' ') : undefined;
+  }, [className, hidden]);
+
   return (
     <img
       src={src}
       alt=""
       draggable={false}
-      className={className}
+      className={resolvedClassName}
       onLoad={handleLoad}
       style={style}
     />


### PR DESCRIPTION
## Summary
- add hidden handling to collage slot images so the crop overlay is the only visible layer while cropping
- hide the active slot image via CSS when a crop session is running

## Testing
- pnpm --filter webapp build

------
https://chatgpt.com/codex/tasks/task_e_68cb348286a88328bd59614549ca4b41