### PR TITLE
Add clear text action to text sheet

### DIFF
--- a/apps/webapp/src/components/sheets/TextSheet.tsx
+++ b/apps/webapp/src/components/sheets/TextSheet.tsx
@@ -1,6 +1,7 @@
 import { useCarouselStore } from '@/state/store';
 import Sheet from '../Sheet/Sheet';
 import { FontPicker } from '../FontPicker';
+import { haptic } from '@/utils/haptics';
 import '@/styles/text-sheet.css';
 
 export default function TextSheet() {
@@ -13,6 +14,12 @@ export default function TextSheet() {
   const onDone = () => {
     applyTextToSlides();
     close();
+  };
+
+  const onClear = () => {
+    if (!bulkText) return;
+    haptic('light');
+    setTextField({ bulkText: '' });
   };
 
   return (
@@ -51,6 +58,14 @@ export default function TextSheet() {
         </div>
       </div>
       <div className="sheet__footer">
+        <button
+          className="btn-soft"
+          onClick={onClear}
+          type="button"
+          disabled={!bulkText}
+        >
+          Очистить
+        </button>
         <button className="btn-soft" onClick={onDone}>Done</button>
       </div>
     </Sheet>


### PR DESCRIPTION
## Summary
- add a Clear button to the Text sheet alongside the Done action
- reset the multiline text field with light haptic feedback and disable the button when empty

## Testing
- npm run build --prefix apps/webapp *(fails: missing @fontsource/inter/400.css in current environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d63ee6ec832880971c22b3fca782