### PR TITLE
Improve crop overlay gestures and geometry

### DIFF
--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -262,27 +262,29 @@
   cursor:default;
 }
 
-.crop-layer{ position:absolute; inset:0; z-index:25; pointer-events:none; }
+.crop-layer{ position:absolute; inset:0; z-index:25; }
 .crop-frame{
   position:absolute;
-  left:var(--box-left);
-  top:var(--box-top);
-  width:var(--box-width);
-  height:var(--box-height);
   overflow:hidden;
   border:none;
   border-radius:inherit;
-  box-shadow:0 0 0 999px rgba(0,0,0,.55);
   pointer-events:auto;
   touch-action:none;
 }
-.crop-img{ position:absolute; will-change:transform; transform-origin:center center; user-select:none; }
+.crop-img{
+  position:absolute;
+  display:block;
+  will-change:transform;
+  transform-origin:center center;
+  user-select:none;
+}
 .crop-grid{ position:absolute; inset:0; pointer-events:none; background:
   linear-gradient(#fff6 0 0,transparent 0) 0 33%/100% 1px no-repeat,
   linear-gradient(#fff6 0 0,transparent 0) 0 66%/100% 1px no-repeat,
   linear-gradient(90deg,#fff6 0 0,transparent 0) 33% 0/1px 100% no-repeat,
   linear-gradient(90deg,#fff6 0 0,transparent 0) 66% 0/1px 100% no-repeat;
 }
+.dim-other{ position:absolute; background:#0008; pointer-events:none; }
 .crop-toolbar{ position:absolute; left:12px; right:12px; bottom:12px; display:flex; gap:8px; justify-content:flex-end; pointer-events:auto; }
 .crop-toolbar__actions{ display:flex; gap:8px; }
 .crop-button{ min-width:72px; padding:10px 16px; border-radius:10px; border:1px solid rgba(255,255,255,.22); background:rgba(0,0,0,.65); color:#fff; font-weight:600; font-size:14px; letter-spacing:0.01em; cursor:pointer; transition:background .15s ease, border-color .15s ease; }

--- a/apps/webapp/src/utils/cropGestures.ts
+++ b/apps/webapp/src/utils/cropGestures.ts
@@ -1,217 +1,165 @@
 import { useCallback, useEffect, useRef } from 'react';
 
-export type CropTransform = {
-  scale: number;
-  offsetX: number;
-  offsetY: number;
-};
-
-export type ClampTransform = (value: CropTransform) => CropTransform;
-
-export type UseCropGesturesConfig = {
-  boxRef: React.RefObject<HTMLElement>;
-  imgRef: React.RefObject<HTMLElement>;
-  initial: CropTransform;
-  clamp: ClampTransform;
-  onChange?: (value: CropTransform) => void;
-};
-
-export type UseCropGesturesResult = {
-  getTransform: () => CropTransform;
-  setTransform: (value: CropTransform | ((prev: CropTransform) => CropTransform)) => void;
-};
-
 type Point = { x: number; y: number };
 
-type PinchState = {
-  distance: number;
-  center: Point;
-} | null;
-
-export const clampValue = (value: number, min: number, max: number) => {
-  if (Number.isNaN(value)) return min;
-  return Math.min(max, Math.max(min, value));
+type CropGestureInternal = {
+  scale: number;
+  x: number;
+  y: number;
+  pts: Map<number, Point>;
+  raf: number;
+  pinchDistance: number;
 };
 
-export function applyTransform(element: HTMLElement, scale: number, offsetX: number, offsetY: number) {
-  const translateX = scale !== 0 ? offsetX / scale : 0;
-  const translateY = scale !== 0 ? offsetY / scale : 0;
-  element.dataset.cropScale = String(scale);
-  element.dataset.cropOffsetX = String(offsetX);
-  element.dataset.cropOffsetY = String(offsetY);
-  element.style.transform = `translate3d(${translateX}px, ${translateY}px, 0) scale(${scale})`;
+type CropInitialTransform = {
+  scale?: number;
+  offsetX?: number;
+  offsetY?: number;
+};
+
+type UseCropGesturesConfig = {
+  frameRef: React.RefObject<HTMLElement>;
+  imgRef: React.RefObject<HTMLElement>;
+  minScale: number;
+  initial: CropInitialTransform;
+};
+
+const MAX_SCALE = 3;
+
+function applyCropTransform(element: HTMLElement, state: CropGestureInternal) {
+  element.style.transform = `translate3d(${state.x}px, ${state.y}px, 0) scale(${state.scale})`;
 }
 
-export function readTransform(element: HTMLElement): CropTransform {
-  const scale = Number(element.dataset.cropScale ?? '1');
-  const offsetX = Number(element.dataset.cropOffsetX ?? '0');
-  const offsetY = Number(element.dataset.cropOffsetY ?? '0');
-  return {
-    scale: Number.isFinite(scale) && scale > 0 ? scale : 1,
-    offsetX: Number.isFinite(offsetX) ? offsetX : 0,
-    offsetY: Number.isFinite(offsetY) ? offsetY : 0,
-  };
-}
+export function useCropGestures({ frameRef, imgRef, minScale, initial }: UseCropGesturesConfig) {
+  const stateRef = useRef<CropGestureInternal>({
+    scale: Math.max(initial.scale ?? 1, minScale),
+    x: initial.offsetX ?? 0,
+    y: initial.offsetY ?? 0,
+    pts: new Map(),
+    raf: 0,
+    pinchDistance: 0,
+  });
 
-export function useCropGestures({ boxRef, imgRef, initial, clamp, onChange }: UseCropGesturesConfig): UseCropGesturesResult {
-  const transformRef = useRef<CropTransform>(initial);
-  const rafRef = useRef(0);
-  const dirtyRef = useRef(true);
-  const pointersRef = useRef<Map<number, Point>>(new Map());
-  const pinchRef = useRef<PinchState>(null);
-  const changeRef = useRef<UseCropGesturesConfig['onChange']>(onChange);
-
-  useEffect(() => {
-    changeRef.current = onChange;
-  }, [onChange]);
-
-  const flush = useCallback(() => {
+  const apply = useCallback(() => {
+    stateRef.current.raf = 0;
     const img = imgRef.current;
     if (!img) return;
-    const { scale, offsetX, offsetY } = transformRef.current;
-    applyTransform(img, scale, offsetX, offsetY);
+    applyCropTransform(img, stateRef.current);
   }, [imgRef]);
 
   const schedule = useCallback(() => {
-    if (rafRef.current) return;
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = 0;
-      dirtyRef.current = false;
-      flush();
-    });
-  }, [flush]);
-
-  const setTransform = useCallback<UseCropGesturesResult['setTransform']>(
-    (value) => {
-      transformRef.current = clamp(
-        typeof value === 'function' ? (value as (prev: CropTransform) => CropTransform)(transformRef.current) : value,
-      );
-      changeRef.current?.(transformRef.current);
-      dirtyRef.current = true;
-      schedule();
-    },
-    [clamp, schedule],
-  );
+    const current = stateRef.current;
+    if (current.raf) return;
+    current.raf = requestAnimationFrame(apply);
+  }, [apply]);
 
   useEffect(() => {
-    transformRef.current = clamp(initial);
-    dirtyRef.current = true;
+    const state = stateRef.current;
+    state.scale = Math.max(initial.scale ?? 1, minScale);
+    state.x = initial.offsetX ?? 0;
+    state.y = initial.offsetY ?? 0;
     schedule();
-    changeRef.current?.(transformRef.current);
-  }, [clamp, initial, schedule]);
+  }, [initial.offsetX, initial.offsetY, initial.scale, minScale, schedule]);
 
   useEffect(() => {
-    const area = boxRef.current;
-    if (!area) return;
+    const frame = frameRef.current;
+    if (!frame) return;
 
-    area.style.touchAction = 'none';
+    const state = stateRef.current;
+    const pointers = state.pts;
+
+    frame.style.touchAction = 'none';
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (!boxRef.current) return;
-      boxRef.current.setPointerCapture(event.pointerId);
-      pointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY });
-      if (pointersRef.current.size === 2) {
-        const values = Array.from(pointersRef.current.values());
-        pinchRef.current = {
-          center: {
-            x: (values[0].x + values[1].x) / 2,
-            y: (values[0].y + values[1].y) / 2,
-          },
-          distance: Math.hypot(values[0].x - values[1].x, values[0].y - values[1].y),
-        };
+      frame.setPointerCapture(event.pointerId);
+      pointers.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      if (pointers.size === 2) {
+        const [a, b] = Array.from(pointers.values());
+        state.pinchDistance = Math.hypot(a.x - b.x, a.y - b.y);
       }
     };
 
     const handlePointerMove = (event: PointerEvent) => {
-      const previous = pointersRef.current.get(event.pointerId);
-      if (!previous) return;
+      const point = pointers.get(event.pointerId);
+      if (!point) return;
 
-      pointersRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY });
+      const prevX = point.x;
+      const prevY = point.y;
+      point.x = event.clientX;
+      point.y = event.clientY;
 
-      if (pointersRef.current.size === 1) {
-        const dx = event.clientX - previous.x;
-        const dy = event.clientY - previous.y;
-        setTransform((prev) => ({
-          scale: prev.scale,
-          offsetX: prev.offsetX + dx,
-          offsetY: prev.offsetY + dy,
-        }));
+      if (pointers.size === 1) {
+        state.x += event.clientX - prevX;
+        state.y += event.clientY - prevY;
+        schedule();
         return;
       }
 
-      if (pointersRef.current.size === 2) {
-        const rect = boxRef.current?.getBoundingClientRect();
-        if (!rect) return;
-        const [pA, pB] = Array.from(pointersRef.current.values());
-        const center: Point = { x: (pA.x + pB.x) / 2, y: (pA.y + pB.y) / 2 };
-        const distance = Math.hypot(pA.x - pB.x, pA.y - pB.y);
-        const pinch = pinchRef.current;
-        if (!pinch || !Number.isFinite(pinch.distance) || pinch.distance <= 0) {
-          pinchRef.current = { center, distance };
+      if (pointers.size === 2) {
+        const [a, b] = Array.from(pointers.values());
+        const nextDistance = Math.hypot(a.x - b.x, a.y - b.y);
+        if (!Number.isFinite(nextDistance) || nextDistance <= 0) {
+          state.pinchDistance = 0;
           return;
         }
 
-        setTransform((prev) => {
-          if (prev.scale <= 0) return prev;
-          const ratio = distance / pinch.distance;
-          const scaled = clamp({ scale: prev.scale * ratio, offsetX: prev.offsetX, offsetY: prev.offsetY });
-          const appliedRatio = scaled.scale / prev.scale;
-          const cx = center.x - rect.left;
-          const cy = center.y - rect.top;
-          const next = clamp({
-            scale: scaled.scale,
-            offsetX: cx - (cx - prev.offsetX) * appliedRatio,
-            offsetY: cy - (cy - prev.offsetY) * appliedRatio,
-          });
+        if (!Number.isFinite(state.pinchDistance) || state.pinchDistance <= 0) {
+          state.pinchDistance = nextDistance;
+          return;
+        }
 
-          const actualRatio = next.scale / prev.scale;
-          pinchRef.current = {
-            center,
-            distance: actualRatio === 0 ? distance : distance / actualRatio,
-          };
-          return next;
-        });
+        const frameRect = frame.getBoundingClientRect();
+        const centerX = (a.x + b.x) / 2 - frameRect.left;
+        const centerY = (a.y + b.y) / 2 - frameRect.top;
+
+        const previousScale = state.scale;
+        const ratio = nextDistance / state.pinchDistance;
+        const unclamped = previousScale * ratio;
+        const nextScale = Math.max(minScale, Math.min(MAX_SCALE, unclamped));
+        const appliedRatio = nextScale / previousScale;
+
+        state.x = centerX - (centerX - state.x) * appliedRatio;
+        state.y = centerY - (centerY - state.y) * appliedRatio;
+        state.scale = nextScale;
+
+        state.pinchDistance = appliedRatio === 0 ? nextDistance : nextDistance / appliedRatio;
+        schedule();
       }
     };
 
     const handlePointerUp = (event: PointerEvent) => {
-      pointersRef.current.delete(event.pointerId);
-      if (pointersRef.current.size < 2) {
-        pinchRef.current = null;
+      pointers.delete(event.pointerId);
+      if (pointers.size < 2) {
+        state.pinchDistance = 0;
       }
     };
 
-    area.addEventListener('pointerdown', handlePointerDown);
-    area.addEventListener('pointermove', handlePointerMove);
-    area.addEventListener('pointerup', handlePointerUp);
-    area.addEventListener('pointercancel', handlePointerUp);
-    area.addEventListener('pointerleave', handlePointerUp);
+    frame.addEventListener('pointerdown', handlePointerDown, { passive: false });
+    frame.addEventListener('pointermove', handlePointerMove, { passive: false });
+    frame.addEventListener('pointerup', handlePointerUp);
+    frame.addEventListener('pointercancel', handlePointerUp);
+    frame.addEventListener('pointerleave', handlePointerUp);
 
     return () => {
-      area.removeEventListener('pointerdown', handlePointerDown);
-      area.removeEventListener('pointermove', handlePointerMove);
-      area.removeEventListener('pointerup', handlePointerUp);
-      area.removeEventListener('pointercancel', handlePointerUp);
-      area.removeEventListener('pointerleave', handlePointerUp);
+      frame.removeEventListener('pointerdown', handlePointerDown);
+      frame.removeEventListener('pointermove', handlePointerMove);
+      frame.removeEventListener('pointerup', handlePointerUp);
+      frame.removeEventListener('pointercancel', handlePointerUp);
+      frame.removeEventListener('pointerleave', handlePointerUp);
+      pointers.clear();
+      state.pinchDistance = 0;
     };
-  }, [boxRef, setTransform]);
+  }, [frameRef, minScale, schedule]);
 
-  useEffect(() => () => {
-    if (rafRef.current) {
-      cancelAnimationFrame(rafRef.current);
-      rafRef.current = 0;
-    }
-  }, []);
+  useEffect(
+    () => () => {
+      if (stateRef.current.raf) {
+        cancelAnimationFrame(stateRef.current.raf);
+        stateRef.current.raf = 0;
+      }
+    },
+    [],
+  );
 
-  useEffect(() => {
-    if (dirtyRef.current) {
-      flush();
-      dirtyRef.current = false;
-    }
-  });
-
-  return {
-    getTransform: () => transformRef.current,
-    setTransform,
-  };
+  return stateRef;
 }


### PR DESCRIPTION
## Summary
- replace the crop gesture hook with a requestAnimationFrame-driven implementation that keeps transforms in refs and applies them via CSS
- rework the crop overlay to reuse shared box math, clamp saves, and dim the inactive half without extra setTransform calls
- adjust the carousel slide wiring and styles so preview and store updates happen only on save and black borders are removed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb406e4ecc8328b5b4bc37fd70a48b