### PR TITLE
feat: add font picker and typography options

### DIFF
--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -8,6 +8,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fontsource/bodoni-moda": "^5.0.0",
+    "@fontsource/dancing-script": "^5.0.0",
+    "@fontsource/dm-sans": "^5.0.0",
+    "@fontsource/inter": "^5.0.0",
+    "@fontsource/lora": "^5.0.0",
+    "@fontsource/montserrat": "^5.0.0",
+    "@fontsource/playfair-display": "^5.0.0",
+    "@fontsource/poppins": "^5.0.0",
+    "@fontsource/raleway": "^5.0.0",
+    "@fontsource/roboto": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "zustand": "^4.5.2",

--- a/apps/webapp/src/App.tsx
+++ b/apps/webapp/src/App.tsx
@@ -1,14 +1,22 @@
-import { useCarouselStore } from './state/store';
+import { useEffect } from 'react';
+import { useCarouselStore, useFontStore } from './state/store';
 import { PreviewCarousel } from './components/Carousel/PreviewCarousel';
 import BottomBar from './components/BottomBar';
 import TextSheet from './components/sheets/TextSheet';
 import PhotosSheet from './components/sheets/PhotosSheet';
 import TemplateSheet from './components/sheets/TemplateSheet';
 import LayoutSheet from './components/sheets/LayoutSheet';
+import { getFontStack } from './features/fonts/fonts';
 
 export default function App() {
   const sheet = useCarouselStore(s => s.activeSheet);
   const slides = useCarouselStore(s => s.slides);
+  const fontId = useFontStore((s) => s.fontId);
+
+  useEffect(() => {
+    const stack = getFontStack(fontId);
+    document.documentElement.style.setProperty('--app-font-family', stack);
+  }, [fontId]);
 
   return (
     <>

--- a/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
+++ b/apps/webapp/src/components/Carousel/PreviewCarousel.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Slide, useCarouselStore, useLayoutSelector } from '@/state/store';
+import { Slide, useCarouselStore, useLayoutSelector, useFontStore } from '@/state/store';
 import { resolveSlideDesign } from '@/styles/theme';
 import { SlideCard } from './SlideCard';
 import { getExportSlides } from '@/utils/getExportSlides';
@@ -8,6 +8,7 @@ export function PreviewCarousel({ slides }: { slides: Slide[] }) {
   const baseTemplate = useCarouselStore((s) => s.style.template);
   const typographySettings = useCarouselStore((s) => s.typography);
   const activeIndex = useCarouselStore((s) => s.activeIndex);
+  const fontId = useFontStore((s) => s.fontId);
   const layout = useLayoutSelector((state) => ({
     text: state.text,
     vOffset: state.vOffset,
@@ -40,6 +41,7 @@ export function PreviewCarousel({ slides }: { slides: Slide[] }) {
               baseTemplate,
               baseLayout: layout,
               typographySettings,
+              fontId,
             })}
             safeAreaEnabled={layout.text.safeArea}
             slideIndex={i}

--- a/apps/webapp/src/components/Carousel/carousel.css
+++ b/apps/webapp/src/components/Carousel/carousel.css
@@ -28,6 +28,7 @@
   flex: 0 0 calc(100% - var(--peek)*2);  /* почти на весь экран */
   scroll-snap-align: center;             /* центрируем каждый */
   display: grid;                         /* чтобы внутрянка не схлопывалась */
+  font-family: var(--app-font-family);
 }
 
 /* Кадр Instagram 4:5 */
@@ -135,7 +136,7 @@
 }
 
 .overlay.editorial .title{
-  font-family: var(--font-inter, var(--font-system));
+  font-family: inherit;
   font-weight: 700;
   font-size: 48px;
   line-height: 1.15;
@@ -146,7 +147,7 @@
 
 .overlay.editorial .body{
   margin-top: 6px;
-  font-family: var(--font-inter, var(--font-system));
+  font-family: inherit;
   font-weight: 400;
   font-size: 28px;
   line-height: 1.25;

--- a/apps/webapp/src/components/FontPicker.css
+++ b/apps/webapp/src/components/FontPicker.css
@@ -1,0 +1,49 @@
+.font-picker {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  padding: 8px 0;
+}
+
+.font-pill {
+  appearance: none;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.04);
+  color: #fff;
+  border-radius: 999px;
+  padding: 10px 12px;
+  font-size: 14px;
+  line-height: 1;
+  transition: transform .12s ease, background .25s ease, border-color .25s ease, box-shadow .25s ease;
+  will-change: transform;
+  cursor: pointer;
+}
+
+.font-pill:hover { transform: translateY(-1px); }
+
+.font-pill:active { transform: scale(0.98); }
+
+.font-pill.is-active {
+  background: rgba(137, 170, 255, 0.18);
+  border-color: rgba(137, 170, 255, 0.55);
+  box-shadow: 0 0 0 6px rgba(137,170,255,0.10) inset;
+  font-weight: 600;
+}
+
+.font-pill:focus-visible {
+  outline: 2px solid rgba(137,170,255,0.8);
+  outline-offset: 2px;
+}
+
+@media (prefers-color-scheme: light) {
+  .font-pill {
+    border-color: rgba(0,0,0,0.1);
+    background: rgba(0,0,0,0.03);
+    color: #111;
+  }
+  .font-pill.is-active {
+    background: rgba(120, 150, 255, 0.18);
+    border-color: rgba(120,150,255,0.45);
+    box-shadow: 0 0 0 6px rgba(120,150,255,0.08) inset;
+  }
+}

--- a/apps/webapp/src/components/FontPicker.tsx
+++ b/apps/webapp/src/components/FontPicker.tsx
@@ -1,0 +1,56 @@
+import { type KeyboardEvent } from 'react';
+import { FONTS, type FontId } from '@/features/fonts/fonts';
+import { useFontStore } from '@/state/store';
+import './FontPicker.css';
+
+export function FontPicker() {
+  const fontId = useFontStore((state) => state.fontId);
+  const setFont = useFontStore((state) => state.setFont);
+
+  const onSelect = (id: FontId) => {
+    setFont(id);
+    if ('vibrate' in navigator) {
+      try {
+        navigator.vibrate?.(10);
+      } catch {}
+    }
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = (index + 1) % FONTS.length;
+      onSelect(FONTS[next].id);
+      return;
+    }
+    if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const prev = (index - 1 + FONTS.length) % FONTS.length;
+      onSelect(FONTS[prev].id);
+    }
+  };
+
+  return (
+    <div className="font-picker" role="radiogroup" aria-label="Font">
+      {FONTS.map((font, index) => {
+        const active = font.id === fontId;
+        return (
+          <button
+            key={font.id}
+            role="radio"
+            aria-checked={active}
+            className={`font-pill${active ? ' is-active' : ''}`}
+            onClick={() => onSelect(font.id)}
+            style={{ fontFamily: font.cssStack }}
+            title={font.label}
+            type="button"
+            tabIndex={active ? 0 : -1}
+            onKeyDown={(event) => handleKeyDown(event, index)}
+          >
+            {font.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/webapp/src/components/sheets/TextSheet.tsx
+++ b/apps/webapp/src/components/sheets/TextSheet.tsx
@@ -1,5 +1,6 @@
 import { useCarouselStore } from '@/state/store';
 import Sheet from '../Sheet/Sheet';
+import { FontPicker } from '../FontPicker';
 import '@/styles/text-sheet.css';
 
 export default function TextSheet() {
@@ -40,6 +41,14 @@ export default function TextSheet() {
             onChange={(e) => setTextField({ bulkText: e.target.value })}
           />
         </label>
+
+        <div className="sheet-group">
+          <div className="sheet-label">Font</div>
+          <FontPicker />
+          <p className="font-preview">
+            The quick brown fox — 0123456789
+          </p>
+        </div>
       </div>
       <div className="sheet__footer">
         <button className="btn-soft" onClick={onDone}>Done</button>

--- a/apps/webapp/src/features/fonts/fonts.ts
+++ b/apps/webapp/src/features/fonts/fonts.ts
@@ -1,0 +1,107 @@
+export type FontId =
+  | 'system'
+  | 'inter'
+  | 'dm-sans'
+  | 'roboto'
+  | 'montserrat'
+  | 'poppins'
+  | 'playfair'
+  | 'bodoni'
+  | 'lora'
+  | 'raleway'
+  | 'dancing-script';
+
+export type FontMeta = {
+  id: FontId;
+  label: string;
+  cssStack: string;
+  previewText?: string;
+  kind: 'sans' | 'serif' | 'display';
+};
+
+export const FONTS: FontMeta[] = [
+  {
+    id: 'system',
+    label: 'System',
+    cssStack:
+      '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", sans-serif',
+    kind: 'sans',
+  },
+  {
+    id: 'inter',
+    label: 'Inter',
+    cssStack:
+      '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif',
+    kind: 'sans',
+  },
+  {
+    id: 'dm-sans',
+    label: 'DM Sans',
+    cssStack:
+      '"DM Sans", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif',
+    kind: 'sans',
+  },
+  {
+    id: 'roboto',
+    label: 'Roboto',
+    cssStack: '"Roboto", "Helvetica Neue", Arial, sans-serif',
+    kind: 'sans',
+  },
+  {
+    id: 'montserrat',
+    label: 'Montserrat',
+    cssStack:
+      '"Montserrat", "Inter", -apple-system, "Segoe UI", Roboto, Arial, sans-serif',
+    kind: 'sans',
+  },
+  {
+    id: 'poppins',
+    label: 'Poppins',
+    cssStack:
+      '"Poppins", "Inter", -apple-system, "Segoe UI", Roboto, Arial, sans-serif',
+    kind: 'sans',
+  },
+  {
+    id: 'playfair',
+    label: 'Playfair',
+    cssStack: '"Playfair Display", Georgia, "Times New Roman", serif',
+    kind: 'serif',
+  },
+  {
+    id: 'bodoni',
+    label: 'Bodoni',
+    cssStack: '"Bodoni Moda", Didot, "Bodoni 72", serif',
+    kind: 'serif',
+  },
+  {
+    id: 'lora',
+    label: 'Lora',
+    cssStack: '"Lora", Georgia, "Times New Roman", serif',
+    kind: 'serif',
+  },
+  {
+    id: 'raleway',
+    label: 'Raleway',
+    cssStack: '"Raleway", "Inter", Arial, sans-serif',
+    kind: 'display',
+  },
+  {
+    id: 'dancing-script',
+    label: 'Dancing Script',
+    cssStack: '"Dancing Script", "Comic Sans MS", "Segoe Script", cursive',
+    kind: 'display',
+  },
+];
+
+const FONT_LOOKUP = FONTS.reduce<Record<FontId, FontMeta>>((acc, font) => {
+  acc[font.id] = font;
+  return acc;
+}, {} as Record<FontId, FontMeta>);
+
+export function getFontMeta(id: FontId): FontMeta {
+  return FONT_LOOKUP[id] ?? FONTS[0];
+}
+
+export function getFontStack(id: FontId): string {
+  return getFontMeta(id).cssStack;
+}

--- a/apps/webapp/src/index.css
+++ b/apps/webapp/src/index.css
@@ -1,7 +1,45 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300..800&family=Playfair+Display:opsz,wght@12..144,400..800&family=Bodoni+Moda:wght@400..800&family=DM+Sans:wght@400..700&display=swap');
+@import "@fontsource/inter/400.css";
+@import "@fontsource/inter/500.css";
+@import "@fontsource/inter/700.css";
+
+@import "@fontsource/dm-sans/400.css";
+@import "@fontsource/dm-sans/500.css";
+@import "@fontsource/dm-sans/700.css";
+
+@import "@fontsource/roboto/400.css";
+@import "@fontsource/roboto/500.css";
+@import "@fontsource/roboto/700.css";
+
+@import "@fontsource/montserrat/400.css";
+@import "@fontsource/montserrat/600.css";
+@import "@fontsource/montserrat/700.css";
+
+@import "@fontsource/poppins/400.css";
+@import "@fontsource/poppins/500.css";
+@import "@fontsource/poppins/700.css";
+
+@import "@fontsource/playfair-display/400.css";
+@import "@fontsource/playfair-display/600.css";
+@import "@fontsource/playfair-display/700.css";
+
+@import "@fontsource/bodoni-moda/400.css";
+@import "@fontsource/bodoni-moda/600.css";
+@import "@fontsource/bodoni-moda/700.css";
+
+@import "@fontsource/lora/400.css";
+@import "@fontsource/lora/600.css";
+@import "@fontsource/lora/700.css";
+
+@import "@fontsource/raleway/400.css";
+@import "@fontsource/raleway/600.css";
+@import "@fontsource/raleway/700.css";
+
+@import "@fontsource/dancing-script/400.css";
+@import "@fontsource/dancing-script/700.css";
 
 :root{
   color-scheme: dark;
+  --app-font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
   /* Цвета */
   --bg-sheet: rgba(22,22,24,.82);
   --bg-section: rgba(255,255,255,.04);
@@ -33,17 +71,11 @@
   --slider-thumb: 14px;
   --seg-gap: 6px;
 
-  /* Шрифты */
-  --font-system: -apple-system,BlinkMacSystemFont,"SF Pro Text","Segoe UI",Inter,Roboto,Arial,sans-serif;
-  --font-inter: "Inter", var(--font-system);
-  --font-playfair: "Playfair Display", Georgia, "Times New Roman", serif;
-  --font-bodoni: "Bodoni Moda", "Didot", "Bodoni 72", serif;
-  --font-dmsans: "DM Sans", var(--font-system);
 }
 
 * { box-sizing: border-box; }
 html, body, #root { height: 100%; }
-body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; background: #0d0d0f; color: #fff; }
+body { margin: 0; font-family: var(--app-font-family); background: #0d0d0f; color: #fff; }
 
 /* iOS зумит инпуты < 16px — не даём повода */
 input, textarea, select, button { font-size: 16px; }

--- a/apps/webapp/src/state/store.ts
+++ b/apps/webapp/src/state/store.ts
@@ -1,5 +1,6 @@
 import { create, type StoreApi } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
+import type { FontId } from '@/features/fonts/fonts';
 import { getExportSlides } from '@/utils/getExportSlides';
 
 export type PhotoId = string;
@@ -193,6 +194,26 @@ const createNoopStorage = (): Storage =>
   } as Storage);
 
 const uid = () => crypto.randomUUID();
+
+type FontState = {
+  fontId: FontId;
+  setFont: (id: FontId) => void;
+};
+
+export const useFontStore = create<FontState>()(
+  persist(
+    (set) => ({
+      fontId: 'inter',
+      setFont: (id) => set({ fontId: id }),
+    }),
+    {
+      name: 'carousel.font',
+      storage: createJSONStorage<FontState>(() =>
+        typeof window !== 'undefined' ? window.localStorage : createNoopStorage(),
+      ),
+    },
+  ),
+);
 
 export type NicknameLayout = {
   position: 'left' | 'center' | 'right';

--- a/apps/webapp/src/styles/text-sheet.css
+++ b/apps/webapp/src/styles/text-sheet.css
@@ -6,6 +6,31 @@
 }
 .text-sheet .textarea{ resize:vertical; min-height:140px; }
 
+.text-sheet .sheet-group{
+  margin:16px 12px;
+  padding:12px 14px;
+  border-radius:14px;
+  border:1px solid rgba(255,255,255,.08);
+  background: rgba(255,255,255,.04);
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+
+.text-sheet .sheet-label{
+  font-size:13px;
+  font-weight:600;
+  letter-spacing:0.01em;
+  opacity:.75;
+}
+
+.text-sheet .font-preview{
+  margin:0;
+  font-family: var(--app-font-family);
+  opacity:.75;
+  font-size:12px;
+}
+
 .btn-soft{
   position:relative; z-index:1;
   display:inline-flex; align-items:center; gap:8px;

--- a/apps/webapp/src/styles/theme.ts
+++ b/apps/webapp/src/styles/theme.ts
@@ -4,7 +4,9 @@ import type {
   TemplateConfig,
   TypographySettings,
 } from '@/state/store';
-import { getBaseTextColor, getHeadingColor } from '@/state/store';
+import { getBaseTextColor, getHeadingColor, useFontStore } from '@/state/store';
+import type { FontId } from '@/features/fonts/fonts';
+import { getFontStack } from '@/features/fonts/fonts';
 import { createTypography, Typography } from './typography';
 
 export type Theme = {
@@ -119,10 +121,12 @@ export function resolveSlideDesign(params: {
   baseTemplate: TemplateConfig;
   baseLayout: LayoutConfig;
   typographySettings: TypographySettings;
+  fontId?: FontId;
 }): SlideDesign {
   const template = mergeTemplate(params.baseTemplate, params.slide.overrides?.template);
   const layout = mergeLayout(params.baseLayout, params.slide.overrides?.layout);
-  const typography = createTypography(template, layout);
+  const activeFontId = params.fontId ?? useFontStore.getState().fontId;
+  const typography = createTypography(template, layout, getFontStack(activeFontId));
   const theme = createTheme(params.slide, template, layout, params.typographySettings);
 
   return { template, layout, typography, theme };

--- a/apps/webapp/src/styles/typography.ts
+++ b/apps/webapp/src/styles/typography.ts
@@ -62,8 +62,12 @@ function computeBodySize(layout: LayoutConfig): { fontSize: number; lineHeight: 
   return { fontSize, lineHeight };
 }
 
-export function createTypography(template: TemplateConfig, layout: LayoutConfig): Typography {
-  const family = getFontFamily(template.font);
+export function createTypography(
+  template: TemplateConfig,
+  layout: LayoutConfig,
+  fontFamilyOverride?: string,
+): Typography {
+  const family = fontFamilyOverride ?? getFontFamily(template.font);
   const titleSize = computeTitleSize(layout);
   const bodySize = computeBodySize(layout);
 


### PR DESCRIPTION
## Summary
- add a reusable font registry and Zustand slice so the selected font persists in local storage
- introduce a capsule-style FontPicker component with preview inside the Text sheet and wire it to vibrate/keyboard interactions
- apply the chosen font via CSS variables and typography helpers across carousel slides and update styling and dependencies accordingly

## Testing
- npm run build *(fails: missing @fontsource packages because registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1c1e420ac8328996a8957966385a8